### PR TITLE
Recover sandbox rootfs after runtime crashes

### DIFF
--- a/ctld/internal/ctld/rootfs/containerd_runtime.go
+++ b/ctld/internal/ctld/rootfs/containerd_runtime.go
@@ -365,15 +365,23 @@ func (r *ContainerdRuntime) resolveContainerID(ctx context.Context, target ctlda
 	if err != nil {
 		return "", "", err
 	}
+	requestedID := normalizeContainerID(target.ContainerID)
+	filter := &runtimeapi.ContainerFilter{}
+	if requestedID != "" {
+		filter.Id = requestedID
+	} else {
+		filter.State = &runtimeapi.ContainerStateValue{State: runtimeapi.ContainerState_CONTAINER_RUNNING}
+	}
 	resp, err := client.ListContainers(ctx, &runtimeapi.ListContainersRequest{
-		Filter: &runtimeapi.ContainerFilter{
-			State: &runtimeapi.ContainerStateValue{State: runtimeapi.ContainerState_CONTAINER_RUNNING},
-		},
+		Filter: filter,
 	})
 	if err != nil {
 		return "", "", fmt.Errorf("list cri containers: %w", err)
 	}
 	for _, item := range resp.GetContainers() {
+		if requestedID != "" && strings.TrimSpace(item.GetId()) != requestedID {
+			continue
+		}
 		metadata := item.GetMetadata()
 		if metadata == nil || metadata.GetName() != target.ContainerName {
 			continue
@@ -386,12 +394,23 @@ func (r *ContainerdRuntime) resolveContainerID(ctx context.Context, target ctlda
 		if target.PodUID != "" && podUID != target.PodUID {
 			continue
 		}
-		if item.GetState() != runtimeapi.ContainerState_CONTAINER_RUNNING {
+		if requestedID == "" && item.GetState() != runtimeapi.ContainerState_CONTAINER_RUNNING {
 			continue
 		}
 		return item.GetId(), podUID, nil
 	}
+	if requestedID != "" {
+		return "", "", fmt.Errorf("%w: container %s for %s in pod %s/%s", ErrNotFound, requestedID, target.ContainerName, target.Namespace, target.PodName)
+	}
 	return "", "", fmt.Errorf("%w: running container %s in pod %s/%s", ErrNotFound, target.ContainerName, target.Namespace, target.PodName)
+}
+
+func normalizeContainerID(containerID string) string {
+	containerID = strings.TrimSpace(containerID)
+	if _, raw, ok := strings.Cut(containerID, "://"); ok {
+		return strings.TrimSpace(raw)
+	}
+	return containerID
 }
 
 // ListPodSandboxStats returns one bulk node-local CRI stats snapshot.

--- a/ctld/internal/ctld/rootfs/containerd_runtime_test.go
+++ b/ctld/internal/ctld/rootfs/containerd_runtime_test.go
@@ -115,6 +115,71 @@ func TestResolveContainerIDPrefersRunningAttempt(t *testing.T) {
 	assert.Equal(t, "uid-1", podUID)
 }
 
+func TestResolveContainerIDSelectsExactExitedAttempt(t *testing.T) {
+	runtime := NewContainerdRuntime(ContainerdRuntimeConfig{
+		CRIClient: fakeCRIClient{containers: []*runtimeapi.Container{
+			{
+				Id:       "exited-container",
+				State:    runtimeapi.ContainerState_CONTAINER_EXITED,
+				Metadata: &runtimeapi.ContainerMetadata{Name: "sandbox"},
+				Labels: map[string]string{
+					"io.kubernetes.pod.namespace": "default",
+					"io.kubernetes.pod.name":      "pod-1",
+					"io.kubernetes.pod.uid":       "uid-1",
+				},
+			},
+			{
+				Id:       "running-container",
+				State:    runtimeapi.ContainerState_CONTAINER_RUNNING,
+				Metadata: &runtimeapi.ContainerMetadata{Name: "sandbox"},
+				Labels: map[string]string{
+					"io.kubernetes.pod.namespace": "default",
+					"io.kubernetes.pod.name":      "pod-1",
+					"io.kubernetes.pod.uid":       "uid-1",
+				},
+			},
+		}},
+	})
+
+	containerID, podUID, err := runtime.resolveContainerID(context.Background(), ctldapi.RootFSContainerRef{
+		Namespace:     "default",
+		PodName:       "pod-1",
+		PodUID:        "uid-1",
+		ContainerName: "sandbox",
+		ContainerID:   "containerd://exited-container",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "exited-container", containerID)
+	assert.Equal(t, "uid-1", podUID)
+}
+
+func TestResolveContainerIDRejectsExactAttemptWithMismatchedPodIdentity(t *testing.T) {
+	runtime := NewContainerdRuntime(ContainerdRuntimeConfig{
+		CRIClient: fakeCRIClient{containers: []*runtimeapi.Container{{
+			Id:       "exited-container",
+			State:    runtimeapi.ContainerState_CONTAINER_EXITED,
+			Metadata: &runtimeapi.ContainerMetadata{Name: "sandbox"},
+			Labels: map[string]string{
+				"io.kubernetes.pod.namespace": "default",
+				"io.kubernetes.pod.name":      "other-pod",
+				"io.kubernetes.pod.uid":       "other-uid",
+			},
+		}}},
+	})
+
+	_, _, err := runtime.resolveContainerID(context.Background(), ctldapi.RootFSContainerRef{
+		Namespace:     "default",
+		PodName:       "pod-1",
+		PodUID:        "uid-1",
+		ContainerName: "sandbox",
+		ContainerID:   "exited-container",
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
 func TestResolveContainerIDReturnsNotFound(t *testing.T) {
 	runtime := NewContainerdRuntime(ContainerdRuntimeConfig{CRIClient: fakeCRIClient{}})
 
@@ -253,6 +318,11 @@ func TestNormalizeCRIEndpoint(t *testing.T) {
 	assert.Equal(t, "unix:///run/containerd/containerd.sock", normalizeCRIEndpoint("/run/containerd/containerd.sock"))
 	assert.Equal(t, "unix:///run/containerd/containerd.sock", normalizeCRIEndpoint("unix:///run/containerd/containerd.sock"))
 	assert.Equal(t, "127.0.0.1:1234", normalizeCRIEndpoint("127.0.0.1:1234"))
+}
+
+func TestNormalizeContainerID(t *testing.T) {
+	assert.Equal(t, "container-1", normalizeContainerID("containerd://container-1"))
+	assert.Equal(t, "container-2", normalizeContainerID(" container-2 "))
 }
 
 type fakeCRIClient struct {

--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -40,6 +40,12 @@ Runtime access paths do not expose `pausing` or `resuming` states. File, context
 
 Automatic pause from `ttl` is opportunistic. If supported runtime access arrives before an automatic pause reaches its commit point, Sandbox0 cancels that automatic pause, releases the runtime barrier, and continues on the existing runtime generation. Explicit pause requests are not canceled by runtime access; those requests wait for the committed pause and then resume if auto-resume is allowed.
 
+## Unexpected Runtime Termination
+
+If the `procd` container in a claimed sandbox exits unexpectedly, including an OOM termination, Sandbox0 leaves that container attempt stopped while `manager` starts a non-cancelable crash-recovery pause. `ctld` checkpoints the exact terminated containerd snapshot, then `manager` atomically commits the new rootfs head and paused state before deleting the old runtime pod. A supported runtime request waits for this transaction and can resume from the recovered checkpoint when auto-resume is allowed.
+
+Explicit sandbox deletion and `hard_ttl` still take precedence over crash recovery. Recovery also depends on the terminated snapshot remaining available on the same node. If the old runtime pod or containerd snapshot disappears before `ctld` can read it, Sandbox0 records the degraded recovery and falls back to the last committed rootfs checkpoint. Files written after that checkpoint may be lost. Mounted Sandbox Volumes keep their independently durable state.
+
 <Endpoint method="POST">
 /api/v1/sandboxes/{'{id}'}/pause
 </Endpoint>
@@ -81,7 +87,7 @@ Resume a sandbox that was paused manually or by TTL expiry.
 
 Resume first restores the writable rootfs checkpoint onto a runtime pod created from the current template image. If that restore fails, Sandbox0 retries once with a runtime pod pinned to the checkpoint's recorded base image digest. Kubernetes pulls and garbage-collects that image through the normal kubelet image lifecycle.
 
-If the current runtime pod has reached the `Failed` phase, sandbox details return that state immediately instead of waiting for a Pod IP. Explicit resume, or a supported access path with `auto_resume: true`, removes the failed pod and creates a new runtime generation. The replacement restores the latest committed rootfs checkpoint; writes made after that checkpoint are not guaranteed to survive an unexpected runtime failure. Mounted Sandbox Volumes are remounted from their durable state.
+If the current runtime pod reaches a terminal phase, explicit resume or a supported access path first waits for any crash-recovery checkpoint to commit. The replacement runtime then restores that recovered rootfs head. When the terminated snapshot is no longer available, the replacement restores the last committed checkpoint instead. Mounted Sandbox Volumes are remounted from their durable state.
 
 <Endpoint method="POST">
 /api/v1/sandboxes/{'{id}'}/resume

--- a/docs/self-hosted/install/page.mdx
+++ b/docs/self-hosted/install/page.mdx
@@ -13,6 +13,10 @@ This is the shortest production-like path from zero to a running self-hosted San
 Kubernetes `1.35+` is required for the supported Sandbox0 runtime stack. Checkpointed pause/resume depends on `ctld` on sandbox nodes so Sandbox0 can save and restore writable rootfs checkpoints when releasing and recreating runtime pods.
 </Callout>
 
+<Callout variant="warning">
+Keep the Kubernetes `ContainerRestartRules` feature gate enabled. Sandbox0 uses its container-level restart policy to leave a terminated `procd` attempt available for crash rootfs recovery while keeping the ReplicaSet-compatible pod restart policy.
+</Callout>
+
 ## 0) Create a Local Kind Cluster
 
 Create the cluster:

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -517,6 +517,8 @@ func main() {
 	podInformer.Informer().AddEventHandler(sandboxCrashLogCollector.ResourceEventHandler())
 	sandboxPauseController := service.NewSandboxPauseController(sandboxService, logger)
 	sandboxService.SetPauseEnqueuer(sandboxPauseController)
+	sandboxCrashRecoveryController := service.NewSandboxCrashRecoveryController(k8sClient, podLister, sandboxService, logger)
+	podInformer.Informer().AddEventHandler(sandboxCrashRecoveryController.ResourceEventHandler())
 	operator.SetSandboxProbeRunner(sandboxService)
 	sandboxLogWorker := buildSandboxObservabilityLogWorker(cfg, internalAuthGen, obsProvider, logger)
 	staticAuth := make([]egressauthruntime.StaticAuthConfig, 0, len(cfg.EgressAuthStaticAuth))
@@ -699,6 +701,11 @@ func main() {
 	go func() {
 		if err := sandboxCrashLogCollector.Run(ctx, 2); err != nil && !errors.Is(err, context.Canceled) {
 			logger.Error("Sandbox crash log collector failed", zap.Error(err))
+		}
+	}()
+	go func() {
+		if err := sandboxCrashRecoveryController.Run(ctx, 2); err != nil && !errors.Is(err, context.Canceled) {
+			logger.Error("Sandbox crash recovery controller failed", zap.Error(err))
 		}
 	}()
 

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers.go
@@ -333,11 +333,13 @@ func buildContainers(template *SandboxTemplate) []corev1.Container {
 // buildContainer builds a single container
 func buildContainer(spec *ContainerSpec, template *SandboxTemplate) corev1.Container {
 	name := "procd"
+	restartPolicy := corev1.ContainerRestartPolicyNever
 
 	container := corev1.Container{
 		Name:            name,
 		Image:           spec.Image,
 		ImagePullPolicy: corev1.PullIfNotPresent,
+		RestartPolicy:   &restartPolicy,
 		Resources:       BuildResourceRequirements(spec.Resources),
 		ResizePolicy: []corev1.ContainerResizePolicy{
 			{ResourceName: corev1.ResourceCPU, RestartPolicy: corev1.NotRequired},

--- a/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
+++ b/manager/pkg/apis/sandbox0/v1alpha1/helpers_test.go
@@ -403,7 +403,7 @@ procd_config:
 	}
 }
 
-func TestBuildPodSpecUsesRestartPolicyAlways(t *testing.T) {
+func TestBuildPodSpecUsesContainerRestartPolicyNever(t *testing.T) {
 	configPath := writeManagerConfig(t, `
 manager_image: sandbox0/manager:test
 `)
@@ -412,6 +412,12 @@ manager_image: sandbox0/manager:test
 	spec := BuildPodSpec(newTestTemplate())
 	if spec.RestartPolicy != corev1.RestartPolicyAlways {
 		t.Fatalf("restartPolicy = %q, want %q", spec.RestartPolicy, corev1.RestartPolicyAlways)
+	}
+	if len(spec.Containers) != 1 || spec.Containers[0].RestartPolicy == nil {
+		t.Fatalf("container restartPolicy = nil, want %q", corev1.ContainerRestartPolicyNever)
+	}
+	if got := *spec.Containers[0].RestartPolicy; got != corev1.ContainerRestartPolicyNever {
+		t.Fatalf("container restartPolicy = %q, want %q", got, corev1.ContainerRestartPolicyNever)
 	}
 }
 

--- a/manager/pkg/controller/cleanup_controller.go
+++ b/manager/pkg/controller/cleanup_controller.go
@@ -197,13 +197,6 @@ func (cc *CleanupController) cleanupExpired(ctx context.Context, template *v1alp
 			cc.forceDeleteStaleDeletingPod(ctx, template, pod, now)
 			continue
 		}
-		if pod.Status.Phase == corev1.PodSucceeded {
-			if cc.deleteCompletedPod(ctx, template, pod) {
-				expiredCount++
-			}
-			continue
-		}
-
 		// Hard expiry deletes the durable sandbox identity and state.
 		if hardExpiresAtStr := pod.Annotations[AnnotationHardExpiresAt]; hardExpiresAtStr != "" {
 			hardExpiresAt, err := time.Parse(time.RFC3339, hardExpiresAtStr)
@@ -245,6 +238,14 @@ func (cc *CleanupController) cleanupExpired(ctx context.Context, template *v1alp
 				expiredCount++
 				continue
 			}
+		}
+
+		// Claimed stopped runtimes are retained until manager checkpoints their
+		// terminated container snapshot. The Pod phase can remain Running when
+		// its container-level restart policy prevents procd from restarting.
+		// Hard expiry above still wins.
+		if claimedSandboxRuntimeStopped(pod) {
+			continue
 		}
 
 		// Check if pod has expiration annotation
@@ -300,6 +301,21 @@ func (cc *CleanupController) cleanupExpired(ctx context.Context, template *v1alp
 	return nil
 }
 
+func claimedSandboxRuntimeStopped(pod *corev1.Pod) bool {
+	if !IsClaimedSandboxPod(pod) {
+		return false
+	}
+	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+		return true
+	}
+	for i := range pod.Status.ContainerStatuses {
+		if pod.Status.ContainerStatuses[i].State.Terminated != nil {
+			return true
+		}
+	}
+	return false
+}
+
 func (cc *CleanupController) cleanupStaleDeletingIdlePods(ctx context.Context, template *v1alpha1.SandboxTemplate, now time.Time) error {
 	pods, err := cc.podLister.Pods(template.Namespace).List(labels.SelectorFromSet(map[string]string{
 		LabelTemplateID: template.Name,
@@ -315,45 +331,6 @@ func (cc *CleanupController) cleanupStaleDeletingIdlePods(ctx context.Context, t
 		}
 	}
 	return nil
-}
-
-func (cc *CleanupController) deleteCompletedPod(ctx context.Context, template *v1alpha1.SandboxTemplate, pod *corev1.Pod) bool {
-	if pod == nil {
-		return false
-	}
-
-	cc.logger.Info("Deleting completed sandbox pod",
-		zap.String("pod", pod.Name),
-		zap.String("phase", string(pod.Status.Phase)),
-	)
-
-	if cc.sandboxTerminator != nil {
-		if err := cc.sandboxTerminator.TerminateSandboxByID(ctx, cleanupSandboxIDFromPod(pod)); err != nil {
-			cc.logger.Error("Failed to delete completed sandbox pod",
-				zap.String("pod", pod.Name),
-				zap.Error(err),
-			)
-			return false
-		}
-	} else {
-		if cc.k8sClient == nil {
-			cc.logger.Warn("Kubernetes client not configured, skipping completed sandbox pod delete",
-				zap.String("pod", pod.Name),
-			)
-			return false
-		}
-		if err := cc.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil {
-			cc.logger.Error("Failed to delete completed sandbox pod",
-				zap.String("pod", pod.Name),
-				zap.Error(err),
-			)
-			return false
-		}
-	}
-
-	cc.recorder.Eventf(template, corev1.EventTypeNormal, "CompletedPodDeleted",
-		"Deleted completed sandbox pod %s", pod.Name)
-	return true
 }
 
 func cleanupSandboxIDFromPod(pod *corev1.Pod) string {

--- a/manager/pkg/controller/cleanup_controller_test.go
+++ b/manager/pkg/controller/cleanup_controller_test.go
@@ -185,6 +185,7 @@ func TestCleanupExpiredDeletesHardExpiredSandbox(t *testing.T) {
 				AnnotationHardExpiresAt: now.Add(-time.Minute).Format(time.RFC3339),
 			},
 		},
+		Status: corev1.PodStatus{Phase: corev1.PodFailed},
 	}
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
 		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
@@ -343,7 +344,7 @@ func TestCleanupExpiredForceDeletesStaleDeletingIdlePod(t *testing.T) {
 	}
 }
 
-func TestCleanupExpiredDeletesCompletedSandboxPodViaTerminator(t *testing.T) {
+func TestCleanupExpiredRetainsCompletedSandboxPodForCrashRecovery(t *testing.T) {
 	now := time.Date(2026, time.April, 15, 19, 31, 0, 0, time.UTC)
 	template := &v1alpha1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{
@@ -385,16 +386,67 @@ func TestCleanupExpiredDeletesCompletedSandboxPodViaTerminator(t *testing.T) {
 
 	require.NoError(t, controller.cleanupExpired(context.Background(), template))
 
-	assert.Equal(t, []string{"sandbox-1"}, terminator.calls)
+	assert.Empty(t, terminator.calls)
 	select {
 	case event := <-recorder.Events:
-		assert.Contains(t, event, "CompletedPodDeleted")
+		t.Fatalf("unexpected cleanup event: %s", event)
 	default:
-		t.Fatal("expected completed-pod-deleted event")
 	}
 }
 
-func TestCleanupExpiredDeletesCompletedSandboxPodDirectlyWhenTerminatorMissing(t *testing.T) {
+func TestCleanupExpiredDoesNotPauseRunningPodWithTerminatedRuntime(t *testing.T) {
+	now := time.Date(2026, time.April, 15, 19, 31, 0, 0, time.UTC)
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "tpl-default",
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sandbox-1",
+			Namespace: "tpl-default",
+			Labels: map[string]string{
+				LabelTemplateID: "default",
+				LabelPoolType:   PoolTypeActive,
+			},
+			Annotations: map[string]string{
+				AnnotationExpiresAt: now.Add(-time.Minute).Format(time.RFC3339),
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "procd",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{ExitCode: 137},
+				},
+			}},
+		},
+	}
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	require.NoError(t, indexer.Add(pod))
+
+	runtimePauser := &recordingRuntimePauser{}
+	controller := NewCleanupController(
+		nil,
+		corelisters.NewPodLister(indexer),
+		nil,
+		record.NewFakeRecorder(1),
+		staticCleanupClock{now: now},
+		runtimePauser,
+		nil,
+		zap.NewNop(),
+		time.Minute,
+	)
+
+	require.NoError(t, controller.cleanupExpired(context.Background(), template))
+	assert.Empty(t, runtimePauser.calls)
+}
+
+func TestCleanupExpiredDoesNotDeleteCompletedSandboxPodDirectly(t *testing.T) {
 	now := time.Date(2026, time.April, 15, 19, 31, 0, 0, time.UTC)
 	template := &v1alpha1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{
@@ -438,11 +490,10 @@ func TestCleanupExpiredDeletesCompletedSandboxPodDirectlyWhenTerminatorMissing(t
 	require.NoError(t, controller.cleanupExpired(context.Background(), template))
 
 	_, err := client.CoreV1().Pods("tpl-default").Get(context.Background(), "sandbox-1", metav1.GetOptions{})
-	require.True(t, apierrors.IsNotFound(err), "expected completed pod to be deleted, got %v", err)
+	require.NoError(t, err)
 	select {
 	case event := <-recorder.Events:
-		assert.Contains(t, event, "CompletedPodDeleted")
+		t.Fatalf("unexpected cleanup event: %s", event)
 	default:
-		t.Fatal("expected completed-pod-deleted event")
 	}
 }

--- a/manager/pkg/service/sandbox_crash_log_collector.go
+++ b/manager/pkg/service/sandbox_crash_log_collector.go
@@ -21,46 +21,46 @@ import (
 )
 
 const (
-	defaultProcdPreviousLogTailLines      int64 = 2048
-	defaultProcdPreviousLogReadLimitBytes int64 = 16 << 20
-	defaultProcdCrashLogRetainBytes             = 512 << 10
-	defaultProcdCrashLogChunkBytes              = 32 << 10
-	defaultProcdCrashLogRequestTimeout          = 3 * time.Second
-	maxProcdPreviousLogCaptureRetries           = 4
+	defaultProcdCrashLogTailLines      int64 = 2048
+	defaultProcdCrashLogReadLimitBytes int64 = 16 << 20
+	defaultProcdCrashLogRetainBytes          = 512 << 10
+	defaultProcdCrashLogChunkBytes           = 32 << 10
+	defaultProcdCrashLogRequestTimeout       = 3 * time.Second
+	maxProcdCrashLogCaptureRetries           = 4
 )
 
-type previousContainerLogReader interface {
-	ReadPreviousLogs(ctx context.Context, namespace, podName string) ([]byte, error)
+type containerLogReader interface {
+	ReadLogs(ctx context.Context, namespace, podName string, previous bool) ([]byte, error)
 }
 
-type kubernetesPreviousContainerLogReader struct {
+type kubernetesContainerLogReader struct {
 	client kubernetes.Interface
 }
 
-func (r *kubernetesPreviousContainerLogReader) ReadPreviousLogs(ctx context.Context, namespace, podName string) ([]byte, error) {
+func (r *kubernetesContainerLogReader) ReadLogs(ctx context.Context, namespace, podName string, previous bool) ([]byte, error) {
 	if r == nil || r.client == nil {
 		return nil, fmt.Errorf("kubernetes client is not configured")
 	}
-	tailLines := defaultProcdPreviousLogTailLines
-	limitBytes := defaultProcdPreviousLogReadLimitBytes
+	tailLines := defaultProcdCrashLogTailLines
+	limitBytes := defaultProcdCrashLogReadLimitBytes
 	stream, err := r.client.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
 		Container:  DefaultSandboxLogContainer,
-		Previous:   true,
+		Previous:   previous,
 		Timestamps: true,
 		TailLines:  &tailLines,
 		LimitBytes: &limitBytes,
 	}).Stream(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("stream previous procd container logs: %w", err)
+		return nil, fmt.Errorf("stream procd container logs: %w", err)
 	}
 	defer stream.Close()
 
 	logs, err := io.ReadAll(io.LimitReader(stream, limitBytes+1))
 	if err != nil {
-		return nil, fmt.Errorf("read previous procd container logs: %w", err)
+		return nil, fmt.Errorf("read procd container logs: %w", err)
 	}
 	if int64(len(logs)) > limitBytes {
-		return nil, fmt.Errorf("previous procd container logs exceeded %d bytes", limitBytes)
+		return nil, fmt.Errorf("procd container logs exceeded %d bytes", limitBytes)
 	}
 	return logs, nil
 }
@@ -73,6 +73,8 @@ type procdCrashLogItem struct {
 	TeamID            string
 	RuntimeGeneration int64
 	RestartCount      int32
+	ContainerID       string
+	Previous          bool
 	ExitCode          int32
 	Signal            int32
 	Reason            string
@@ -86,13 +88,16 @@ func (i procdCrashLogItem) crashID() string {
 	if podIdentity == "" {
 		podIdentity = i.Namespace + "/" + i.PodName
 	}
+	if !i.Previous && strings.TrimSpace(i.ContainerID) != "" {
+		return podIdentity + ":" + strings.TrimSpace(i.ContainerID)
+	}
 	return fmt.Sprintf("%s:%d", podIdentity, i.RestartCount)
 }
 
-// SandboxCrashLogCollector captures the previous procd container logs after an
-// unexpected restart and emits them through the manager's platform logger.
+// SandboxCrashLogCollector captures procd logs after an unexpected termination
+// and emits them through the manager's platform logger.
 type SandboxCrashLogCollector struct {
-	reader  previousContainerLogReader
+	reader  containerLogReader
 	logger  *zap.Logger
 	metrics *obsmetrics.ManagerMetrics
 	queue   workqueue.TypedRateLimitingInterface[procdCrashLogItem]
@@ -105,7 +110,7 @@ func NewSandboxCrashLogCollector(k8sClient kubernetes.Interface, logger *zap.Log
 		logger = zap.NewNop()
 	}
 	return &SandboxCrashLogCollector{
-		reader:  &kubernetesPreviousContainerLogReader{client: k8sClient},
+		reader:  &kubernetesContainerLogReader{client: k8sClient},
 		logger:  logger,
 		metrics: metrics,
 		queue: workqueue.NewTypedRateLimitingQueue(
@@ -114,17 +119,17 @@ func NewSandboxCrashLogCollector(k8sClient kubernetes.Interface, logger *zap.Log
 	}
 }
 
-// ResourceEventHandler detects failed procd restarts from shared Pod informer events.
+// ResourceEventHandler detects terminated procd attempts from shared Pod informer events.
 func (c *SandboxCrashLogCollector) ResourceEventHandler() cache.ResourceEventHandlerFuncs {
 	if c == nil {
 		return cache.ResourceEventHandlerFuncs{}
 	}
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj any) {
-			c.enqueueRestart(nil, extractPod(obj))
+			c.enqueueTermination(nil, extractPod(obj))
 		},
 		UpdateFunc: func(oldObj, newObj any) {
-			c.enqueueRestart(extractPod(oldObj), extractPod(newObj))
+			c.enqueueTermination(extractPod(oldObj), extractPod(newObj))
 		},
 	}
 }
@@ -156,15 +161,26 @@ func (c *SandboxCrashLogCollector) Run(ctx context.Context, workers int) error {
 	return ctx.Err()
 }
 
-func (c *SandboxCrashLogCollector) enqueueRestart(oldPod, newPod *corev1.Pod) {
+func (c *SandboxCrashLogCollector) enqueueTermination(oldPod, newPod *corev1.Pod) {
 	if c == nil || c.queue == nil || !sandboxCrashLogPodEligible(newPod) {
 		return
 	}
 	newStatus := procdContainerStatus(newPod)
-	if newStatus == nil || newStatus.RestartCount == 0 || newStatus.LastTerminationState.Terminated == nil {
+	if newStatus == nil {
 		return
 	}
 
+	if terminated := newStatus.State.Terminated; terminated != nil {
+		if sameCurrentProcdTermination(oldPod, newPod, newStatus, terminated) {
+			return
+		}
+		c.queue.Add(crashLogItem(newPod, newStatus, terminated, false))
+		return
+	}
+
+	if newStatus.RestartCount == 0 || newStatus.LastTerminationState.Terminated == nil {
+		return
+	}
 	oldRestartCount := int32(0)
 	if oldPod != nil && oldPod.UID == newPod.UID {
 		if oldStatus := procdContainerStatus(oldPod); oldStatus != nil {
@@ -179,25 +195,52 @@ func (c *SandboxCrashLogCollector) enqueueRestart(oldPod, newPod *corev1.Pod) {
 	if terminated.ExitCode == 0 && terminated.Signal == 0 {
 		return
 	}
-	c.queue.Add(procdCrashLogItem{
-		Namespace:         newPod.Namespace,
-		PodName:           newPod.Name,
-		PodUID:            string(newPod.UID),
-		SandboxID:         sandboxIDFromPod(newPod),
-		TeamID:            strings.TrimSpace(newPod.Annotations[controller.AnnotationTeamID]),
-		RuntimeGeneration: runtimeGenerationFromPod(newPod),
-		RestartCount:      newStatus.RestartCount,
+	c.queue.Add(crashLogItem(newPod, newStatus, terminated, true))
+}
+
+func sameCurrentProcdTermination(
+	oldPod, newPod *corev1.Pod,
+	newStatus *corev1.ContainerStatus,
+	newTerminated *corev1.ContainerStateTerminated,
+) bool {
+	if oldPod == nil || newPod == nil || oldPod.UID != newPod.UID {
+		return false
+	}
+	oldStatus := procdContainerStatus(oldPod)
+	if oldStatus == nil || oldStatus.State.Terminated == nil {
+		return false
+	}
+	return oldStatus.ContainerID == newStatus.ContainerID &&
+		oldStatus.State.Terminated.FinishedAt.Equal(&newTerminated.FinishedAt)
+}
+
+func crashLogItem(
+	pod *corev1.Pod,
+	status *corev1.ContainerStatus,
+	terminated *corev1.ContainerStateTerminated,
+	previous bool,
+) procdCrashLogItem {
+	return procdCrashLogItem{
+		Namespace:         pod.Namespace,
+		PodName:           pod.Name,
+		PodUID:            string(pod.UID),
+		SandboxID:         sandboxIDFromPod(pod),
+		TeamID:            strings.TrimSpace(pod.Annotations[controller.AnnotationTeamID]),
+		RuntimeGeneration: runtimeGenerationFromPod(pod),
+		RestartCount:      status.RestartCount,
+		ContainerID:       status.ContainerID,
+		Previous:          previous,
 		ExitCode:          terminated.ExitCode,
 		Signal:            terminated.Signal,
 		Reason:            terminated.Reason,
 		Message:           terminated.Message,
 		StartedAt:         terminated.StartedAt.Time,
 		FinishedAt:        terminated.FinishedAt.Time,
-	})
+	}
 }
 
 func sandboxCrashLogPodEligible(pod *corev1.Pod) bool {
-	if pod == nil || !controller.IsClaimedSandboxPod(pod) {
+	if pod == nil || pod.DeletionTimestamp != nil || !controller.IsClaimedSandboxPod(pod) {
 		return false
 	}
 	if strings.TrimSpace(pod.Annotations[controller.AnnotationTeamID]) == "" {
@@ -230,7 +273,7 @@ func (c *SandboxCrashLogCollector) processNextWorkItem(ctx context.Context) bool
 	}
 	defer c.queue.Done(item)
 
-	err := c.capturePreviousLogs(ctx, item)
+	err := c.captureLogs(ctx, item)
 	if err == nil {
 		c.queue.Forget(item)
 		return true
@@ -239,8 +282,8 @@ func (c *SandboxCrashLogCollector) processNextWorkItem(ctx context.Context) bool
 		c.queue.Forget(item)
 		return true
 	}
-	if c.queue.NumRequeues(item) < maxProcdPreviousLogCaptureRetries {
-		c.logger.Debug("Previous procd log capture failed, retrying",
+	if c.queue.NumRequeues(item) < maxProcdCrashLogCaptureRetries {
+		c.logger.Debug("Procd crash log capture failed, retrying",
 			append(procdCrashLogFields(item), zap.Error(err))...,
 		)
 		c.queue.AddRateLimited(item)
@@ -249,41 +292,41 @@ func (c *SandboxCrashLogCollector) processNextWorkItem(ctx context.Context) bool
 
 	c.queue.Forget(item)
 	c.observeCapture("error", 0)
-	c.logger.Warn("Failed to capture previous procd container logs",
+	c.logger.Warn("Failed to capture terminated procd container logs",
 		append(procdCrashLogFields(item), zap.Error(err))...,
 	)
 	return true
 }
 
-func (c *SandboxCrashLogCollector) capturePreviousLogs(ctx context.Context, item procdCrashLogItem) error {
+func (c *SandboxCrashLogCollector) captureLogs(ctx context.Context, item procdCrashLogItem) error {
 	if c == nil || c.reader == nil {
 		return fmt.Errorf("previous container log reader is not configured")
 	}
 	requestCtx, cancel := context.WithTimeout(ctx, defaultProcdCrashLogRequestTimeout)
 	defer cancel()
 
-	raw, err := c.reader.ReadPreviousLogs(requestCtx, item.Namespace, item.PodName)
+	raw, err := c.reader.ReadLogs(requestCtx, item.Namespace, item.PodName, item.Previous)
 	if err != nil {
 		return err
 	}
 	if len(bytes.TrimSpace(raw)) == 0 {
-		return fmt.Errorf("previous procd container logs were empty")
+		return fmt.Errorf("terminated procd container logs were empty")
 	}
 
-	filtered, droppedProcessLines, err := filterPreviousProcdLogs(raw)
+	filtered, droppedProcessLines, err := filterProcdCrashLogs(raw)
 	if err != nil {
 		return err
 	}
 	if len(bytes.TrimSpace(filtered)) == 0 {
 		c.observeCapture("empty", 0)
-		c.logger.Warn("Previous procd container logs contained no internal log lines",
+		c.logger.Warn("Terminated procd container logs contained no internal log lines",
 			append(procdCrashLogFields(item), zap.Int("dropped_process_log_lines", droppedProcessLines))...,
 		)
 		return nil
 	}
 
-	retained, truncated := retainPreviousLogTail(filtered, defaultProcdCrashLogRetainBytes)
-	chunks := splitPreviousLogChunks(retained, defaultProcdCrashLogChunkBytes)
+	retained, truncated := retainProcdCrashLogTail(filtered, defaultProcdCrashLogRetainBytes)
+	chunks := splitProcdCrashLogChunks(retained, defaultProcdCrashLogChunkBytes)
 	fields := procdCrashLogFields(item)
 	fields = append(fields,
 		zap.Int("captured_log_bytes", len(retained)),
@@ -298,15 +341,15 @@ func (c *SandboxCrashLogCollector) capturePreviousLogs(ctx context.Context, item
 			zap.Int("chunk_index", index),
 			zap.String("log_chunk", chunk),
 		)
-		c.logger.Warn("Captured previous procd container logs", chunkFields...)
+		c.logger.Warn("Captured terminated procd container logs", chunkFields...)
 	}
 	c.observeCapture("success", len(retained))
 	return nil
 }
 
-func filterPreviousProcdLogs(raw []byte) ([]byte, int, error) {
+func filterProcdCrashLogs(raw []byte) ([]byte, int, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(raw))
-	scanner.Buffer(make([]byte, 64<<10), int(defaultProcdPreviousLogReadLimitBytes))
+	scanner.Buffer(make([]byte, 64<<10), int(defaultProcdCrashLogReadLimitBytes))
 	var filtered bytes.Buffer
 	droppedProcessLines := 0
 	for scanner.Scan() {
@@ -319,12 +362,12 @@ func filterPreviousProcdLogs(raw []byte) ([]byte, int, error) {
 		filtered.WriteByte('\n')
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, 0, fmt.Errorf("filter previous procd container logs: %w", err)
+		return nil, 0, fmt.Errorf("filter terminated procd container logs: %w", err)
 	}
 	return filtered.Bytes(), droppedProcessLines, nil
 }
 
-func retainPreviousLogTail(logs []byte, limit int) ([]byte, bool) {
+func retainProcdCrashLogTail(logs []byte, limit int) ([]byte, bool) {
 	if limit <= 0 || len(logs) <= limit {
 		return logs, false
 	}
@@ -335,7 +378,7 @@ func retainPreviousLogTail(logs []byte, limit int) ([]byte, bool) {
 	return logs, true
 }
 
-func splitPreviousLogChunks(logs []byte, limit int) []string {
+func splitProcdCrashLogChunks(logs []byte, limit int) []string {
 	if len(logs) == 0 {
 		return nil
 	}
@@ -367,6 +410,8 @@ func procdCrashLogFields(item procdCrashLogItem) []zap.Field {
 		zap.String("pod_uid", item.PodUID),
 		zap.Int64("runtime_generation", item.RuntimeGeneration),
 		zap.Int32("restart_count", item.RestartCount),
+		zap.String("container_id", item.ContainerID),
+		zap.Bool("previous_logs", item.Previous),
 		zap.Int32("exit_code", item.ExitCode),
 		zap.Int32("signal", item.Signal),
 		zap.String("reason", item.Reason),

--- a/manager/pkg/service/sandbox_crash_log_collector_test.go
+++ b/manager/pkg/service/sandbox_crash_log_collector_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -43,7 +44,27 @@ func TestSandboxCrashLogCollectorEnqueuesUnexpectedProcdRestart(t *testing.T) {
 	assert.Equal(t, int64(7), item.RuntimeGeneration)
 	assert.Equal(t, int32(1), item.RestartCount)
 	assert.Equal(t, int32(2), item.ExitCode)
+	assert.True(t, item.Previous)
 	assert.Equal(t, "pod-uid:1", item.crashID())
+}
+
+func TestSandboxCrashLogCollectorEnqueuesCurrentTerminatedProcdAttempt(t *testing.T) {
+	collector := NewSandboxCrashLogCollector(nil, zap.NewNop(), nil)
+	t.Cleanup(collector.queue.ShutDown)
+
+	oldPod := testProcdCrashPod(0, 0)
+	newPod := testTerminatedProcdCrashPod(0)
+	collector.ResourceEventHandler().UpdateFunc(oldPod, newPod)
+
+	require.Equal(t, 1, collector.queue.Len())
+	item, shutdown := collector.queue.Get()
+	require.False(t, shutdown)
+	collector.queue.Done(item)
+	collector.queue.Forget(item)
+	assert.False(t, item.Previous)
+	assert.Equal(t, "containerd://terminated-procd", item.ContainerID)
+	assert.Equal(t, int32(0), item.ExitCode)
+	assert.Equal(t, "pod-uid:containerd://terminated-procd", item.crashID())
 }
 
 func TestSandboxCrashLogCollectorIgnoresExpectedOrIrrelevantPodUpdates(t *testing.T) {
@@ -80,6 +101,16 @@ func TestSandboxCrashLogCollectorIgnoresExpectedOrIrrelevantPodUpdates(t *testin
 				return pod
 			}(),
 		},
+		{
+			name:   "pod being deleted",
+			oldPod: testProcdCrashPod(0, 0),
+			newPod: func() *corev1.Pod {
+				pod := testTerminatedProcdCrashPod(137)
+				now := metav1.Now()
+				pod.DeletionTimestamp = &now
+				return pod
+			}(),
+		},
 	}
 
 	for _, tt := range tests {
@@ -110,7 +141,7 @@ func TestSandboxCrashLogCollectorCapturesInternalLogsAndDropsProcessOutput(t *te
 	core, observed := observer.New(zap.DebugLevel)
 	registry := prometheus.NewRegistry()
 	metrics := obsmetrics.NewManager(registry)
-	reader := &recordingPreviousLogReader{logs: []byte(strings.Join([]string{
+	reader := &recordingContainerLogReader{logs: []byte(strings.Join([]string{
 		`2026-07-23T03:26:46.900000000Z {"level":"info","msg":"request started","service":"procd"}`,
 		`2026-07-23T03:26:46.950000000Z {"message":"sandbox process output","process_id":"ctx-1","process_type":"cmd","source":"stderr","data":"TOP_SECRET"}`,
 		`2026-07-23T03:26:46.978000000Z panic: test crash`,
@@ -121,10 +152,10 @@ func TestSandboxCrashLogCollectorCapturesInternalLogsAndDropsProcessOutput(t *te
 	t.Cleanup(collector.queue.ShutDown)
 
 	item := crashLogItemFromPod(testProcdCrashPod(1, 2))
-	require.NoError(t, collector.capturePreviousLogs(context.Background(), item))
+	require.NoError(t, collector.captureLogs(context.Background(), item))
 
-	assert.Equal(t, []string{"sandbox-ns/sandbox-pod"}, reader.Calls())
-	entries := observed.FilterMessage("Captured previous procd container logs").All()
+	assert.Equal(t, []string{"sandbox-ns/sandbox-pod:true"}, reader.Calls())
+	entries := observed.FilterMessage("Captured terminated procd container logs").All()
 	require.Len(t, entries, 1)
 	fields := entries[0].ContextMap()
 	assert.Equal(t, "sandbox_procd_crash", fields["event"])
@@ -142,26 +173,27 @@ func TestSandboxCrashLogCollectorDoesNotEmitFilteredProcessOutput(t *testing.T) 
 	core, observed := observer.New(zap.DebugLevel)
 	registry := prometheus.NewRegistry()
 	metrics := obsmetrics.NewManager(registry)
-	reader := &recordingPreviousLogReader{logs: []byte(`2026-07-23T03:26:46.950000000Z {"message":"sandbox process output","process_id":"ctx-1","process_type":"cmd","source":"stdout","data":"TOP_SECRET"}`)}
+	reader := &recordingContainerLogReader{logs: []byte(`2026-07-23T03:26:46.950000000Z {"message":"sandbox process output","process_id":"ctx-1","process_type":"cmd","source":"stdout","data":"TOP_SECRET"}`)}
 	collector := NewSandboxCrashLogCollector(nil, zap.New(core), metrics)
 	collector.reader = reader
 	t.Cleanup(collector.queue.ShutDown)
 
-	require.NoError(t, collector.capturePreviousLogs(context.Background(), crashLogItemFromPod(testProcdCrashPod(1, 2))))
+	require.NoError(t, collector.captureLogs(context.Background(), crashLogItemFromPod(testProcdCrashPod(1, 2))))
 
-	assert.Equal(t, 0, observed.FilterMessage("Captured previous procd container logs").Len())
-	emptyEntries := observed.FilterMessage("Previous procd container logs contained no internal log lines").All()
+	assert.Equal(t, 0, observed.FilterMessage("Captured terminated procd container logs").Len())
+	emptyEntries := observed.FilterMessage("Terminated procd container logs contained no internal log lines").All()
 	require.Len(t, emptyEntries, 1)
 	assert.NotContains(t, emptyEntries[0].ContextMap(), "log_chunk")
 	assert.Equal(t, float64(1), testutil.ToFloat64(metrics.ProcdCrashLogCapturesTotal.WithLabelValues("empty")))
 }
 
-func TestKubernetesPreviousContainerLogReaderUsesPreviousProcdLogOptions(t *testing.T) {
+func TestKubernetesContainerLogReaderUsesRequestedProcdLogAttempt(t *testing.T) {
+	var previousValues []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/api/v1/namespaces/sandbox-ns/pods/sandbox-pod/log", r.URL.Path)
 		query := r.URL.Query()
 		assert.Equal(t, DefaultSandboxLogContainer, query.Get("container"))
-		assert.Equal(t, "true", query.Get("previous"))
+		previousValues = append(previousValues, query.Get("previous"))
 		assert.Equal(t, "true", query.Get("timestamps"))
 		assert.Equal(t, "2048", query.Get("tailLines"))
 		assert.Equal(t, "16777216", query.Get("limitBytes"))
@@ -171,16 +203,20 @@ func TestKubernetesPreviousContainerLogReaderUsesPreviousProcdLogOptions(t *test
 
 	client, err := kubernetes.NewForConfig(&rest.Config{Host: server.URL})
 	require.NoError(t, err)
-	reader := &kubernetesPreviousContainerLogReader{client: client}
+	reader := &kubernetesContainerLogReader{client: client}
 
-	logs, err := reader.ReadPreviousLogs(context.Background(), "sandbox-ns", "sandbox-pod")
+	logs, err := reader.ReadLogs(context.Background(), "sandbox-ns", "sandbox-pod", true)
 	require.NoError(t, err)
 	assert.Equal(t, "panic: captured\n", string(logs))
+	logs, err = reader.ReadLogs(context.Background(), "sandbox-ns", "sandbox-pod", false)
+	require.NoError(t, err)
+	assert.Equal(t, "panic: captured\n", string(logs))
+	assert.Equal(t, []string{"true", ""}, previousValues)
 }
 
 func TestSandboxCrashLogCollectorRetriesTransientReadFailure(t *testing.T) {
 	core, observed := observer.New(zap.DebugLevel)
-	reader := &recordingPreviousLogReader{
+	reader := &recordingContainerLogReader{
 		logs:         []byte("panic: captured after retry\n"),
 		failuresLeft: 2,
 	}
@@ -193,7 +229,7 @@ func TestSandboxCrashLogCollectorRetriesTransientReadFailure(t *testing.T) {
 	go func() { done <- collector.Run(ctx, 1) }()
 	collector.queue.Add(crashLogItemFromPod(testProcdCrashPod(1, 2)))
 	require.Eventually(t, func() bool {
-		return observed.FilterMessage("Captured previous procd container logs").Len() == 1
+		return observed.FilterMessage("Captured terminated procd container logs").Len() == 1
 	}, 3*time.Second, 20*time.Millisecond)
 	assert.Equal(t, 3, len(reader.Calls()))
 
@@ -201,17 +237,17 @@ func TestSandboxCrashLogCollectorRetriesTransientReadFailure(t *testing.T) {
 	require.ErrorIs(t, <-done, context.Canceled)
 }
 
-type recordingPreviousLogReader struct {
+type recordingContainerLogReader struct {
 	mu           sync.Mutex
 	logs         []byte
 	failuresLeft int
 	calls        []string
 }
 
-func (r *recordingPreviousLogReader) ReadPreviousLogs(_ context.Context, namespace, podName string) ([]byte, error) {
+func (r *recordingContainerLogReader) ReadLogs(_ context.Context, namespace, podName string, previous bool) ([]byte, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.calls = append(r.calls, namespace+"/"+podName)
+	r.calls = append(r.calls, fmt.Sprintf("%s/%s:%t", namespace, podName, previous))
 	if r.failuresLeft > 0 {
 		r.failuresLeft--
 		return nil, errors.New("transient log read failure")
@@ -219,7 +255,7 @@ func (r *recordingPreviousLogReader) ReadPreviousLogs(_ context.Context, namespa
 	return append([]byte(nil), r.logs...), nil
 }
 
-func (r *recordingPreviousLogReader) Calls() []string {
+func (r *recordingContainerLogReader) Calls() []string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return append([]string(nil), r.calls...)
@@ -261,6 +297,26 @@ func testProcdCrashPod(restartCount, exitCode int32) *corev1.Pod {
 	}
 }
 
+func testTerminatedProcdCrashPod(exitCode int32) *corev1.Pod {
+	pod := testProcdCrashPod(0, 0)
+	now := time.Now().UTC()
+	pod.Status.Phase = corev1.PodFailed
+	if exitCode == 0 {
+		pod.Status.Phase = corev1.PodSucceeded
+	}
+	status := &pod.Status.ContainerStatuses[0]
+	status.ContainerID = "containerd://terminated-procd"
+	status.LastTerminationState = corev1.ContainerState{}
+	status.State.Terminated = &corev1.ContainerStateTerminated{
+		ContainerID: "containerd://terminated-procd",
+		ExitCode:    exitCode,
+		Reason:      "Error",
+		StartedAt:   metav1.NewTime(now.Add(-time.Minute)),
+		FinishedAt:  metav1.NewTime(now),
+	}
+	return pod
+}
+
 func crashLogItemFromPod(pod *corev1.Pod) procdCrashLogItem {
 	status := procdContainerStatus(pod)
 	terminated := status.LastTerminationState.Terminated
@@ -272,6 +328,7 @@ func crashLogItemFromPod(pod *corev1.Pod) procdCrashLogItem {
 		TeamID:            pod.Annotations[controller.AnnotationTeamID],
 		RuntimeGeneration: runtimeGenerationFromPod(pod),
 		RestartCount:      status.RestartCount,
+		Previous:          true,
 		ExitCode:          terminated.ExitCode,
 		Signal:            terminated.Signal,
 		Reason:            terminated.Reason,

--- a/manager/pkg/service/sandbox_crash_recovery.go
+++ b/manager/pkg/service/sandbox_crash_recovery.go
@@ -1,0 +1,185 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var errSandboxCrashRecoveryBlocked = errors.New("sandbox crash recovery is blocked by another lifecycle transaction")
+
+// RecoverTerminatedSandboxRuntime durably starts checkpoint recovery for an
+// unexpectedly terminated claimed runtime. The existing pause controller owns
+// checkpoint completion so manager restarts reuse the same durable transaction.
+func (s *SandboxService) RecoverTerminatedSandboxRuntime(ctx context.Context, pod *corev1.Pod) error {
+	if s == nil || s.sandboxStore == nil || pod == nil || pod.DeletionTimestamp != nil {
+		return nil
+	}
+	status, terminated := terminatedProcdContainer(pod)
+	if !sandboxCrashRecoveryPodEligible(pod) || (terminated == nil && !sandboxRuntimePodTerminal(pod)) {
+		return nil
+	}
+
+	sandboxID := sandboxIDFromPod(pod)
+	enqueue := false
+	deleteStaleRuntime := false
+	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
+		if record == nil || record.Status == SandboxStatusDeleted || !record.DeletedAt.IsZero() || sandboxHardExpired(record.HardExpiresAt, s.now()) {
+			return nil
+		}
+		if !sandboxRecordReferencesPod(record, pod) {
+			return nil
+		}
+		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sandboxID)
+		if err != nil {
+			return err
+		}
+		if activeTxn != nil {
+			if crashRecoveryTxnReferencesPod(activeTxn, pod) {
+				enqueue = true
+				return nil
+			}
+			return fmt.Errorf("%w: active %s transaction %s", errSandboxCrashRecoveryBlocked, activeTxn.Kind, activeTxn.ID)
+		}
+		if record.Status == SandboxStatusPaused {
+			deleteStaleRuntime = true
+			return nil
+		}
+		if err := beginCrashRecoveryTxn(lockCtx, tx, record, pod); err != nil {
+			return err
+		}
+		enqueue = true
+		return nil
+	})
+	if errors.Is(err, ErrSandboxRecordNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if deleteStaleRuntime {
+		return s.deleteRecoveredRuntimePod(ctx, pod)
+	}
+	if !enqueue {
+		return nil
+	}
+	if s.logger != nil {
+		containerID := ""
+		if status != nil {
+			containerID = status.ContainerID
+		}
+		exitCode := int32(0)
+		signal := int32(0)
+		reason := ""
+		if terminated != nil {
+			exitCode = terminated.ExitCode
+			signal = terminated.Signal
+			reason = terminated.Reason
+		}
+		s.logger.Warn("Queued terminated sandbox runtime rootfs recovery",
+			zap.String("sandboxID", sandboxID),
+			zap.String("namespace", pod.Namespace),
+			zap.String("pod", pod.Name),
+			zap.String("podUID", string(pod.UID)),
+			zap.String("containerID", containerID),
+			zap.Int64("runtimeGeneration", runtimeGenerationFromPod(pod)),
+			zap.Int32("exitCode", exitCode),
+			zap.Int32("signal", signal),
+			zap.String("reason", reason),
+		)
+	}
+	s.enqueueSandboxPause(sandboxID)
+	return nil
+}
+
+func beginCrashRecoveryTxn(ctx context.Context, tx SandboxStoreTx, record *SandboxRecord, pod *corev1.Pod) error {
+	if tx == nil || record == nil || pod == nil {
+		return nil
+	}
+	_, terminated := terminatedProcdContainer(pod)
+	if terminated == nil && !sandboxRuntimePodTerminal(pod) {
+		return fmt.Errorf("pod %s/%s has no terminated procd container to recover", pod.Namespace, pod.Name)
+	}
+	if !sandboxRecordReferencesPod(record, pod) {
+		return fmt.Errorf("sandbox runtime identity changed before crash recovery")
+	}
+	return tx.BeginLifecycleTxn(ctx, &SandboxLifecycleTxn{
+		ID:               uuid.NewString(),
+		SandboxID:        record.ID,
+		Kind:             SandboxLifecycleKindPause,
+		Phase:            SandboxLifecyclePhasePreparing,
+		Source:           SandboxLifecycleSourceCrash,
+		Cancelable:       false,
+		FromGeneration:   runtimeGenerationFromPod(pod),
+		FromPodNamespace: pod.Namespace,
+		FromPodName:      pod.Name,
+	})
+}
+
+func sandboxRecordReferencesPod(record *SandboxRecord, pod *corev1.Pod) bool {
+	if record == nil || pod == nil {
+		return false
+	}
+	if strings.TrimSpace(record.CurrentPodNamespace) != strings.TrimSpace(pod.Namespace) ||
+		strings.TrimSpace(record.CurrentPodName) != strings.TrimSpace(pod.Name) {
+		return false
+	}
+	return record.RuntimeGeneration == runtimeGenerationFromPod(pod)
+}
+
+func crashRecoveryTxnReferencesPod(txn *SandboxLifecycleTxn, pod *corev1.Pod) bool {
+	if txn == nil || pod == nil || txn.Kind != SandboxLifecycleKindPause || txn.Source != SandboxLifecycleSourceCrash {
+		return false
+	}
+	return txn.FromGeneration == runtimeGenerationFromPod(pod) &&
+		strings.TrimSpace(txn.FromPodNamespace) == strings.TrimSpace(pod.Namespace) &&
+		strings.TrimSpace(txn.FromPodName) == strings.TrimSpace(pod.Name)
+}
+
+func sandboxCrashRecoveryPodEligible(pod *corev1.Pod) bool {
+	if pod == nil || pod.DeletionTimestamp != nil || !controller.IsClaimedSandboxPod(pod) {
+		return false
+	}
+	return strings.TrimSpace(sandboxIDFromPod(pod)) != ""
+}
+
+func terminatedProcdContainer(pod *corev1.Pod) (*corev1.ContainerStatus, *corev1.ContainerStateTerminated) {
+	status := procdContainerStatus(pod)
+	if status == nil || status.State.Terminated == nil {
+		return status, nil
+	}
+	return status, status.State.Terminated
+}
+
+func sandboxRuntimePodTerminal(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	return pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded
+}
+
+func (s *SandboxService) deleteRecoveredRuntimePod(ctx context.Context, pod *corev1.Pod) error {
+	if s == nil || pod == nil || s.k8sClient == nil {
+		return nil
+	}
+	current, err := s.ensureSandboxDeletionFinalizer(ctx, pod)
+	if err != nil {
+		return fmt.Errorf("ensure sandbox cleanup finalizer before deleting recovered runtime: %w", err)
+	}
+	if current == nil {
+		current = pod
+	}
+	err = s.k8sClient.CoreV1().Pods(current.Namespace).Delete(ctx, current.Name, metav1.DeleteOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return fmt.Errorf("delete recovered runtime pod: %w", err)
+	}
+	return nil
+}

--- a/manager/pkg/service/sandbox_crash_recovery_controller.go
+++ b/manager/pkg/service/sandbox_crash_recovery_controller.go
@@ -1,0 +1,174 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+type terminatedSandboxRuntimeRecoverer interface {
+	RecoverTerminatedSandboxRuntime(ctx context.Context, pod *corev1.Pod) error
+}
+
+type sandboxCrashRecoveryItem struct {
+	Namespace string
+	PodName   string
+	PodUID    string
+}
+
+// SandboxCrashRecoveryController starts durable rootfs recovery as soon as a
+// claimed procd container terminates.
+type SandboxCrashRecoveryController struct {
+	k8sClient kubernetes.Interface
+	podLister corelisters.PodLister
+	recoverer terminatedSandboxRuntimeRecoverer
+	logger    *zap.Logger
+	queue     workqueue.TypedRateLimitingInterface[sandboxCrashRecoveryItem]
+}
+
+func NewSandboxCrashRecoveryController(
+	k8sClient kubernetes.Interface,
+	podLister corelisters.PodLister,
+	recoverer terminatedSandboxRuntimeRecoverer,
+	logger *zap.Logger,
+) *SandboxCrashRecoveryController {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &SandboxCrashRecoveryController{
+		k8sClient: k8sClient,
+		podLister: podLister,
+		recoverer: recoverer,
+		logger:    logger,
+		queue: workqueue.NewTypedRateLimitingQueue(
+			workqueue.NewTypedItemExponentialFailureRateLimiter[sandboxCrashRecoveryItem](100*time.Millisecond, 5*time.Second),
+		),
+	}
+}
+
+func (c *SandboxCrashRecoveryController) ResourceEventHandler() cache.ResourceEventHandlerFuncs {
+	if c == nil {
+		return cache.ResourceEventHandlerFuncs{}
+	}
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			c.enqueueTerminatedPod(nil, extractPod(obj))
+		},
+		UpdateFunc: func(oldObj, newObj any) {
+			c.enqueueTerminatedPod(extractPod(oldObj), extractPod(newObj))
+		},
+	}
+}
+
+func (c *SandboxCrashRecoveryController) Run(ctx context.Context, workers int) error {
+	if c == nil {
+		return nil
+	}
+	if workers <= 0 {
+		workers = 1
+	}
+	defer runtime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	c.logger.Info("Starting sandbox crash recovery controller", zap.Int("workers", workers))
+	for i := 0; i < workers; i++ {
+		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
+	}
+	<-ctx.Done()
+	c.logger.Info("Sandbox crash recovery controller stopped")
+	return ctx.Err()
+}
+
+func (c *SandboxCrashRecoveryController) enqueueTerminatedPod(oldPod, newPod *corev1.Pod) {
+	if c == nil || c.queue == nil || !sandboxCrashRecoveryPodEligible(newPod) {
+		return
+	}
+	newStatus, newTerminated := terminatedProcdContainer(newPod)
+	if newTerminated == nil && !sandboxRuntimePodTerminal(newPod) {
+		return
+	}
+	if oldPod != nil && oldPod.UID == newPod.UID {
+		oldStatus, oldTerminated := terminatedProcdContainer(oldPod)
+		if newStatus != nil && newTerminated != nil && oldStatus != nil && oldTerminated != nil &&
+			oldStatus.ContainerID == newStatus.ContainerID &&
+			oldTerminated.FinishedAt.Equal(&newTerminated.FinishedAt) {
+			return
+		}
+		if newTerminated == nil && oldTerminated == nil && oldPod.Status.Phase == newPod.Status.Phase {
+			return
+		}
+	}
+	c.queue.Add(sandboxCrashRecoveryItem{
+		Namespace: newPod.Namespace,
+		PodName:   newPod.Name,
+		PodUID:    string(newPod.UID),
+	})
+}
+
+func (c *SandboxCrashRecoveryController) runWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *SandboxCrashRecoveryController) processNextWorkItem(ctx context.Context) bool {
+	item, shutdown := c.queue.Get()
+	if shutdown {
+		return false
+	}
+	defer c.queue.Done(item)
+
+	if err := c.reconcile(ctx, item); err != nil {
+		c.logger.Warn("Sandbox crash recovery reconcile failed, requeueing",
+			zap.String("namespace", item.Namespace),
+			zap.String("pod", item.PodName),
+			zap.String("podUID", item.PodUID),
+			zap.Error(err),
+		)
+		c.queue.AddRateLimited(item)
+		return true
+	}
+	c.queue.Forget(item)
+	return true
+}
+
+func (c *SandboxCrashRecoveryController) reconcile(ctx context.Context, item sandboxCrashRecoveryItem) error {
+	if c == nil || c.recoverer == nil || strings.TrimSpace(item.Namespace) == "" || strings.TrimSpace(item.PodName) == "" {
+		return nil
+	}
+	pod, err := c.getPod(ctx, item.Namespace, item.PodName)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("get terminated sandbox pod: %w", err)
+	}
+	if item.PodUID != "" && string(pod.UID) != item.PodUID {
+		return nil
+	}
+	if _, terminated := terminatedProcdContainer(pod); (terminated == nil && !sandboxRuntimePodTerminal(pod)) || pod.DeletionTimestamp != nil {
+		return nil
+	}
+	return c.recoverer.RecoverTerminatedSandboxRuntime(ctx, pod)
+}
+
+func (c *SandboxCrashRecoveryController) getPod(ctx context.Context, namespace, name string) (*corev1.Pod, error) {
+	if c.podLister != nil {
+		return c.podLister.Pods(namespace).Get(name)
+	}
+	if c.k8sClient == nil {
+		return nil, fmt.Errorf("kubernetes client is not configured")
+	}
+	return c.k8sClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+}

--- a/manager/pkg/service/sandbox_crash_recovery_test.go
+++ b/manager/pkg/service/sandbox_crash_recovery_test.go
@@ -1,0 +1,450 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func TestRecoverTerminatedSandboxRuntimeStartsDurableCrashPause(t *testing.T) {
+	pod := crashRecoveryTestPod(corev1.PodRunning, 137, "OOMKilled")
+	store := crashRecoveryTestStore(pod)
+	enqueuer := &recordingPauseEnqueuer{}
+	svc := &SandboxService{
+		sandboxStore:  store,
+		pauseEnqueuer: enqueuer,
+		clock:         systemTime{},
+		logger:        zap.NewNop(),
+	}
+
+	require.NoError(t, svc.RecoverTerminatedSandboxRuntime(context.Background(), pod))
+	require.NoError(t, svc.RecoverTerminatedSandboxRuntime(context.Background(), pod))
+
+	require.Len(t, store.lifecycleTxns, 1)
+	var txn *SandboxLifecycleTxn
+	for _, candidate := range store.lifecycleTxns {
+		txn = candidate
+	}
+	require.NotNil(t, txn)
+	assert.Equal(t, SandboxLifecycleKindPause, txn.Kind)
+	assert.Equal(t, SandboxLifecycleSourceCrash, txn.Source)
+	assert.False(t, txn.Cancelable)
+	assert.Equal(t, int64(3), txn.FromGeneration)
+	assert.Equal(t, pod.Namespace, txn.FromPodNamespace)
+	assert.Equal(t, pod.Name, txn.FromPodName)
+	assert.Equal(t, []string{"sandbox-1", "sandbox-1"}, enqueuer.calls)
+}
+
+func TestSandboxRuntimePodNeedsReplacementWhenProcdTerminatedWhilePodRunning(t *testing.T) {
+	pod := crashRecoveryTestPod(corev1.PodRunning, 137, "OOMKilled")
+
+	assert.True(t, sandboxRuntimePodNeedsReplacement(pod))
+}
+
+func TestRecoverTerminatedSandboxRuntimeIgnoresStalePod(t *testing.T) {
+	pod := crashRecoveryTestPod(corev1.PodFailed, 2, "Error")
+	store := crashRecoveryTestStore(pod)
+	store.records["sandbox-1"].CurrentPodName = "new-runtime"
+	store.records["sandbox-1"].RuntimeGeneration = 4
+	enqueuer := &recordingPauseEnqueuer{}
+	svc := &SandboxService{
+		sandboxStore:  store,
+		pauseEnqueuer: enqueuer,
+		clock:         systemTime{},
+		logger:        zap.NewNop(),
+	}
+
+	require.NoError(t, svc.RecoverTerminatedSandboxRuntime(context.Background(), pod))
+
+	assert.Empty(t, store.lifecycleTxns)
+	assert.Empty(t, enqueuer.calls)
+}
+
+func TestRecoverTerminatedSandboxRuntimeWaitsForConflictingLifecycle(t *testing.T) {
+	pod := crashRecoveryTestPod(corev1.PodFailed, 2, "Error")
+	store := crashRecoveryTestStore(pod)
+	store.lifecycleTxns = map[string]*SandboxLifecycleTxn{
+		"manual-pause": {
+			ID:        "manual-pause",
+			SandboxID: "sandbox-1",
+			Kind:      SandboxLifecycleKindPause,
+			Phase:     SandboxLifecyclePhasePublishing,
+			Source:    SandboxLifecycleSourceManual,
+		},
+	}
+	svc := &SandboxService{sandboxStore: store, clock: systemTime{}, logger: zap.NewNop()}
+
+	err := svc.RecoverTerminatedSandboxRuntime(context.Background(), pod)
+
+	require.ErrorIs(t, err, errSandboxCrashRecoveryBlocked)
+	assert.Len(t, store.lifecycleTxns, 1)
+}
+
+func TestCompleteCrashRecoveryCommitsRootFSBeforeDeletingPod(t *testing.T) {
+	var preparedTarget ctldapi.RootFSContainerRef
+	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/rootfs/snapshots/prepare":
+			var req ctldapi.PrepareRootFSSnapshotRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			preparedTarget = req.Target
+			require.NoError(t, json.NewEncoder(w).Encode(crashRecoveryPrepareResponse()))
+		case "/api/v1/rootfs/snapshots/publish":
+			require.NoError(t, json.NewEncoder(w).Encode(crashRecoveryPublishResponse()))
+		default:
+			t.Fatalf("unexpected ctld path %s", r.URL.Path)
+		}
+	}))
+	defer ctld.Close()
+	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
+
+	pod := crashRecoveryTestPod(corev1.PodFailed, 137, "OOMKilled")
+	pod.Status.HostIP = ctldURL.Hostname()
+	store := crashRecoveryTestStore(pod)
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	deleted := false
+	client.PrependReactor("delete", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+		record, err := store.GetSandbox(context.Background(), "sandbox-1")
+		require.NoError(t, err)
+		require.Equal(t, SandboxStatusPaused, record.Status, "runtime must be fenced before pod deletion")
+		require.NotNil(t, store.rootFSStates["sandbox-1"], "rootfs head must commit before pod deletion")
+		deleted = true
+		return true, nil, nil
+	})
+	svc := &SandboxService{
+		k8sClient:     client,
+		podLister:     newTestPodLister(t, pod),
+		sandboxStore:  store,
+		ctldClient:    NewCtldClientWithHTTPClient(ctld.Client()),
+		pauseEnqueuer: &recordingPauseEnqueuer{},
+		config:        SandboxServiceConfig{CtldEnabled: true, CtldPort: ctldPort},
+		clock:         systemTime{},
+		logger:        zap.NewNop(),
+	}
+
+	require.NoError(t, svc.RecoverTerminatedSandboxRuntime(context.Background(), pod))
+	require.NoError(t, svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"))
+
+	assert.True(t, deleted)
+	assert.Equal(t, "containerd://terminated-container", preparedTarget.ContainerID)
+	assert.Equal(t, string(pod.UID), preparedTarget.PodUID)
+	assert.Equal(t, SandboxStatusPaused, store.records["sandbox-1"].Status)
+	assert.Nil(t, activeLifecycleTxnForTest(store, "sandbox-1"))
+	state := store.rootFSStates["sandbox-1"]
+	require.NotNil(t, state)
+	assert.Equal(t, "sha256:recovered", state.DiffDigest)
+	assert.NotEmpty(t, state.LayerID)
+}
+
+func TestCompleteCrashRecoveryRetainsPodAndTransactionOnTransientCheckpointFailure(t *testing.T) {
+	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(ctldapi.PrepareRootFSSnapshotResponse{Error: "object store temporarily unavailable"})
+	}))
+	defer ctld.Close()
+	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
+
+	pod := crashRecoveryTestPod(corev1.PodFailed, 2, "Error")
+	pod.Status.HostIP = ctldURL.Hostname()
+	store := crashRecoveryTestStore(pod)
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	svc := &SandboxService{
+		k8sClient:     client,
+		podLister:     newTestPodLister(t, pod),
+		sandboxStore:  store,
+		ctldClient:    NewCtldClientWithHTTPClient(ctld.Client()),
+		pauseEnqueuer: &recordingPauseEnqueuer{},
+		config:        SandboxServiceConfig{CtldEnabled: true, CtldPort: ctldPort},
+		clock:         systemTime{},
+		logger:        zap.NewNop(),
+	}
+
+	require.NoError(t, svc.RecoverTerminatedSandboxRuntime(context.Background(), pod))
+	err := svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-1")
+
+	require.Error(t, err)
+	assert.Equal(t, SandboxStatusRunning, store.records["sandbox-1"].Status)
+	require.NotNil(t, activeLifecycleTxnForTest(store, "sandbox-1"))
+	for _, action := range client.Actions() {
+		assert.False(t, action.GetVerb() == "delete" && action.GetResource().Resource == "pods")
+	}
+}
+
+func TestCompleteCrashRecoveryFallsBackToLastCommittedHeadWhenSnapshotWasRemoved(t *testing.T) {
+	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(ctldapi.PrepareRootFSSnapshotResponse{Error: "container snapshot not found"})
+	}))
+	defer ctld.Close()
+	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
+
+	pod := crashRecoveryTestPod(corev1.PodFailed, 137, "OOMKilled")
+	pod.Status.ContainerStatuses = nil
+	pod.Status.HostIP = ctldURL.Hostname()
+	store := crashRecoveryTestStore(pod)
+	store.rootFSStates = map[string]*SandboxRootFSState{
+		"sandbox-1": {
+			SandboxID:         "sandbox-1",
+			TeamID:            "team-1",
+			LayerID:           "previous-head",
+			RuntimeGeneration: 2,
+		},
+	}
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	deleted := false
+	client.PrependReactor("delete", "pods", func(ktesting.Action) (bool, runtime.Object, error) {
+		deleted = true
+		return true, nil, nil
+	})
+	svc := &SandboxService{
+		k8sClient:     client,
+		podLister:     newTestPodLister(t, pod),
+		sandboxStore:  store,
+		ctldClient:    NewCtldClientWithHTTPClient(ctld.Client()),
+		pauseEnqueuer: &recordingPauseEnqueuer{},
+		config:        SandboxServiceConfig{CtldEnabled: true, CtldPort: ctldPort},
+		clock:         systemTime{},
+		logger:        zap.NewNop(),
+	}
+
+	require.NoError(t, svc.RecoverTerminatedSandboxRuntime(context.Background(), pod))
+	require.NoError(t, svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"))
+
+	assert.True(t, deleted)
+	assert.Equal(t, SandboxStatusPaused, store.records["sandbox-1"].Status)
+	assert.Equal(t, "previous-head", store.rootFSStates["sandbox-1"].LayerID)
+	assert.Nil(t, activeLifecycleTxnForTest(store, "sandbox-1"))
+}
+
+func TestCrashRecoveryCommitDoesNotResurrectDeletedSandbox(t *testing.T) {
+	pod := crashRecoveryTestPod(corev1.PodFailed, 137, "OOMKilled")
+	store := crashRecoveryTestStore(pod)
+	svc := &SandboxService{
+		sandboxStore:  store,
+		pauseEnqueuer: &recordingPauseEnqueuer{},
+		clock:         systemTime{},
+		logger:        zap.NewNop(),
+	}
+	require.NoError(t, svc.RecoverTerminatedSandboxRuntime(context.Background(), pod))
+	txn := activeLifecycleTxnForTest(store, "sandbox-1")
+	require.NotNil(t, txn)
+	require.NoError(t, store.MarkSandboxDeleted(context.Background(), "sandbox-1", time.Now().UTC()))
+
+	committed, err := svc.commitPausingRuntimePaused(context.Background(), "sandbox-1", txn, 3, &SandboxRootFSState{
+		SandboxID: "sandbox-1",
+		TeamID:    "team-1",
+		LayerID:   "uncommitted-crash-head",
+	})
+
+	require.NoError(t, err)
+	assert.False(t, committed)
+	assert.Equal(t, SandboxStatusDeleted, store.records["sandbox-1"].Status)
+	assert.Nil(t, store.rootFSStates["sandbox-1"])
+}
+
+func TestCompleteCrashRecoveryAbortsWhenRuntimeDeletionAlreadyStarted(t *testing.T) {
+	pod := crashRecoveryTestPod(corev1.PodFailed, 2, "Error")
+	store := crashRecoveryTestStore(pod)
+	svc := &SandboxService{
+		sandboxStore:  store,
+		pauseEnqueuer: &recordingPauseEnqueuer{},
+		clock:         systemTime{},
+		logger:        zap.NewNop(),
+	}
+	require.NoError(t, svc.RecoverTerminatedSandboxRuntime(context.Background(), pod))
+
+	deleting := pod.DeepCopy()
+	now := metav1.Now()
+	deleting.DeletionTimestamp = &now
+	client := fake.NewSimpleClientset(deleting.DeepCopy())
+	svc.k8sClient = client
+	svc.podLister = newTestPodLister(t, deleting)
+
+	require.NoError(t, svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"))
+
+	assert.Nil(t, activeLifecycleTxnForTest(store, "sandbox-1"))
+	assert.Equal(t, SandboxStatusRunning, store.records["sandbox-1"].Status)
+	for _, action := range client.Actions() {
+		assert.False(t, action.GetVerb() == "delete" && action.GetResource().Resource == "pods")
+	}
+}
+
+func TestCrashRecoveryControllerRecoversTerminalPodOnce(t *testing.T) {
+	pod := crashRecoveryTestPod(corev1.PodSucceeded, 0, "Completed")
+	recoverer := &recordingCrashRecoverer{}
+	controller := NewSandboxCrashRecoveryController(nil, newTestPodLister(t, pod), recoverer, zap.NewNop())
+
+	handler := controller.ResourceEventHandler()
+	handler.AddFunc(pod)
+	handler.UpdateFunc(pod.DeepCopy(), pod.DeepCopy())
+	require.True(t, controller.processNextWorkItem(context.Background()))
+
+	require.Len(t, recoverer.pods, 1)
+	assert.Equal(t, pod.Name, recoverer.pods[0].Name)
+}
+
+func TestCrashRecoveryControllerIgnoresStalePodUID(t *testing.T) {
+	pod := crashRecoveryTestPod(corev1.PodFailed, 2, "Error")
+	recoverer := &recordingCrashRecoverer{}
+	controller := NewSandboxCrashRecoveryController(nil, newTestPodLister(t, pod), recoverer, zap.NewNop())
+	controller.queue.Add(sandboxCrashRecoveryItem{
+		Namespace: pod.Namespace,
+		PodName:   pod.Name,
+		PodUID:    "old-pod-uid",
+	})
+
+	require.True(t, controller.processNextWorkItem(context.Background()))
+
+	assert.Empty(t, recoverer.pods)
+}
+
+func TestCrashRecoveryControllerRecoversTerminalPodWithoutContainerStatus(t *testing.T) {
+	pod := crashRecoveryTestPod(corev1.PodFailed, 137, "OOMKilled")
+	pod.Status.ContainerStatuses = nil
+	recoverer := &recordingCrashRecoverer{}
+	controller := NewSandboxCrashRecoveryController(nil, newTestPodLister(t, pod), recoverer, zap.NewNop())
+
+	controller.ResourceEventHandler().AddFunc(pod)
+	require.True(t, controller.processNextWorkItem(context.Background()))
+
+	require.Len(t, recoverer.pods, 1)
+	assert.Equal(t, pod.Name, recoverer.pods[0].Name)
+}
+
+func TestCrashRecoveryControllerRetriesRecovererFailure(t *testing.T) {
+	pod := crashRecoveryTestPod(corev1.PodFailed, 2, "Error")
+	recoverer := &recordingCrashRecoverer{err: errors.New("checkpoint unavailable")}
+	controller := NewSandboxCrashRecoveryController(nil, newTestPodLister(t, pod), recoverer, zap.NewNop())
+	controller.queue.Add(sandboxCrashRecoveryItem{
+		Namespace: pod.Namespace,
+		PodName:   pod.Name,
+		PodUID:    string(pod.UID),
+	})
+
+	require.True(t, controller.processNextWorkItem(context.Background()))
+
+	assert.Equal(t, 1, controller.queue.NumRequeues(sandboxCrashRecoveryItem{
+		Namespace: pod.Namespace,
+		PodName:   pod.Name,
+		PodUID:    string(pod.UID),
+	}))
+}
+
+func TestSandboxPauseControllerFindsCrashRecoveryAfterManagerRestart(t *testing.T) {
+	pod := crashRecoveryTestPod(corev1.PodFailed, 137, "OOMKilled")
+	store := crashRecoveryTestStore(pod)
+	store.lifecycleTxns = map[string]*SandboxLifecycleTxn{
+		"crash-pause": {
+			ID:        "crash-pause",
+			SandboxID: "sandbox-1",
+			Kind:      SandboxLifecycleKindPause,
+			Phase:     SandboxLifecyclePhasePublishing,
+			Source:    SandboxLifecycleSourceCrash,
+		},
+	}
+	controller := NewSandboxPauseController(&SandboxService{sandboxStore: store}, zap.NewNop())
+	t.Cleanup(controller.queue.ShutDown)
+
+	controller.enqueuePausingSandboxes(context.Background())
+
+	require.Equal(t, 1, controller.queue.Len())
+	sandboxID, shutdown := controller.queue.Get()
+	require.False(t, shutdown)
+	controller.queue.Done(sandboxID)
+	controller.queue.Forget(sandboxID)
+	assert.Equal(t, "sandbox-1", sandboxID)
+}
+
+func crashRecoveryTestPod(phase corev1.PodPhase, exitCode int32, reason string) *corev1.Pod {
+	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
+	pod.UID = types.UID("crashed-pod-uid")
+	pod.Status.Phase = phase
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name:        "procd",
+		ContainerID: "containerd://terminated-container",
+		State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+			ExitCode:  exitCode,
+			Reason:    reason,
+			StartedAt: metav1.NewTime(time.Date(2026, time.July, 28, 1, 0, 0, 0, time.UTC)),
+			FinishedAt: metav1.NewTime(
+				time.Date(2026, time.July, 28, 1, 1, 0, 0, time.UTC),
+			),
+		}},
+	}}
+	return pod
+}
+
+func crashRecoveryTestStore(pod *corev1.Pod) *memorySandboxStore {
+	return &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-1": {
+			ID:                  "sandbox-1",
+			TeamID:              "team-1",
+			UserID:              "user-1",
+			Status:              SandboxStatusRunning,
+			CurrentPodNamespace: pod.Namespace,
+			CurrentPodName:      pod.Name,
+			RuntimeGeneration:   runtimeGenerationFromPod(pod),
+		},
+	}}
+}
+
+func crashRecoveryPrepareResponse() ctldapi.PrepareRootFSSnapshotResponse {
+	return ctldapi.PrepareRootFSSnapshotResponse{
+		Handle: "crash-handle",
+		Info: ctldapi.RootFSInfo{
+			Runtime:         "runc",
+			RuntimeHandler:  "io.containerd.runc.v2",
+			Snapshotter:     "overlayfs",
+			BaseImageDigest: "sha256:base",
+		},
+		Descriptor: ctldapi.RootFSDiffDescriptor{
+			MediaType: "application/vnd.oci.image.layer.v1.tar",
+			Digest:    "sha256:recovered",
+			Size:      42,
+		},
+	}
+}
+
+func crashRecoveryPublishResponse() ctldapi.PublishRootFSSnapshotResponse {
+	prepared := crashRecoveryPrepareResponse()
+	prepared.Descriptor.ObjectKey = "sandbox-rootfs/team-1/sandbox-1/3/sha256/recovered.tar"
+	return ctldapi.PublishRootFSSnapshotResponse{
+		Published:  true,
+		Info:       prepared.Info,
+		Descriptor: prepared.Descriptor,
+	}
+}
+
+func activeLifecycleTxnForTest(store *memorySandboxStore, sandboxID string) *SandboxLifecycleTxn {
+	txn, _ := store.GetActiveLifecycleTxn(context.Background(), sandboxID)
+	return txn
+}
+
+type recordingCrashRecoverer struct {
+	mu   sync.Mutex
+	pods []*corev1.Pod
+	err  error
+}
+
+func (r *recordingCrashRecoverer) RecoverTerminatedSandboxRuntime(_ context.Context, pod *corev1.Pod) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pods = append(r.pods, pod.DeepCopy())
+	return r.err
+}

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -321,6 +321,12 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 	if record == nil {
 		return nil
 	}
+	crashRecovery := txn.Source == SandboxLifecycleSourceCrash
+	abortOnError := func(completionErr error) {
+		if !crashRecovery && completionErr != nil {
+			_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, completionErr.Error())
+		}
+	}
 	if canceled, err := s.abortPauseIfCancelRequested(ctx, sandboxID, txn.ID); err != nil || canceled {
 		return err
 	}
@@ -328,7 +334,14 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 	pod, err := s.getSandboxPod(ctx, sandboxID)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return s.commitPausingRuntimePaused(ctx, sandboxID, txn, record.RuntimeGeneration, nil)
+			if crashRecovery && s.logger != nil {
+				s.logger.Error("Terminated runtime disappeared before rootfs recovery",
+					zap.String("sandboxID", sandboxID),
+					zap.Int64("runtimeGeneration", txn.FromGeneration),
+				)
+			}
+			_, commitErr := s.commitPausingRuntimePaused(ctx, sandboxID, txn, record.RuntimeGeneration, nil)
+			return commitErr
 		}
 		return fmt.Errorf("get pod: %w", err)
 	}
@@ -342,7 +355,17 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 	if txn.FromPodNamespace != "" && pod.Namespace != txn.FromPodNamespace {
 		return k8serrors.NewConflict(schema.GroupResource{Resource: "pod"}, pod.Name, fmt.Errorf("pause transaction points at runtime namespace %s", txn.FromPodNamespace))
 	}
-	if !s.config.CtldEnabled || s.ctldClient == nil {
+	if crashRecovery && pod.DeletionTimestamp != nil {
+		_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, "runtime deletion requested during crash recovery")
+		return nil
+	}
+	if crashRecovery {
+		_, terminated := terminatedProcdContainer(pod)
+		if terminated == nil && !sandboxRuntimePodTerminal(pod) {
+			return fmt.Errorf("crash recovery expected terminated procd container in pod %s/%s", pod.Namespace, pod.Name)
+		}
+	}
+	if !crashRecovery && (!s.config.CtldEnabled || s.ctldClient == nil) {
 		return ErrSandboxCheckpointRequiresCtld
 	}
 	if canceled, err := s.abortPauseIfCancelRequested(ctx, sandboxID, txn.ID); err != nil || canceled {
@@ -354,12 +377,17 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 		}
 		return err
 	}
-	procdAddress, internalToken, err := s.activatePauseRuntimeBarrier(ctx, pod, record, txn)
-	if err != nil {
-		_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, err.Error())
-		return err
+	procdAddress := ""
+	internalToken := ""
+	barrierActive := false
+	if !crashRecovery {
+		procdAddress, internalToken, err = s.activatePauseRuntimeBarrier(ctx, pod, record, txn)
+		if err != nil {
+			abortOnError(err)
+			return err
+		}
+		barrierActive = true
 	}
-	barrierActive := true
 	defer func() {
 		if barrierActive {
 			s.releasePauseRuntimeBarrier(context.Background(), procdAddress, internalToken)
@@ -372,26 +400,46 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 		if errors.Is(err, errSandboxLifecycleCanceled) {
 			return nil
 		}
-		_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, err.Error())
+		abortOnError(err)
 		return err
 	}
-	rootFSState, err := s.prepareSandboxRootFSCheckpoint(ctx, pod, record)
-	if err != nil {
-		_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, err.Error())
-		return err
+	var rootFSState *SandboxRootFSState
+	rootFSSnapshotMissing := false
+	if !s.config.CtldEnabled || s.ctldClient == nil {
+		rootFSSnapshotMissing = true
+	} else {
+		rootFSState, err = s.prepareSandboxRootFSCheckpoint(ctx, pod, record)
+		if err != nil {
+			if crashRecovery && rootFSTerminatedSnapshotMissing(err) {
+				rootFSSnapshotMissing = true
+			} else {
+				abortOnError(err)
+				return err
+			}
+		}
+	}
+	if rootFSSnapshotMissing && crashRecovery && s.logger != nil {
+		s.logger.Error("Terminated runtime snapshot is unavailable; preserving the last committed rootfs head",
+			zap.String("sandboxID", sandboxID),
+			zap.String("namespace", pod.Namespace),
+			zap.String("pod", pod.Name),
+			zap.Int64("runtimeGeneration", generation),
+		)
 	}
 	rootFSCommitted := false
 	defer func() {
-		if !rootFSCommitted {
+		if rootFSState != nil && !rootFSCommitted {
 			s.deleteUncommittedRootFSObject(rootFSState, "pause transaction did not commit")
 		}
 	}()
-	if err := s.markLifecycleTxnPreparedHead(ctx, sandboxID, txn.ID, rootFSState.LayerID); err != nil {
-		if errors.Is(err, errSandboxLifecycleCanceled) {
-			return nil
+	if rootFSState != nil {
+		if err := s.markLifecycleTxnPreparedHead(ctx, sandboxID, txn.ID, rootFSState.LayerID); err != nil {
+			if errors.Is(err, errSandboxLifecycleCanceled) {
+				return nil
+			}
+			abortOnError(err)
+			return err
 		}
-		_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, err.Error())
-		return err
 	}
 	stillPausing, err := s.sandboxStillPausing(ctx, sandboxID, txn.ID)
 	if err != nil || !stillPausing {
@@ -402,21 +450,25 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 	}
 	pod, err = s.ensureSandboxDeletionFinalizer(ctx, pod)
 	if err != nil {
-		_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, err.Error())
+		abortOnError(err)
 		return fmt.Errorf("ensure sandbox cleanup finalizer: %w", err)
 	}
 	if err := s.markLifecycleTxnPhase(ctx, sandboxID, txn.ID, SandboxLifecyclePhaseCommitting); err != nil {
 		if errors.Is(err, errSandboxLifecycleCanceled) {
 			return nil
 		}
-		_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, err.Error())
+		abortOnError(err)
 		return err
 	}
-	if err := s.commitPausingRuntimePaused(ctx, sandboxID, txn, generation, rootFSState); err != nil {
-		_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, err.Error())
+	committed, err := s.commitPausingRuntimePaused(ctx, sandboxID, txn, generation, rootFSState)
+	if err != nil {
+		abortOnError(err)
 		return err
 	}
-	rootFSCommitted = true
+	if !committed {
+		return nil
+	}
+	rootFSCommitted = rootFSState != nil
 	barrierActive = false
 	if err := s.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
 		if s.logger != nil {
@@ -426,6 +478,15 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 				zap.Error(err),
 			)
 		}
+	}
+	if crashRecovery && s.logger != nil {
+		s.logger.Info("Recovered terminated sandbox runtime rootfs",
+			zap.String("sandboxID", sandboxID),
+			zap.String("namespace", pod.Namespace),
+			zap.String("pod", pod.Name),
+			zap.Int64("runtimeGeneration", generation),
+			zap.Bool("snapshotRecovered", rootFSState != nil),
+		)
 	}
 	return nil
 }
@@ -466,11 +527,12 @@ func (s *SandboxService) markLifecycleTxnPreparedHead(ctx context.Context, sandb
 	return err
 }
 
-func (s *SandboxService) commitPausingRuntimePaused(ctx context.Context, sandboxID string, txn *SandboxLifecycleTxn, generation int64, rootFSState *SandboxRootFSState) error {
+func (s *SandboxService) commitPausingRuntimePaused(ctx context.Context, sandboxID string, txn *SandboxLifecycleTxn, generation int64, rootFSState *SandboxRootFSState) (bool, error) {
 	if s == nil || s.sandboxStore == nil {
-		return nil
+		return false, nil
 	}
-	return s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
+	committed := false
+	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
 		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sandboxID)
 		if err != nil {
 			return err
@@ -490,8 +552,13 @@ func (s *SandboxService) commitPausingRuntimePaused(ctx context.Context, sandbox
 		if rootFSState != nil {
 			preparedHead = rootFSState.LayerID
 		}
-		return tx.CommitLifecycleTxn(lockCtx, txn.ID, preparedHead)
+		if err := tx.CommitLifecycleTxn(lockCtx, txn.ID, preparedHead); err != nil {
+			return err
+		}
+		committed = true
+		return nil
 	})
+	return committed, err
 }
 
 func (s *SandboxService) markLifecycleTxnPhase(ctx context.Context, sandboxID, txnID, phase string) error {

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -20,8 +20,8 @@ import (
 const sandboxLifecycleWaitInterval = 100 * time.Millisecond
 
 // ResumePausedSandboxRuntime creates a new runtime for a paused durable sandbox
-// and restores the latest writable rootfs checkpoint. A failed runtime is first
-// committed as paused and then replaced through the same generation transition.
+// and restores the latest writable rootfs checkpoint. A terminal runtime first
+// completes crash recovery through the durable pause transaction.
 func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandboxID string) (*Sandbox, error) {
 	if s == nil || s.sandboxStore == nil {
 		return nil, k8serrors.NewNotFound(corev1.Resource("pod"), sandboxID)
@@ -33,7 +33,7 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 	var txn *SandboxLifecycleTxn
 	var req *ClaimRequest
 	var deletingPodRef *sandboxRuntimePodRef
-	var failedPodRef *sandboxRuntimePodRef
+	crashRecoveryRequested := false
 	claimType := "hot"
 	restoreNeeded := false
 	for {
@@ -43,7 +43,7 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 		txn = nil
 		req = nil
 		deletingPodRef = nil
-		failedPodRef = nil
+		crashRecoveryRequested = false
 		restoreNeeded = false
 		var waitErr error
 		err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, locked *SandboxRecord) error {
@@ -88,11 +88,12 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 					return errSandboxRuntimeDeleting
 				}
 				if sandboxRuntimePodNeedsReplacement(existing) {
-					failedPodRef = &sandboxRuntimePodRef{
-						namespace: existing.Namespace,
-						name:      existing.Name,
+					if err := beginCrashRecoveryTxn(lockCtx, tx, locked, existing); err != nil {
+						return err
 					}
-					return tx.MarkRuntimePaused(lockCtx, sandboxID, runtimeGenerationFromPod(existing), s.now())
+					crashRecoveryRequested = true
+					waitErr = errSandboxLifecyclePausing
+					return nil
 				}
 				if locked.Status == SandboxStatusPaused {
 					deletingPodRef = &sandboxRuntimePodRef{
@@ -148,25 +149,9 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 			}
 			return tx.BeginLifecycleTxn(lockCtx, txn)
 		})
-		if err == nil && failedPodRef != nil {
-			if s.logger != nil {
-				s.logger.Warn("Replacing failed sandbox runtime",
-					zap.String("sandboxID", sandboxID),
-					zap.String("namespace", failedPodRef.namespace),
-					zap.String("pod", failedPodRef.name),
-				)
-			}
-			if s.k8sClient == nil {
-				return nil, fmt.Errorf("delete failed runtime pod: kubernetes client is not configured")
-			}
-			deleteErr := s.k8sClient.CoreV1().Pods(failedPodRef.namespace).Delete(ctx, failedPodRef.name, metav1.DeleteOptions{})
-			if deleteErr != nil && !k8serrors.IsNotFound(deleteErr) {
-				return nil, fmt.Errorf("delete failed runtime pod: %w", deleteErr)
-			}
-			if err := s.waitForSandboxRuntimePodDeletion(ctx, failedPodRef.namespace, failedPodRef.name); err != nil {
-				return nil, err
-			}
-			continue
+		if err == nil && crashRecoveryRequested {
+			s.enqueueSandboxPause(sandboxID)
+			err = waitErr
 		}
 		if err == nil && waitErr != nil {
 			err = waitErr
@@ -314,7 +299,11 @@ type sandboxRuntimePodRef struct {
 }
 
 func sandboxRuntimePodNeedsReplacement(pod *corev1.Pod) bool {
-	return pod != nil && pod.Status.Phase == corev1.PodFailed
+	if pod == nil {
+		return false
+	}
+	_, terminated := terminatedProcdContainer(pod)
+	return terminated != nil || sandboxRuntimePodTerminal(pod)
 }
 
 func (s *SandboxService) waitForSandboxLifecycleTxnExit(ctx context.Context, sandboxID string) error {

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -484,11 +484,16 @@ func rootFSTargetForPod(pod *corev1.Pod) ctldapi.RootFSContainerRef {
 	if pod == nil {
 		return ctldapi.RootFSContainerRef{ContainerName: sandboxRootFSContainerName}
 	}
+	containerID := ""
+	if status := procdContainerStatus(pod); status != nil {
+		containerID = status.ContainerID
+	}
 	return ctldapi.RootFSContainerRef{
 		Namespace:     pod.Namespace,
 		PodName:       pod.Name,
 		PodUID:        string(pod.UID),
 		ContainerName: sandboxRootFSContainerName,
+		ContainerID:   containerID,
 	}
 }
 
@@ -647,6 +652,11 @@ func rootFSBaselineMissing(err error, resp *ctldapi.SaveRootFSResponse) bool {
 	}
 	message := strings.ToLower(saveRootFSError(resp))
 	return strings.Contains(message, "baseline") && strings.Contains(message, "not captured")
+}
+
+func rootFSTerminatedSnapshotMissing(err error) bool {
+	var reqErr *ctldapi.RequestError
+	return errors.As(err, &reqErr) && reqErr != nil && reqErr.StatusCode == http.StatusNotFound
 }
 
 func rootFSResponseError(err error, message string) error {

--- a/manager/pkg/service/sandbox_store.go
+++ b/manager/pkg/service/sandbox_store.go
@@ -114,6 +114,7 @@ const (
 
 	SandboxLifecycleSourceManual = "manual"
 	SandboxLifecycleSourceAuto   = "auto"
+	SandboxLifecycleSourceCrash  = "crash"
 
 	SandboxLifecyclePhasePreparing  = "preparing"
 	SandboxLifecyclePhaseBarriered  = "barriered"

--- a/pkg/ctldapi/types.go
+++ b/pkg/ctldapi/types.go
@@ -40,6 +40,7 @@ type RootFSContainerRef struct {
 	PodName       string `json:"pod_name"`
 	PodUID        string `json:"pod_uid,omitempty"`
 	ContainerName string `json:"container_name"`
+	ContainerID   string `json:"container_id,omitempty"`
 }
 
 // RootFSInfo is the containerd metadata needed to validate and restore a

--- a/pkg/observability/metrics/manager.go
+++ b/pkg/observability/metrics/manager.go
@@ -99,11 +99,11 @@ func NewManager(registry prometheus.Registerer) *ManagerMetrics {
 		}, []string{"template", "result"}),
 		ProcdCrashLogCapturesTotal: factory.NewCounterVec(prometheus.CounterOpts{
 			Name: "manager_sandbox_procd_crash_log_captures_total",
-			Help: "Total number of previous procd crash log capture outcomes by result",
+			Help: "Total number of terminated procd crash log capture outcomes by result",
 		}, []string{"result"}),
 		ProcdCrashLogBytes: factory.NewHistogram(prometheus.HistogramOpts{
 			Name:    "manager_sandbox_procd_crash_log_bytes",
-			Help:    "Number of retained bytes emitted for a captured previous procd crash log",
+			Help:    "Number of retained bytes emitted for a captured terminated procd crash log",
 			Buckets: []float64{1024, 4096, 16384, 65536, 262144, 524288},
 		}),
 		PodNetworkIdentityChecksTotal: factory.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
## Summary

- keep ReplicaSet-compatible Pod `restartPolicy: Always`, but set the `procd` container restart policy to `Never`
- detect a terminated claimed runtime even when the Pod phase remains `Running`
- recover the exact exited containerd snapshot through `ctld` using the Pod UID and ContainerID
- reuse the durable pause transaction so rootfs and paused state commit before the old Pod is deleted
- retain the old Pod and transaction across transient `ctld`, Kubernetes, object-store, and manager failures
- let explicit delete and `hard_ttl` win; if the terminated snapshot is already gone, preserve the last committed rootfs head and record a degraded recovery
- capture logs from the current terminated container while retaining compatibility with previous-attempt crash logs
- document the recovery contract and Kubernetes `ContainerRestartRules` requirement

## Why

With only Pod-level `restartPolicy: Always`, a normal `procd` crash or OOM can leave the Pod in `Running`/`CrashLoopBackOff` and let kubelet start a clean container rootfs. That bypasses recovery paths that only look for `PodFailed` and loses writes made since the last checkpoint.

The container-level `Never` policy preserves the exited attempt long enough for `manager` and `ctld` to checkpoint it, without violating the ReplicaSet requirement that the Pod policy remain `Always`.

## Recovery invariants

1. A crash creates a non-cancelable durable pause transaction tied to the runtime namespace, Pod name, and generation.
2. The snapshot request carries the live Pod UID and exact ContainerID; `ctld` validates both against the container's Kubernetes identity before reading the exited snapshot.
3. The new rootfs head and paused state commit atomically before Pod deletion.
4. Transient failures keep the exited attempt and transaction for retry, including after a manager restart.
5. Explicit sandbox deletion and hard TTL take precedence and cannot be undone by a late recovery commit.
6. A missing/GC'd snapshot degrades to the previous committed head; uncheckpointed writes are explicitly not claimed as recovered.

## Validation

Local:

- `GOTOOLCHAIN=go1.25.0+auto go test -race -count=1 ./manager/... ./ctld/... ./pkg/...`
- `make manifests apispec`
- `GOTOOLCHAIN=go1.25.0+auto go mod tidy`
- `GOFLAGS=-buildvcs=false /root/go/bin/golangci-lint run ./manager/... ./ctld/... ./pkg/...`
- `git diff --check`

Remote persistent kind environment, Kubernetes v1.35:

- verified Pod policy `Always`, `procd` policy `Never`
- exit 137: observed `Pod=Running`, current container `Terminated`, `restartCount=0`; recovered the pre-crash marker into generation 2
- real cgroup OOM at a 128Mi limit: observed `reason=OOMKilled`, `restartCount=0`; recovered the marker into generation 2
- blocked node-local `ctld`: transaction remained `publishing`, while the old Pod and exited CRI container were retained; unblocking completed recovery
- deleted during an active crash transaction: sandbox became deleted, the crash transaction became `aborted`, no recovery commit occurred, and no paused sandbox was resurrected
- removed the exited CRI container before retry: recovery committed the previous durable head; the previously committed marker remained and the post-checkpoint marker correctly returned 404
- restarted manager while the transaction was `publishing`: the replacement manager found the durable transaction and completed it after `ctld` recovered
- final exact-image smoke used `sandbox0ai/infra:latest` image ID `sha256:643cab68a71c2e7a50d8f8e8c14202ad252892af2a6dad7177208464227ecb53`

The remote ECS instance was returned to `Stopped` / `StopCharging` after cleanup.
