### PR TITLE
Batch metering projections and guard ClickHouse OSS cleanup

### DIFF
--- a/internal/clickhouseobjectgc/reconciler.go
+++ b/internal/clickhouseobjectgc/reconciler.go
@@ -1,0 +1,288 @@
+package clickhouseobjectgc
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+const (
+	ManifestVersion    = 1
+	maxDeleteBatchSize = 1000
+)
+
+type objectClient interface {
+	ListObjectsV2(context.Context, *s3.ListObjectsV2Input, ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+	DeleteObjects(context.Context, *s3.DeleteObjectsInput, ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error)
+}
+
+type Candidate struct {
+	Key          string    `json:"key"`
+	Size         int64     `json:"size"`
+	LastModified time.Time `json:"last_modified"`
+	ETag         string    `json:"etag,omitempty"`
+}
+
+type Manifest struct {
+	Version           int         `json:"version"`
+	Bucket            string      `json:"bucket"`
+	Prefix            string      `json:"prefix"`
+	GeneratedAt       time.Time   `json:"generated_at"`
+	Cutoff            time.Time   `json:"cutoff"`
+	LivePathCount     int         `json:"live_path_count"`
+	ListedObjectCount int         `json:"listed_object_count"`
+	ListedBytes       int64       `json:"listed_bytes"`
+	CandidateBytes    int64       `json:"candidate_bytes"`
+	Candidates        []Candidate `json:"candidates"`
+}
+
+type DeleteOptions struct {
+	Now               time.Time
+	MinObjectAge      time.Duration
+	MinManifestAge    time.Duration
+	MaxDeleteFraction float64
+	MinLivePaths      int
+}
+
+type DeleteResult struct {
+	ManifestCandidates int   `json:"manifest_candidates"`
+	SkippedLive        int   `json:"skipped_live"`
+	DeletedObjects     int   `json:"deleted_objects"`
+	DeletedBytes       int64 `json:"deleted_bytes"`
+}
+
+type Reconciler struct {
+	client objectClient
+	bucket string
+	prefix string
+	now    func() time.Time
+}
+
+func New(client objectClient, bucket, prefix string) (*Reconciler, error) {
+	if client == nil {
+		return nil, fmt.Errorf("object client is required")
+	}
+	bucket = strings.TrimSpace(bucket)
+	if bucket == "" {
+		return nil, fmt.Errorf("bucket is required")
+	}
+	normalizedPrefix, err := normalizePrefix(prefix)
+	if err != nil {
+		return nil, err
+	}
+	return &Reconciler{
+		client: client,
+		bucket: bucket,
+		prefix: normalizedPrefix,
+		now: func() time.Time {
+			return time.Now().UTC()
+		},
+	}, nil
+}
+
+// Scan lists the exact ClickHouse prefix and records only objects that are
+// older than minAge and absent from the union of live remote-path snapshots.
+func (r *Reconciler) Scan(ctx context.Context, livePaths map[string]struct{}, minAge time.Duration) (*Manifest, error) {
+	if minAge <= 0 {
+		return nil, fmt.Errorf("minimum object age must be positive")
+	}
+	if len(livePaths) == 0 {
+		return nil, fmt.Errorf("at least one live ClickHouse remote path is required")
+	}
+	now := r.timestamp()
+	manifest := &Manifest{
+		Version:       ManifestVersion,
+		Bucket:        r.bucket,
+		Prefix:        r.prefix,
+		GeneratedAt:   now,
+		Cutoff:        now.Add(-minAge),
+		LivePathCount: len(livePaths),
+		Candidates:    make([]Candidate, 0),
+	}
+
+	var continuationToken *string
+	for {
+		output, err := r.client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+			Bucket:            aws.String(r.bucket),
+			Prefix:            aws.String(r.prefix),
+			ContinuationToken: continuationToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list ClickHouse objects: %w", err)
+		}
+		for _, object := range output.Contents {
+			key := aws.ToString(object.Key)
+			if !strings.HasPrefix(key, r.prefix) {
+				return nil, fmt.Errorf("object %q is outside prefix %q", key, r.prefix)
+			}
+			size := aws.ToInt64(object.Size)
+			modified := aws.ToTime(object.LastModified).UTC()
+			manifest.ListedObjectCount++
+			manifest.ListedBytes += size
+			if _, live := livePaths[key]; live || !modified.Before(manifest.Cutoff) {
+				continue
+			}
+			manifest.Candidates = append(manifest.Candidates, Candidate{
+				Key:          key,
+				Size:         size,
+				LastModified: modified,
+				ETag:         strings.Trim(aws.ToString(object.ETag), `"`),
+			})
+			manifest.CandidateBytes += size
+		}
+		if !aws.ToBool(output.IsTruncated) {
+			break
+		}
+		if output.NextContinuationToken == nil || aws.ToString(output.NextContinuationToken) == "" {
+			return nil, fmt.Errorf("truncated object listing has no continuation token")
+		}
+		continuationToken = output.NextContinuationToken
+	}
+	sort.Slice(manifest.Candidates, func(i, j int) bool {
+		return manifest.Candidates[i].Key < manifest.Candidates[j].Key
+	})
+	return manifest, nil
+}
+
+// Delete removes candidates from an earlier manifest after rechecking the
+// current live set and every destructive guardrail.
+func (r *Reconciler) Delete(
+	ctx context.Context,
+	manifest *Manifest,
+	livePaths map[string]struct{},
+	options DeleteOptions,
+) (*DeleteResult, error) {
+	if options.Now.IsZero() {
+		options.Now = r.timestamp()
+	}
+	if options.MinLivePaths <= 0 {
+		options.MinLivePaths = 1
+	}
+	if err := r.validateDelete(manifest, livePaths, options); err != nil {
+		return nil, err
+	}
+	cutoff := options.Now.UTC().Add(-options.MinObjectAge)
+	eligible := make([]Candidate, 0, len(manifest.Candidates))
+	result := &DeleteResult{ManifestCandidates: len(manifest.Candidates)}
+	for _, candidate := range manifest.Candidates {
+		if !strings.HasPrefix(candidate.Key, r.prefix) {
+			return nil, fmt.Errorf("candidate %q is outside prefix %q", candidate.Key, r.prefix)
+		}
+		if _, live := livePaths[candidate.Key]; live {
+			result.SkippedLive++
+			continue
+		}
+		if !candidate.LastModified.Before(cutoff) {
+			return nil, fmt.Errorf("candidate %q is newer than the object-age cutoff", candidate.Key)
+		}
+		eligible = append(eligible, candidate)
+	}
+
+	for len(eligible) > 0 {
+		chunkSize := min(len(eligible), maxDeleteBatchSize)
+		chunk := eligible[:chunkSize]
+		objects := make([]types.ObjectIdentifier, 0, len(chunk))
+		for _, candidate := range chunk {
+			objects = append(objects, types.ObjectIdentifier{Key: aws.String(candidate.Key)})
+		}
+		quiet := true
+		output, err := r.client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+			Bucket: aws.String(r.bucket),
+			Delete: &types.Delete{
+				Objects: objects,
+				Quiet:   &quiet,
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("delete ClickHouse orphan batch: %w", err)
+		}
+		if len(output.Errors) > 0 {
+			first := output.Errors[0]
+			return nil, fmt.Errorf(
+				"delete ClickHouse orphan %q: %s: %s",
+				aws.ToString(first.Key),
+				aws.ToString(first.Code),
+				aws.ToString(first.Message),
+			)
+		}
+		for _, candidate := range chunk {
+			result.DeletedObjects++
+			result.DeletedBytes += candidate.Size
+		}
+		eligible = eligible[chunkSize:]
+	}
+	return result, nil
+}
+
+func (r *Reconciler) validateDelete(
+	manifest *Manifest,
+	livePaths map[string]struct{},
+	options DeleteOptions,
+) error {
+	if manifest == nil {
+		return fmt.Errorf("manifest is required")
+	}
+	if manifest.Version != ManifestVersion {
+		return fmt.Errorf("unsupported manifest version %d", manifest.Version)
+	}
+	if manifest.Bucket != r.bucket || manifest.Prefix != r.prefix {
+		return fmt.Errorf(
+			"manifest target %s/%s does not match %s/%s",
+			manifest.Bucket,
+			manifest.Prefix,
+			r.bucket,
+			r.prefix,
+		)
+	}
+	if options.MinObjectAge <= 0 {
+		return fmt.Errorf("minimum object age must be positive")
+	}
+	if options.MinManifestAge < 0 {
+		return fmt.Errorf("minimum manifest age cannot be negative")
+	}
+	if manifest.GeneratedAt.After(options.Now.UTC().Add(-options.MinManifestAge)) {
+		return fmt.Errorf("manifest is younger than %s", options.MinManifestAge)
+	}
+	if len(livePaths) < options.MinLivePaths {
+		return fmt.Errorf("live path count %d is below required minimum %d", len(livePaths), options.MinLivePaths)
+	}
+	if options.MaxDeleteFraction <= 0 || options.MaxDeleteFraction > 1 {
+		return fmt.Errorf("maximum delete fraction must be in (0, 1]")
+	}
+	if manifest.ListedObjectCount <= 0 {
+		return fmt.Errorf("manifest has no listed objects")
+	}
+	fraction := float64(len(manifest.Candidates)) / float64(manifest.ListedObjectCount)
+	if fraction > options.MaxDeleteFraction {
+		return fmt.Errorf(
+			"candidate fraction %.4f exceeds maximum %.4f",
+			fraction,
+			options.MaxDeleteFraction,
+		)
+	}
+	return nil
+}
+
+func normalizePrefix(prefix string) (string, error) {
+	prefix = strings.Trim(strings.TrimSpace(prefix), "/")
+	if prefix == "" {
+		return "", fmt.Errorf("non-root prefix is required")
+	}
+	if strings.Contains(prefix, "..") {
+		return "", fmt.Errorf("prefix must not contain '..'")
+	}
+	return prefix + "/", nil
+}
+
+func (r *Reconciler) timestamp() time.Time {
+	if r == nil || r.now == nil {
+		return time.Now().UTC()
+	}
+	return r.now().UTC()
+}

--- a/internal/clickhouseobjectgc/reconciler_test.go
+++ b/internal/clickhouseobjectgc/reconciler_test.go
@@ -1,0 +1,180 @@
+package clickhouseobjectgc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+type fakeObjectClient struct {
+	listOutputs []*s3.ListObjectsV2Output
+	listIndex   int
+	deleteSizes []int
+}
+
+func (f *fakeObjectClient) ListObjectsV2(
+	context.Context,
+	*s3.ListObjectsV2Input,
+	...func(*s3.Options),
+) (*s3.ListObjectsV2Output, error) {
+	if f.listIndex >= len(f.listOutputs) {
+		return nil, fmt.Errorf("unexpected list call %d", f.listIndex)
+	}
+	output := f.listOutputs[f.listIndex]
+	f.listIndex++
+	return output, nil
+}
+
+func (f *fakeObjectClient) DeleteObjects(
+	_ context.Context,
+	input *s3.DeleteObjectsInput,
+	_ ...func(*s3.Options),
+) (*s3.DeleteObjectsOutput, error) {
+	f.deleteSizes = append(f.deleteSizes, len(input.Delete.Objects))
+	return &s3.DeleteObjectsOutput{}, nil
+}
+
+func TestScanRequiresAgeAndAbsenceFromLiveSet(t *testing.T) {
+	now := time.Date(2026, 7, 28, 10, 0, 0, 0, time.UTC)
+	old := now.Add(-96 * time.Hour)
+	recent := now.Add(-time.Hour)
+	truncated := true
+	client := &fakeObjectClient{listOutputs: []*s3.ListObjectsV2Output{
+		{
+			Contents: []types.Object{
+				testObject("clickhouse/region/live", 10, old),
+				testObject("clickhouse/region/orphan-a", 20, old),
+				testObject("clickhouse/region/recent", 30, recent),
+			},
+			IsTruncated:           &truncated,
+			NextContinuationToken: aws.String("next"),
+		},
+		{
+			Contents: []types.Object{
+				testObject("clickhouse/region/orphan-b", 40, old),
+			},
+		},
+	}}
+	reconciler, err := New(client, "bucket-1", "clickhouse/region")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	reconciler.now = func() time.Time { return now }
+
+	manifest, err := reconciler.Scan(context.Background(), map[string]struct{}{
+		"clickhouse/region/live": {},
+	}, 72*time.Hour)
+	if err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+	if manifest.ListedObjectCount != 4 || manifest.ListedBytes != 100 {
+		t.Fatalf("listed totals = (%d, %d)", manifest.ListedObjectCount, manifest.ListedBytes)
+	}
+	if len(manifest.Candidates) != 2 || manifest.CandidateBytes != 60 {
+		t.Fatalf("candidate totals = (%d, %d)", len(manifest.Candidates), manifest.CandidateBytes)
+	}
+	if manifest.Candidates[0].Key != "clickhouse/region/orphan-a" ||
+		manifest.Candidates[1].Key != "clickhouse/region/orphan-b" {
+		t.Fatalf("candidates = %#v", manifest.Candidates)
+	}
+}
+
+func TestDeleteRechecksLiveSetAndChunksRequests(t *testing.T) {
+	now := time.Date(2026, 7, 28, 10, 0, 0, 0, time.UTC)
+	old := now.Add(-96 * time.Hour)
+	candidates := make([]Candidate, 0, 1002)
+	for index := 0; index < 1002; index++ {
+		candidates = append(candidates, Candidate{
+			Key:          fmt.Sprintf("clickhouse/region/object-%04d", index),
+			Size:         2,
+			LastModified: old,
+		})
+	}
+	manifest := &Manifest{
+		Version:           ManifestVersion,
+		Bucket:            "bucket-1",
+		Prefix:            "clickhouse/region/",
+		GeneratedAt:       now.Add(-2 * time.Hour),
+		ListedObjectCount: 2000,
+		Candidates:        candidates,
+	}
+	client := &fakeObjectClient{}
+	reconciler, err := New(client, "bucket-1", "clickhouse/region")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	result, err := reconciler.Delete(
+		context.Background(),
+		manifest,
+		map[string]struct{}{candidates[0].Key: {}},
+		DeleteOptions{
+			Now:               now,
+			MinObjectAge:      72 * time.Hour,
+			MinManifestAge:    time.Hour,
+			MaxDeleteFraction: 0.6,
+			MinLivePaths:      1,
+		},
+	)
+	if err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if result.SkippedLive != 1 || result.DeletedObjects != 1001 || result.DeletedBytes != 2002 {
+		t.Fatalf("delete result = %#v", result)
+	}
+	if len(client.deleteSizes) != 2 || client.deleteSizes[0] != 1000 || client.deleteSizes[1] != 1 {
+		t.Fatalf("delete request sizes = %v", client.deleteSizes)
+	}
+}
+
+func TestDeleteRejectsUnexpectedCandidateFraction(t *testing.T) {
+	now := time.Now().UTC()
+	client := &fakeObjectClient{}
+	reconciler, err := New(client, "bucket-1", "clickhouse/region")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	_, err = reconciler.Delete(
+		context.Background(),
+		&Manifest{
+			Version:           ManifestVersion,
+			Bucket:            "bucket-1",
+			Prefix:            "clickhouse/region/",
+			GeneratedAt:       now.Add(-2 * time.Hour),
+			ListedObjectCount: 2,
+			Candidates: []Candidate{{
+				Key:          "clickhouse/region/orphan",
+				LastModified: now.Add(-96 * time.Hour),
+			}},
+		},
+		map[string]struct{}{"clickhouse/region/live": {}},
+		DeleteOptions{
+			Now:               now,
+			MinObjectAge:      72 * time.Hour,
+			MinManifestAge:    time.Hour,
+			MaxDeleteFraction: 0.25,
+			MinLivePaths:      1,
+		},
+	)
+	if err == nil {
+		t.Fatal("Delete() accepted an excessive candidate fraction")
+	}
+}
+
+func TestNewRejectsRootPrefix(t *testing.T) {
+	if _, err := New(&fakeObjectClient{}, "bucket-1", "/"); err == nil {
+		t.Fatal("New() accepted a root prefix")
+	}
+}
+
+func testObject(key string, size int64, modified time.Time) types.Object {
+	return types.Object{
+		Key:          aws.String(key),
+		Size:         aws.Int64(size),
+		LastModified: aws.Time(modified),
+	}
+}

--- a/pkg/metering/clickhouse/repository.go
+++ b/pkg/metering/clickhouse/repository.go
@@ -15,6 +15,8 @@ import (
 const (
 	dateTime64NanoPlaceholder         = "fromUnixTimestamp64Nano(?, 'UTC')"
 	nullableDateTime64NanoPlaceholder = "if(toUInt8(?), fromUnixTimestamp64Nano(?, 'UTC'), NULL)"
+	maxMeteringInsertBatchSize        = 500
+	meteringInsertReliabilitySettings = " SETTINGS async_insert = 0, wait_for_async_insert = 1"
 )
 
 type Repository struct {
@@ -34,34 +36,154 @@ func NewRepository(db *sql.DB, cfg Config) *Repository {
 	}
 }
 
-func (r *Repository) AppendEvent(ctx context.Context, event *metering.Event) error {
-	return r.appendEvent(ctx, event)
-}
-
-func (r *Repository) appendEvent(ctx context.Context, event *metering.Event) error {
+// ApplyProjectionBatch writes data and state rows before advancing producer
+// watermarks. PostgreSQL remains the durable producer boundary, so any partial
+// ClickHouse acceptance is retried safely through versioned rows.
+func (r *Repository) ApplyProjectionBatch(ctx context.Context, batch *metering.ProjectionBatch) error {
 	if r == nil || r.db == nil {
 		return fmt.Errorf("metering clickhouse repository is not configured")
 	}
+	if batch == nil {
+		return fmt.Errorf("metering projection batch is nil")
+	}
+
+	// Validate the complete batch before the first INSERT. Once validation has
+	// succeeded, transient failures may still leave a partial idempotent write.
+	for _, event := range batch.Events {
+		if _, err := r.eventInsertValues(event); err != nil {
+			return err
+		}
+	}
+	for _, window := range batch.Windows {
+		if _, err := r.windowInsertValues(window); err != nil {
+			return err
+		}
+	}
+	for _, state := range batch.SandboxStates {
+		if _, err := r.sandboxStateInsertValues(state); err != nil {
+			return err
+		}
+	}
+	for _, mutation := range batch.StorageMutations {
+		if mutation == nil {
+			return fmt.Errorf("storage projection mutation is nil")
+		}
+		if _, err := r.storageStateInsertValues(mutation.State, mutation.Deleted, mutation.DeletedAt); err != nil {
+			return err
+		}
+	}
+	for _, watermark := range batch.Watermarks {
+		if _, err := r.watermarkInsertValues(watermark); err != nil {
+			return err
+		}
+	}
+
+	if err := r.appendEvents(ctx, batch.Events); err != nil {
+		return err
+	}
+	if err := r.appendWindows(ctx, batch.Windows); err != nil {
+		return err
+	}
+	if err := r.upsertSandboxProjectionStates(ctx, batch.SandboxStates); err != nil {
+		return err
+	}
+	if err := r.writeStorageProjectionStates(ctx, batch.StorageMutations); err != nil {
+		return err
+	}
+	return r.upsertProducerWatermarks(ctx, batch.Watermarks)
+}
+
+type insertRowsConfig struct {
+	table        string
+	columns      string
+	placeholders string
+	description  string
+}
+
+func (r *Repository) execInsertRows(ctx context.Context, cfg insertRowsConfig, rows [][]any) error {
+	for len(rows) > 0 {
+		chunkSize := min(len(rows), maxMeteringInsertBatchSize)
+		chunk := rows[:chunkSize]
+		var query strings.Builder
+		query.WriteString("INSERT INTO ")
+		query.WriteString(cfg.table)
+		query.WriteString(" (")
+		query.WriteString(cfg.columns)
+		query.WriteString(")")
+		query.WriteString(meteringInsertReliabilitySettings)
+		query.WriteString(" VALUES ")
+
+		args := make([]any, 0)
+		for index, row := range chunk {
+			if index > 0 {
+				query.WriteString(", ")
+			}
+			query.WriteString(cfg.placeholders)
+			args = append(args, row...)
+		}
+		if _, err := r.db.ExecContext(ctx, query.String(), args...); err != nil {
+			return fmt.Errorf("%s: %w", cfg.description, err)
+		}
+		rows = rows[chunkSize:]
+	}
+	return nil
+}
+
+func (r *Repository) AppendEvent(ctx context.Context, event *metering.Event) error {
+	return r.appendEvents(ctx, []*metering.Event{event})
+}
+
+func (r *Repository) appendEvents(ctx context.Context, events []*metering.Event) error {
+	if r == nil || r.db == nil {
+		return fmt.Errorf("metering clickhouse repository is not configured")
+	}
+	rows := make([][]any, 0, len(events))
+	for _, event := range events {
+		row, err := r.eventInsertValues(event)
+		if err != nil {
+			return err
+		}
+		rows = append(rows, row)
+	}
+	return r.execInsertRows(ctx, insertRowsConfig{
+		table: qualified(r.cfg.Database, r.cfg.EventsTable),
+		columns: `
+    sequence, event_id, producer, region_id, event_type,
+    subject_type, subject_id,
+    team_id, user_id,
+    sandbox_id, volume_id, snapshot_id,
+    template_id, cluster_id,
+    occurred_at, recorded_at, version, data`,
+		placeholders: fmt.Sprintf(
+			"(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s, %s, ?, ?)",
+			dateTime64NanoPlaceholder,
+			dateTime64NanoPlaceholder,
+		),
+		description: "insert usage events",
+	}, rows)
+}
+
+func (r *Repository) eventInsertValues(event *metering.Event) ([]any, error) {
 	if event == nil {
-		return fmt.Errorf("event is nil")
+		return nil, fmt.Errorf("event is nil")
 	}
 	if event.EventID == "" {
-		return fmt.Errorf("event_id is required")
+		return nil, fmt.Errorf("event_id is required")
 	}
 	if event.Sequence <= 0 {
-		return fmt.Errorf("sequence is required")
+		return nil, fmt.Errorf("sequence is required")
 	}
 	if event.Producer == "" {
-		return fmt.Errorf("producer is required")
+		return nil, fmt.Errorf("producer is required")
 	}
 	if event.EventType == "" {
-		return fmt.Errorf("event_type is required")
+		return nil, fmt.Errorf("event_type is required")
 	}
 	if event.SubjectType == "" || event.SubjectID == "" {
-		return fmt.Errorf("subject_type and subject_id are required")
+		return nil, fmt.Errorf("subject_type and subject_id are required")
 	}
 	if event.OccurredAt.IsZero() {
-		return fmt.Errorf("occurred_at is required")
+		return nil, fmt.Errorf("occurred_at is required")
 	}
 	recordedAt := event.RecordedAt
 	if recordedAt.IsZero() {
@@ -71,66 +193,82 @@ func (r *Repository) appendEvent(ctx context.Context, event *metering.Event) err
 	if len(data) == 0 {
 		data = json.RawMessage(`{}`)
 	}
-	_, err := r.db.ExecContext(ctx, fmt.Sprintf(`
-INSERT INTO %s (
-    sequence, event_id, producer, region_id, event_type,
-    subject_type, subject_id,
-    team_id, user_id,
-    sandbox_id, volume_id, snapshot_id,
-    template_id, cluster_id,
-    occurred_at, recorded_at, version, data
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s, %s, ?, ?)
-`, qualified(r.cfg.Database, r.cfg.EventsTable), dateTime64NanoPlaceholder, dateTime64NanoPlaceholder),
+	return []any{
 		event.Sequence, event.EventID, event.Producer, event.RegionID, event.EventType,
 		event.SubjectType, event.SubjectID,
 		event.TeamID, event.UserID,
 		event.SandboxID, event.VolumeID, event.SnapshotID,
 		event.TemplateID, event.ClusterID,
 		dateTime64NanoArg(event.OccurredAt), dateTime64NanoArg(recordedAt), versionFrom(recordedAt), string(data),
-	)
-	if err != nil {
-		return fmt.Errorf("insert usage event: %w", err)
-	}
-	return nil
+	}, nil
 }
 
 func (r *Repository) AppendWindow(ctx context.Context, window *metering.Window) error {
-	return r.appendWindow(ctx, window)
+	return r.appendWindows(ctx, []*metering.Window{window})
 }
 
-func (r *Repository) appendWindow(ctx context.Context, window *metering.Window) error {
+func (r *Repository) appendWindows(ctx context.Context, windows []*metering.Window) error {
 	if r == nil || r.db == nil {
 		return fmt.Errorf("metering clickhouse repository is not configured")
 	}
+	rows := make([][]any, 0, len(windows))
+	for _, window := range windows {
+		row, err := r.windowInsertValues(window)
+		if err != nil {
+			return err
+		}
+		rows = append(rows, row)
+	}
+	return r.execInsertRows(ctx, insertRowsConfig{
+		table: qualified(r.cfg.Database, r.cfg.WindowsTable),
+		columns: `
+    sequence, window_id, producer, region_id, window_type,
+    subject_type, subject_id,
+    team_id, user_id,
+    sandbox_id, volume_id, snapshot_id,
+    template_id, cluster_id,
+    window_start, window_end,
+    value, unit, recorded_at, version, data`,
+		placeholders: fmt.Sprintf(
+			"(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s, %s, ?, ?, %s, ?, ?)",
+			dateTime64NanoPlaceholder,
+			dateTime64NanoPlaceholder,
+			dateTime64NanoPlaceholder,
+		),
+		description: "insert usage windows",
+	}, rows)
+}
+
+func (r *Repository) windowInsertValues(window *metering.Window) ([]any, error) {
 	if window == nil {
-		return fmt.Errorf("window is nil")
+		return nil, fmt.Errorf("window is nil")
 	}
 	if window.WindowID == "" {
-		return fmt.Errorf("window_id is required")
+		return nil, fmt.Errorf("window_id is required")
 	}
 	if window.Sequence <= 0 {
-		return fmt.Errorf("sequence is required")
+		return nil, fmt.Errorf("sequence is required")
 	}
 	if window.Producer == "" {
-		return fmt.Errorf("producer is required")
+		return nil, fmt.Errorf("producer is required")
 	}
 	if window.WindowType == "" {
-		return fmt.Errorf("window_type is required")
+		return nil, fmt.Errorf("window_type is required")
 	}
 	if window.SubjectType == "" || window.SubjectID == "" {
-		return fmt.Errorf("subject_type and subject_id are required")
+		return nil, fmt.Errorf("subject_type and subject_id are required")
 	}
 	if window.WindowStart.IsZero() || window.WindowEnd.IsZero() {
-		return fmt.Errorf("window_start and window_end are required")
+		return nil, fmt.Errorf("window_start and window_end are required")
 	}
 	if window.WindowEnd.Before(window.WindowStart) {
-		return fmt.Errorf("window_end must be greater than or equal to window_start")
+		return nil, fmt.Errorf("window_end must be greater than or equal to window_start")
 	}
 	if window.Unit == "" {
-		return fmt.Errorf("unit is required")
+		return nil, fmt.Errorf("unit is required")
 	}
 	if window.Value < 0 {
-		return fmt.Errorf("value must be non-negative")
+		return nil, fmt.Errorf("value must be non-negative")
 	}
 	recordedAt := window.RecordedAt
 	if recordedAt.IsZero() {
@@ -140,17 +278,7 @@ func (r *Repository) appendWindow(ctx context.Context, window *metering.Window) 
 	if len(data) == 0 {
 		data = json.RawMessage(`{}`)
 	}
-	_, err := r.db.ExecContext(ctx, fmt.Sprintf(`
-INSERT INTO %s (
-    sequence, window_id, producer, region_id, window_type,
-    subject_type, subject_id,
-    team_id, user_id,
-    sandbox_id, volume_id, snapshot_id,
-    template_id, cluster_id,
-    window_start, window_end,
-    value, unit, recorded_at, version, data
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s, %s, ?, ?, %s, ?, ?)
-`, qualified(r.cfg.Database, r.cfg.WindowsTable), dateTime64NanoPlaceholder, dateTime64NanoPlaceholder, dateTime64NanoPlaceholder),
+	return []any{
 		window.Sequence, window.WindowID, window.Producer, window.RegionID, window.WindowType,
 		window.SubjectType, window.SubjectID,
 		window.TeamID, window.UserID,
@@ -158,38 +286,58 @@ INSERT INTO %s (
 		window.TemplateID, window.ClusterID,
 		dateTime64NanoArg(window.WindowStart), dateTime64NanoArg(window.WindowEnd),
 		window.Value, window.Unit, dateTime64NanoArg(recordedAt), versionFrom(recordedAt), string(data),
-	)
-	if err != nil {
-		return fmt.Errorf("insert usage window: %w", err)
-	}
-	return nil
+	}, nil
 }
 
 func (r *Repository) UpsertProducerWatermark(ctx context.Context, producer string, regionID string, completeBefore time.Time) error {
-	return r.upsertProducerWatermark(ctx, producer, regionID, completeBefore)
+	return r.upsertProducerWatermarks(ctx, []*metering.ProducerWatermark{{
+		Producer:       producer,
+		RegionID:       regionID,
+		CompleteBefore: completeBefore,
+	}})
 }
 
-func (r *Repository) upsertProducerWatermark(ctx context.Context, producer string, regionID string, completeBefore time.Time) error {
+func (r *Repository) upsertProducerWatermarks(ctx context.Context, watermarks []*metering.ProducerWatermark) error {
 	if r == nil || r.db == nil {
 		return fmt.Errorf("metering clickhouse repository is not configured")
 	}
-	if producer == "" {
-		return fmt.Errorf("producer is required")
+	rows := make([][]any, 0, len(watermarks))
+	for _, watermark := range watermarks {
+		row, err := r.watermarkInsertValues(watermark)
+		if err != nil {
+			return err
+		}
+		rows = append(rows, row)
 	}
-	if completeBefore.IsZero() {
-		return fmt.Errorf("complete_before is required")
+	return r.execInsertRows(ctx, insertRowsConfig{
+		table:        qualified(r.cfg.Database, r.cfg.WatermarksTable),
+		columns:      "producer, region_id, complete_before, updated_at, version",
+		placeholders: fmt.Sprintf("(?, ?, %s, %s, ?)", dateTime64NanoPlaceholder, dateTime64NanoPlaceholder),
+		description:  "upsert producer watermarks",
+	}, rows)
+}
+
+func (r *Repository) watermarkInsertValues(watermark *metering.ProducerWatermark) ([]any, error) {
+	if watermark == nil {
+		return nil, fmt.Errorf("producer watermark is nil")
 	}
-	updatedAt := r.now()
-	_, err := r.db.ExecContext(ctx, fmt.Sprintf(`
-INSERT INTO %s (producer, region_id, complete_before, updated_at, version)
-VALUES (?, ?, %s, %s, ?)
-`, qualified(r.cfg.Database, r.cfg.WatermarksTable), dateTime64NanoPlaceholder, dateTime64NanoPlaceholder),
-		producer, regionID, dateTime64NanoArg(completeBefore), dateTime64NanoArg(updatedAt), versionFrom(completeBefore),
-	)
-	if err != nil {
-		return fmt.Errorf("upsert producer watermark: %w", err)
+	if watermark.Producer == "" {
+		return nil, fmt.Errorf("producer is required")
 	}
-	return nil
+	if watermark.CompleteBefore.IsZero() {
+		return nil, fmt.Errorf("complete_before is required")
+	}
+	updatedAt := watermark.UpdatedAt
+	if updatedAt.IsZero() {
+		updatedAt = r.now()
+	}
+	return []any{
+		watermark.Producer,
+		watermark.RegionID,
+		dateTime64NanoArg(watermark.CompleteBefore),
+		dateTime64NanoArg(updatedAt),
+		versionFrom(watermark.CompleteBefore),
+	}, nil
 }
 
 func (r *Repository) GetStatus(ctx context.Context, fallbackRegionID string) (*metering.Status, error) {
@@ -535,18 +683,49 @@ WHERE terminated_at IS NULL
 }
 
 func (r *Repository) UpsertSandboxProjectionState(ctx context.Context, state *metering.SandboxProjectionState) error {
-	return r.upsertSandboxProjectionState(ctx, state)
+	return r.upsertSandboxProjectionStates(ctx, []*metering.SandboxProjectionState{state})
 }
 
-func (r *Repository) upsertSandboxProjectionState(ctx context.Context, state *metering.SandboxProjectionState) error {
+func (r *Repository) upsertSandboxProjectionStates(ctx context.Context, states []*metering.SandboxProjectionState) error {
+	if r == nil || r.db == nil {
+		return fmt.Errorf("metering clickhouse repository is not configured")
+	}
+	rows := make([][]any, 0, len(states))
+	for _, state := range states {
+		row, err := r.sandboxStateInsertValues(state)
+		if err != nil {
+			return err
+		}
+		rows = append(rows, row)
+	}
+	return r.execInsertRows(ctx, insertRowsConfig{
+		table: qualified(r.cfg.Database, r.cfg.SandboxStateTable),
+		columns: `
+    sandbox_id, namespace, team_id, user_id, template_id, cluster_id,
+    owner_kind, resource_millicpu, resource_memory_mib,
+    claimed_at, active_since, paused, paused_at, terminated_at,
+    last_observed_at, last_resource_version, version`,
+		placeholders: fmt.Sprintf(
+			"(?, ?, ?, ?, ?, ?, ?, ?, ?, %s, %s, ?, %s, %s, %s, ?, ?)",
+			nullableDateTime64NanoPlaceholder,
+			nullableDateTime64NanoPlaceholder,
+			nullableDateTime64NanoPlaceholder,
+			nullableDateTime64NanoPlaceholder,
+			dateTime64NanoPlaceholder,
+		),
+		description: "upsert sandbox projection states",
+	}, rows)
+}
+
+func (r *Repository) sandboxStateInsertValues(state *metering.SandboxProjectionState) ([]any, error) {
 	if state == nil {
-		return fmt.Errorf("state is nil")
+		return nil, fmt.Errorf("state is nil")
 	}
 	if state.SandboxID == "" {
-		return fmt.Errorf("sandbox_id is required")
+		return nil, fmt.Errorf("sandbox_id is required")
 	}
 	if state.Namespace == "" {
-		return fmt.Errorf("namespace is required")
+		return nil, fmt.Errorf("namespace is required")
 	}
 	if state.LastObservedAt.IsZero() {
 		state.LastObservedAt = r.now()
@@ -555,21 +734,7 @@ func (r *Repository) upsertSandboxProjectionState(ctx context.Context, state *me
 	activeSincePresent, activeSinceNanos := nullableDateTime64NanoArgs(state.ActiveSince)
 	pausedAtPresent, pausedAtNanos := nullableDateTime64NanoArgs(state.PausedAt)
 	terminatedAtPresent, terminatedAtNanos := nullableDateTime64NanoArgs(state.TerminatedAt)
-	_, err := r.db.ExecContext(ctx, fmt.Sprintf(`
-INSERT INTO %s (
-    sandbox_id, namespace, team_id, user_id, template_id, cluster_id,
-    owner_kind, resource_millicpu, resource_memory_mib,
-    claimed_at, active_since, paused, paused_at, terminated_at,
-    last_observed_at, last_resource_version, version
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, %s, %s, ?, %s, %s, %s, ?, ?)
-`,
-		qualified(r.cfg.Database, r.cfg.SandboxStateTable),
-		nullableDateTime64NanoPlaceholder,
-		nullableDateTime64NanoPlaceholder,
-		nullableDateTime64NanoPlaceholder,
-		nullableDateTime64NanoPlaceholder,
-		dateTime64NanoPlaceholder,
-	),
+	return []any{
 		state.SandboxID, state.Namespace, state.TeamID, state.UserID, state.TemplateID, state.ClusterID,
 		state.OwnerKind, state.ResourceMillicpu, state.ResourceMemoryMiB,
 		claimedAtPresent, claimedAtNanos,
@@ -578,40 +743,15 @@ INSERT INTO %s (
 		pausedAtPresent, pausedAtNanos,
 		terminatedAtPresent, terminatedAtNanos,
 		dateTime64NanoArg(state.LastObservedAt), state.LastResourceVer, versionFrom(state.LastObservedAt),
-	)
-	if err != nil {
-		return fmt.Errorf("upsert sandbox projection state: %w", err)
-	}
-	return nil
-}
-
-func (r *Repository) upsertStorageProjectionState(ctx context.Context, state *metering.StorageProjectionState) error {
-	_, err := r.db.ExecContext(ctx, fmt.Sprintf(`
-INSERT INTO %s (
-    subject_type, subject_id, product, owner_kind,
-    team_id, user_id, sandbox_id, volume_id, snapshot_id,
-    cluster_id, region_id, size_bytes, observed_at, unbilled_byte_nanoseconds,
-    deleted, version
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s, ?, 0, ?)
-`, qualified(r.cfg.Database, r.cfg.StorageStateTable), dateTime64NanoPlaceholder),
-		state.SubjectType, state.SubjectID, state.Product, state.OwnerKind,
-		state.TeamID, state.UserID, state.SandboxID, state.VolumeID, state.SnapshotID,
-		state.ClusterID, state.RegionID, state.SizeBytes, dateTime64NanoArg(state.ObservedAt), state.UnbilledByteNanoseconds,
-		versionFrom(state.ObservedAt),
-	)
-	if err != nil {
-		return fmt.Errorf("upsert storage projection state: %w", err)
-	}
-	return nil
+	}, nil
 }
 
 // UpsertStorageProjectionState applies an idempotent storage-state mutation
 // captured by the PostgreSQL metering outbox.
 func (r *Repository) UpsertStorageProjectionState(ctx context.Context, state *metering.StorageProjectionState) error {
-	if state == nil {
-		return fmt.Errorf("storage projection state is nil")
-	}
-	return r.upsertStorageProjectionState(ctx, state)
+	return r.writeStorageProjectionStates(ctx, []*metering.StorageProjectionMutation{{
+		State: state,
+	}})
 }
 
 // ListActiveStorageProjectionStates returns current producer state needed to
@@ -649,36 +789,70 @@ WHERE deleted = 0
 	return states, nil
 }
 
-func (r *Repository) deleteStorageProjectionState(ctx context.Context, state *metering.StorageProjectionState, deletedAt time.Time) error {
-	if deletedAt.IsZero() {
-		deletedAt = r.now()
-	}
-	_, err := r.db.ExecContext(ctx, fmt.Sprintf(`
-INSERT INTO %s (
-    subject_type, subject_id, product, owner_kind,
-    team_id, user_id, sandbox_id, volume_id, snapshot_id,
-    cluster_id, region_id, size_bytes, observed_at, unbilled_byte_nanoseconds,
-    deleted, version
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s, ?, 1, ?)
-`, qualified(r.cfg.Database, r.cfg.StorageStateTable), dateTime64NanoPlaceholder),
-		state.SubjectType, state.SubjectID, state.Product, state.OwnerKind,
-		state.TeamID, state.UserID, state.SandboxID, state.VolumeID, state.SnapshotID,
-		state.ClusterID, state.RegionID, state.SizeBytes, dateTime64NanoArg(deletedAt), state.UnbilledByteNanoseconds,
-		versionFrom(deletedAt),
-	)
-	if err != nil {
-		return fmt.Errorf("delete storage projection state: %w", err)
-	}
-	return nil
-}
-
 // DeleteStorageProjectionState applies an idempotent storage-state tombstone
 // captured by the PostgreSQL metering outbox.
 func (r *Repository) DeleteStorageProjectionState(ctx context.Context, state *metering.StorageProjectionState, deletedAt time.Time) error {
-	if state == nil {
-		return fmt.Errorf("storage projection state is nil")
+	return r.writeStorageProjectionStates(ctx, []*metering.StorageProjectionMutation{{
+		State:     state,
+		Deleted:   true,
+		DeletedAt: deletedAt,
+	}})
+}
+
+func (r *Repository) writeStorageProjectionStates(
+	ctx context.Context,
+	mutations []*metering.StorageProjectionMutation,
+) error {
+	if r == nil || r.db == nil {
+		return fmt.Errorf("metering clickhouse repository is not configured")
 	}
-	return r.deleteStorageProjectionState(ctx, state, deletedAt)
+	rows := make([][]any, 0, len(mutations))
+	for _, mutation := range mutations {
+		if mutation == nil {
+			return fmt.Errorf("storage projection mutation is nil")
+		}
+		row, err := r.storageStateInsertValues(mutation.State, mutation.Deleted, mutation.DeletedAt)
+		if err != nil {
+			return err
+		}
+		rows = append(rows, row)
+	}
+	return r.execInsertRows(ctx, insertRowsConfig{
+		table: qualified(r.cfg.Database, r.cfg.StorageStateTable),
+		columns: `
+    subject_type, subject_id, product, owner_kind,
+    team_id, user_id, sandbox_id, volume_id, snapshot_id,
+    cluster_id, region_id, size_bytes, observed_at, unbilled_byte_nanoseconds,
+    deleted, version`,
+		placeholders: fmt.Sprintf(
+			"(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s, ?, ?, ?)",
+			dateTime64NanoPlaceholder,
+		),
+		description: "write storage projection states",
+	}, rows)
+}
+
+func (r *Repository) storageStateInsertValues(
+	state *metering.StorageProjectionState,
+	deleted bool,
+	deletedAt time.Time,
+) ([]any, error) {
+	if state == nil {
+		return nil, fmt.Errorf("storage projection state is nil")
+	}
+	observedAt := state.ObservedAt
+	if deleted {
+		observedAt = deletedAt
+		if observedAt.IsZero() {
+			observedAt = r.now()
+		}
+	}
+	return []any{
+		state.SubjectType, state.SubjectID, state.Product, state.OwnerKind,
+		state.TeamID, state.UserID, state.SandboxID, state.VolumeID, state.SnapshotID,
+		state.ClusterID, state.RegionID, state.SizeBytes, dateTime64NanoArg(observedAt), state.UnbilledByteNanoseconds,
+		boolUInt8(deleted), versionFrom(observedAt),
+	}, nil
 }
 
 func (r *Repository) CurrentUsage(ctx context.Context, teamID string, dimension quota.Dimension) (int64, error) {

--- a/pkg/metering/clickhouse/repository_test.go
+++ b/pkg/metering/clickhouse/repository_test.go
@@ -31,8 +31,11 @@ func (captureDriver) Open(string) (driver.Conn, error) {
 }
 
 type captureConn struct {
-	query string
-	args  []driver.NamedValue
+	query       string
+	args        []driver.NamedValue
+	queries     []string
+	argsHistory [][]driver.NamedValue
+	failExec    int
 }
 
 func (c *captureConn) Prepare(string) (driver.Stmt, error) {
@@ -50,6 +53,11 @@ func (c *captureConn) Begin() (driver.Tx, error) {
 func (c *captureConn) ExecContext(_ context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
 	c.query = query
 	c.args = append([]driver.NamedValue(nil), args...)
+	c.queries = append(c.queries, query)
+	c.argsHistory = append(c.argsHistory, append([]driver.NamedValue(nil), args...))
+	if c.failExec > 0 && len(c.queries) == c.failExec {
+		return nil, errors.New("injected ClickHouse failure")
+	}
 	return driver.RowsAffected(1), nil
 }
 
@@ -152,6 +160,237 @@ func TestAppendRequiresOutboxSequence(t *testing.T) {
 		Unit:        metering.WindowUnitBytes,
 	}); err == nil || !strings.Contains(err.Error(), "sequence is required") {
 		t.Fatalf("AppendWindow() error = %v, want missing sequence", err)
+	}
+}
+
+func TestApplyProjectionBatchUsesBoundedMultiRowInsertsAndAdvancesWatermarksLast(t *testing.T) {
+	repo, conn := newCaptureRepository(t)
+	now := time.Date(2026, 7, 28, 10, 0, 0, 123, time.UTC)
+	repo.now = func() time.Time { return now }
+
+	events := make([]*metering.Event, 0, 2)
+	windows := make([]*metering.Window, 0, 2)
+	sandboxStates := make([]*metering.SandboxProjectionState, 0, 2)
+	storageMutations := make([]*metering.StorageProjectionMutation, 0, 2)
+	watermarks := make([]*metering.ProducerWatermark, 0, 2)
+	for index := 1; index <= 2; index++ {
+		events = append(events, &metering.Event{
+			Sequence:    int64(index),
+			EventID:     "event-" + string(rune('0'+index)),
+			Producer:    "producer-1",
+			EventType:   metering.EventTypeSandboxClaimed,
+			SubjectType: metering.SubjectTypeSandbox,
+			SubjectID:   "sandbox-1",
+			OccurredAt:  now,
+			RecordedAt:  now,
+		})
+		windows = append(windows, &metering.Window{
+			Sequence:    int64(index + 2),
+			WindowID:    "window-" + string(rune('0'+index)),
+			Producer:    "producer-1",
+			WindowType:  metering.WindowTypeSandboxEgressBytes,
+			SubjectType: metering.SubjectTypeSandbox,
+			SubjectID:   "sandbox-1",
+			WindowStart: now,
+			WindowEnd:   now.Add(time.Minute),
+			Value:       int64(index),
+			Unit:        metering.WindowUnitBytes,
+			RecordedAt:  now,
+		})
+		sandboxStates = append(sandboxStates, &metering.SandboxProjectionState{
+			SandboxID:      "sandbox-" + string(rune('0'+index)),
+			Namespace:      "default",
+			LastObservedAt: now,
+		})
+		storageMutations = append(storageMutations, &metering.StorageProjectionMutation{
+			State: &metering.StorageProjectionState{
+				SubjectType: metering.SubjectTypeVolume,
+				SubjectID:   "volume-" + string(rune('0'+index)),
+				ObservedAt:  now,
+			},
+		})
+		watermarks = append(watermarks, &metering.ProducerWatermark{
+			Producer:       "producer-" + string(rune('0'+index)),
+			RegionID:       "region-1",
+			CompleteBefore: now,
+		})
+	}
+	tombstone := &metering.StorageProjectionMutation{
+		State: &metering.StorageProjectionState{
+			SubjectType: metering.SubjectTypeVolume,
+			SubjectID:   "volume-deleted",
+			ObservedAt:  now.Add(-time.Minute),
+		},
+		Deleted:   true,
+		DeletedAt: now,
+	}
+
+	err := repo.ApplyProjectionBatch(context.Background(), &metering.ProjectionBatch{
+		Events:           events,
+		Windows:          windows,
+		SandboxStates:    sandboxStates,
+		StorageMutations: append(storageMutations, tombstone),
+		Watermarks:       watermarks,
+	})
+	if err != nil {
+		t.Fatalf("ApplyProjectionBatch() error = %v", err)
+	}
+	if len(conn.queries) != 5 {
+		t.Fatalf("ClickHouse INSERT count = %d, want 5", len(conn.queries))
+	}
+	for index, query := range conn.queries {
+		if !strings.Contains(query, meteringInsertReliabilitySettings) {
+			t.Fatalf("query %d is missing durability settings: %s", index, query)
+		}
+	}
+	if !strings.Contains(conn.queries[len(conn.queries)-1], "producer_watermarks") {
+		t.Fatalf("last INSERT does not advance watermarks: %s", conn.queries[len(conn.queries)-1])
+	}
+	wantArgCounts := []int{36, 42, 42, 48, 10}
+	for index, want := range wantArgCounts {
+		if got := len(conn.argsHistory[index]); got != want {
+			t.Fatalf("query %d argument count = %d, want %d", index, got, want)
+		}
+	}
+}
+
+func TestApplyProjectionBatchValidatesAllRowsBeforeWriting(t *testing.T) {
+	repo, conn := newCaptureRepository(t)
+	now := time.Now().UTC()
+	err := repo.ApplyProjectionBatch(context.Background(), &metering.ProjectionBatch{
+		Events: []*metering.Event{{
+			Sequence:    1,
+			EventID:     "event-1",
+			Producer:    "producer-1",
+			EventType:   metering.EventTypeSandboxClaimed,
+			SubjectType: metering.SubjectTypeSandbox,
+			SubjectID:   "sandbox-1",
+			OccurredAt:  now,
+		}},
+		Windows: []*metering.Window{{
+			Sequence: 2,
+			WindowID: "invalid-window",
+		}},
+	})
+	if err == nil {
+		t.Fatal("ApplyProjectionBatch() succeeded with an invalid later row")
+	}
+	if len(conn.queries) != 0 {
+		t.Fatalf("ClickHouse INSERT count = %d, want 0", len(conn.queries))
+	}
+}
+
+func TestApplyProjectionBatchDoesNotAdvanceWatermarkAfterPartialFailure(t *testing.T) {
+	repo, conn := newCaptureRepository(t)
+	now := time.Now().UTC()
+	conn.failExec = 2
+
+	err := repo.ApplyProjectionBatch(context.Background(), &metering.ProjectionBatch{
+		Events: []*metering.Event{{
+			Sequence:    1,
+			EventID:     "event-1",
+			Producer:    "producer-1",
+			EventType:   metering.EventTypeSandboxClaimed,
+			SubjectType: metering.SubjectTypeSandbox,
+			SubjectID:   "sandbox-1",
+			OccurredAt:  now,
+			RecordedAt:  now,
+		}},
+		Windows: []*metering.Window{{
+			Sequence:    2,
+			WindowID:    "window-1",
+			Producer:    "producer-1",
+			WindowType:  metering.WindowTypeSandboxEgressBytes,
+			SubjectType: metering.SubjectTypeSandbox,
+			SubjectID:   "sandbox-1",
+			WindowStart: now,
+			WindowEnd:   now.Add(time.Minute),
+			Value:       1,
+			Unit:        metering.WindowUnitBytes,
+			RecordedAt:  now,
+		}},
+		Watermarks: []*metering.ProducerWatermark{{
+			Producer:       "producer-1",
+			CompleteBefore: now,
+		}},
+	})
+	if err == nil {
+		t.Fatal("ApplyProjectionBatch() succeeded after an injected partial failure")
+	}
+	if len(conn.queries) != 2 {
+		t.Fatalf("ClickHouse INSERT count = %d, want 2", len(conn.queries))
+	}
+	for _, query := range conn.queries {
+		if strings.Contains(query, "producer_watermarks") {
+			t.Fatalf("watermark advanced after a partial failure: %s", query)
+		}
+	}
+}
+
+func TestApplyProjectionBatchPreservesStorageMutationOrder(t *testing.T) {
+	repo, conn := newCaptureRepository(t)
+	now := time.Now().UTC()
+	state := &metering.StorageProjectionState{
+		SubjectType: metering.SubjectTypeVolume,
+		SubjectID:   "volume-1",
+		ObservedAt:  now,
+	}
+
+	err := repo.ApplyProjectionBatch(context.Background(), &metering.ProjectionBatch{
+		StorageMutations: []*metering.StorageProjectionMutation{
+			{
+				State:     state,
+				Deleted:   true,
+				DeletedAt: now,
+			},
+			{State: state},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ApplyProjectionBatch() error = %v", err)
+	}
+	if len(conn.queries) != 1 {
+		t.Fatalf("ClickHouse INSERT count = %d, want 1", len(conn.queries))
+	}
+	const storageRowArgumentCount = 16
+	if got := conn.argsHistory[0][14].Value; got != int64(1) {
+		t.Fatalf("first storage mutation deleted arg = %#v, want 1", got)
+	}
+	if got := conn.argsHistory[0][storageRowArgumentCount+14].Value; got != int64(0) {
+		t.Fatalf("second storage mutation deleted arg = %#v, want 0", got)
+	}
+}
+
+func TestApplyProjectionBatchChunksLargeTables(t *testing.T) {
+	repo, conn := newCaptureRepository(t)
+	now := time.Now().UTC()
+	windows := make([]*metering.Window, 0, maxMeteringInsertBatchSize+1)
+	for index := 0; index <= maxMeteringInsertBatchSize; index++ {
+		windows = append(windows, &metering.Window{
+			Sequence:    int64(index + 1),
+			WindowID:    "window-" + time.Duration(index).String(),
+			Producer:    "producer-1",
+			WindowType:  metering.WindowTypeSandboxEgressBytes,
+			SubjectType: metering.SubjectTypeSandbox,
+			SubjectID:   "sandbox-1",
+			WindowStart: now,
+			WindowEnd:   now.Add(time.Minute),
+			Value:       1,
+			Unit:        metering.WindowUnitBytes,
+			RecordedAt:  now,
+		})
+	}
+	if err := repo.ApplyProjectionBatch(context.Background(), &metering.ProjectionBatch{Windows: windows}); err != nil {
+		t.Fatalf("ApplyProjectionBatch() error = %v", err)
+	}
+	if len(conn.queries) != 2 {
+		t.Fatalf("ClickHouse INSERT count = %d, want 2", len(conn.queries))
+	}
+	if got := len(conn.argsHistory[0]); got != maxMeteringInsertBatchSize*21 {
+		t.Fatalf("first chunk argument count = %d", got)
+	}
+	if got := len(conn.argsHistory[1]); got != 21 {
+		t.Fatalf("second chunk argument count = %d", got)
 	}
 }
 

--- a/pkg/metering/outbox/migrations/00007_index_pending_outbox_batches.sql
+++ b/pkg/metering/outbox/migrations/00007_index_pending_outbox_batches.sql
@@ -1,0 +1,10 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_projection_outbox_pending_batch
+    ON metering.projection_outbox(batch_id)
+    WHERE delivered_at IS NULL;
+
+-- +goose Down
+
+DROP INDEX CONCURRENTLY IF EXISTS metering.idx_projection_outbox_pending_batch;

--- a/pkg/metering/outbox/projector.go
+++ b/pkg/metering/outbox/projector.go
@@ -16,9 +16,11 @@ import (
 )
 
 const (
-	defaultPollInterval = 2 * time.Second
-	defaultClaimLease   = 30 * time.Second
-	defaultCleanupAge   = 24 * time.Hour
+	defaultPollInterval       = 2 * time.Second
+	defaultClaimLease         = 30 * time.Second
+	defaultCleanupAge         = 24 * time.Hour
+	defaultDeliveryOperations = 500
+	defaultDeliveryBatches    = 500
 )
 
 type projectionStore interface {
@@ -29,13 +31,21 @@ type projectionStore interface {
 	Stats(context.Context) (*Stats, error)
 }
 
+type coalescingProjectionStore interface {
+	ClaimNextBatches(context.Context, string, time.Duration, int, int) ([]*Batch, error)
+	MarkDeliveredBatches(context.Context, []int64, string) error
+	MarkFailedBatches(context.Context, []int64, string, string, time.Time) error
+}
+
 // ProjectorConfig controls PostgreSQL outbox delivery to ClickHouse.
 type ProjectorConfig struct {
-	WorkerID     string
-	PollInterval time.Duration
-	ClaimLease   time.Duration
-	CleanupAge   time.Duration
-	CleanupBatch int
+	WorkerID           string
+	PollInterval       time.Duration
+	ClaimLease         time.Duration
+	MaxDeliveryOps     int
+	MaxDeliveryBatches int
+	CleanupAge         time.Duration
+	CleanupBatch       int
 }
 
 // Projector retries exact, idempotent operations until ClickHouse accepts the
@@ -65,6 +75,12 @@ func NewProjector(store projectionStore, sink Sink, config ProjectorConfig, logg
 	}
 	if config.ClaimLease <= 0 {
 		config.ClaimLease = defaultClaimLease
+	}
+	if config.MaxDeliveryOps <= 0 {
+		config.MaxDeliveryOps = defaultDeliveryOperations
+	}
+	if config.MaxDeliveryBatches <= 0 {
+		config.MaxDeliveryBatches = defaultDeliveryBatches
 	}
 	if config.CleanupAge <= 0 {
 		config.CleanupAge = defaultCleanupAge
@@ -129,32 +145,187 @@ func (p *Projector) ProjectOnce(ctx context.Context) (bool, error) {
 	if p.sink == nil {
 		return false, fmt.Errorf("metering projection sink is not configured")
 	}
-	batch, err := p.store.ClaimNextBatch(ctx, p.config.WorkerID, p.config.ClaimLease)
-	if err != nil || batch == nil {
+	batches, err := p.claimBatches(ctx)
+	if err != nil || len(batches) == 0 {
 		return false, err
 	}
-	sort.Slice(batch.Operations, func(i, j int) bool {
-		return batch.Operations[i].Sequence < batch.Operations[j].Sequence
-	})
-	for _, operation := range batch.Operations {
-		if err := p.apply(ctx, operation); err != nil {
+	operations := orderedOperations(batches)
+	applyErr := p.applyOperations(ctx, operations)
+	if applyErr != nil {
+		for _, operation := range operations {
 			p.recordOperation(operation.Type, "error")
-			p.recordBatch("error")
-			retryAt := p.timestamp().Add(retryDelay(operation.Attempts))
-			markErr := p.store.MarkFailed(ctx, batch.ID, p.config.WorkerID, err.Error(), retryAt)
-			if markErr != nil {
-				return true, errors.Join(err, markErr)
-			}
-			return true, fmt.Errorf("apply metering outbox batch %d operation %d (%s): %w", batch.ID, operation.Sequence, operation.Type, err)
 		}
+		for range batches {
+			p.recordBatch("error")
+		}
+		retryAt := p.timestamp().Add(retryDelay(maxAttempts(operations)))
+		markErr := p.markFailed(ctx, batches, applyErr.Error(), retryAt)
+		if markErr != nil {
+			return true, errors.Join(applyErr, markErr)
+		}
+		return true, fmt.Errorf("apply metering outbox batches %v: %w", batchIDs(batches), applyErr)
+	}
+	for _, operation := range operations {
 		p.recordOperation(operation.Type, "success")
 	}
-	if err := p.store.MarkDelivered(ctx, batch.ID, p.config.WorkerID); err != nil {
-		p.recordBatch("error")
+	if err := p.markDelivered(ctx, batches); err != nil {
+		for range batches {
+			p.recordBatch("error")
+		}
 		return true, err
 	}
-	p.recordBatch("success")
+	for range batches {
+		p.recordBatch("success")
+	}
 	return true, nil
+}
+
+func (p *Projector) claimBatches(ctx context.Context) ([]*Batch, error) {
+	batchSink, supportsBatchSink := p.sink.(BatchSink)
+	store, supportsCoalescing := p.store.(coalescingProjectionStore)
+	if supportsBatchSink && batchSink != nil && supportsCoalescing {
+		return store.ClaimNextBatches(
+			ctx,
+			p.config.WorkerID,
+			p.config.ClaimLease,
+			p.config.MaxDeliveryBatches,
+			p.config.MaxDeliveryOps,
+		)
+	}
+	batch, err := p.store.ClaimNextBatch(ctx, p.config.WorkerID, p.config.ClaimLease)
+	if err != nil || batch == nil {
+		return nil, err
+	}
+	return []*Batch{batch}, nil
+}
+
+func (p *Projector) applyOperations(ctx context.Context, operations []*Operation) error {
+	if sink, ok := p.sink.(BatchSink); ok && sink != nil {
+		batch, err := decodeProjectionBatch(operations)
+		if err != nil {
+			return err
+		}
+		return sink.ApplyProjectionBatch(ctx, batch)
+	}
+	for _, operation := range operations {
+		if err := p.apply(ctx, operation); err != nil {
+			return fmt.Errorf("operation %d (%s): %w", operation.Sequence, operation.Type, err)
+		}
+	}
+	return nil
+}
+
+func (p *Projector) markDelivered(ctx context.Context, batches []*Batch) error {
+	if store, ok := p.store.(coalescingProjectionStore); ok && len(batches) > 1 {
+		return store.MarkDeliveredBatches(ctx, batchIDs(batches), p.config.WorkerID)
+	}
+	return p.store.MarkDelivered(ctx, batches[0].ID, p.config.WorkerID)
+}
+
+func (p *Projector) markFailed(ctx context.Context, batches []*Batch, message string, retryAt time.Time) error {
+	if store, ok := p.store.(coalescingProjectionStore); ok && len(batches) > 1 {
+		return store.MarkFailedBatches(ctx, batchIDs(batches), p.config.WorkerID, message, retryAt)
+	}
+	return p.store.MarkFailed(ctx, batches[0].ID, p.config.WorkerID, message, retryAt)
+}
+
+func orderedOperations(batches []*Batch) []*Operation {
+	operations := make([]*Operation, 0)
+	for _, batch := range batches {
+		if batch == nil {
+			continue
+		}
+		operations = append(operations, batch.Operations...)
+	}
+	sort.Slice(operations, func(i, j int) bool {
+		return operations[i].Sequence < operations[j].Sequence
+	})
+	return operations
+}
+
+func batchIDs(batches []*Batch) []int64 {
+	ids := make([]int64, 0, len(batches))
+	for _, batch := range batches {
+		if batch != nil {
+			ids = append(ids, batch.ID)
+		}
+	}
+	return ids
+}
+
+func maxAttempts(operations []*Operation) int {
+	attempts := 1
+	for _, operation := range operations {
+		if operation != nil && operation.Attempts > attempts {
+			attempts = operation.Attempts
+		}
+	}
+	return attempts
+}
+
+func decodeProjectionBatch(operations []*Operation) (*metering.ProjectionBatch, error) {
+	batch := &metering.ProjectionBatch{}
+	for _, operation := range operations {
+		if operation == nil {
+			return nil, fmt.Errorf("metering outbox operation is nil")
+		}
+		switch operation.Type {
+		case OperationEvent:
+			value := &metering.Event{}
+			if err := json.Unmarshal(operation.Payload, value); err != nil {
+				return nil, fmt.Errorf("decode event operation %d: %w", operation.Sequence, err)
+			}
+			value.Sequence = operation.Sequence
+			batch.Events = append(batch.Events, value)
+		case OperationWindow:
+			value := &metering.Window{}
+			if err := json.Unmarshal(operation.Payload, value); err != nil {
+				return nil, fmt.Errorf("decode window operation %d: %w", operation.Sequence, err)
+			}
+			value.Sequence = operation.Sequence
+			batch.Windows = append(batch.Windows, value)
+		case OperationWatermark:
+			value := &WatermarkOperation{}
+			if err := json.Unmarshal(operation.Payload, value); err != nil {
+				return nil, fmt.Errorf("decode watermark operation %d: %w", operation.Sequence, err)
+			}
+			batch.Watermarks = append(batch.Watermarks, &metering.ProducerWatermark{
+				Producer:       value.Producer,
+				RegionID:       value.RegionID,
+				CompleteBefore: value.CompleteBefore,
+			})
+		case OperationSandboxState:
+			value := &metering.SandboxProjectionState{}
+			if err := json.Unmarshal(operation.Payload, value); err != nil {
+				return nil, fmt.Errorf("decode sandbox state operation %d: %w", operation.Sequence, err)
+			}
+			batch.SandboxStates = append(batch.SandboxStates, value)
+		case OperationStorageState:
+			value := &metering.StorageProjectionState{}
+			if err := json.Unmarshal(operation.Payload, value); err != nil {
+				return nil, fmt.Errorf("decode storage state operation %d: %w", operation.Sequence, err)
+			}
+			batch.StorageMutations = append(batch.StorageMutations, &metering.StorageProjectionMutation{
+				State: value,
+			})
+		case OperationStorageStateDelete:
+			value := &metering.StorageProjectionStateTombstone{}
+			if err := json.Unmarshal(operation.Payload, value); err != nil {
+				return nil, fmt.Errorf("decode storage state delete operation %d: %w", operation.Sequence, err)
+			}
+			if value.State == nil {
+				return nil, fmt.Errorf("storage state delete operation %d is missing state", operation.Sequence)
+			}
+			batch.StorageMutations = append(batch.StorageMutations, &metering.StorageProjectionMutation{
+				State:     value.State,
+				Deleted:   true,
+				DeletedAt: value.DeletedAt,
+			})
+		default:
+			return nil, fmt.Errorf("unsupported metering outbox operation type %q", operation.Type)
+		}
+	}
+	return batch, nil
 }
 
 func (p *Projector) apply(ctx context.Context, operation *Operation) error {

--- a/pkg/metering/outbox/projector_test.go
+++ b/pkg/metering/outbox/projector_test.go
@@ -65,6 +65,20 @@ type fakeSink struct {
 	failWindowOnce      bool
 }
 
+type fakeBatchSink struct {
+	*fakeSink
+	batches []*metering.ProjectionBatch
+	err     error
+}
+
+func (f *fakeBatchSink) ApplyProjectionBatch(_ context.Context, batch *metering.ProjectionBatch) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.batches = append(f.batches, batch)
+	return nil
+}
+
 func (f *fakeSink) AppendEvent(_ context.Context, value *metering.Event) error {
 	f.events = append(f.events, value)
 	return nil
@@ -183,6 +197,208 @@ func TestProjectorAppliesProjectionStateOperations(t *testing.T) {
 	if len(sink.sandboxStates) != 1 || len(sink.storageStates) != 1 || len(sink.storageStateDeletes) != 1 || len(sink.watermarks) != 1 {
 		t.Fatalf("applied operations = sandbox:%d storage:%d delete:%d watermark:%d",
 			len(sink.sandboxStates), len(sink.storageStates), len(sink.storageStateDeletes), len(sink.watermarks))
+	}
+}
+
+type fakeCoalescingProjectionStore struct {
+	batches       []*Batch
+	claimed       bool
+	deliveredIDs  []int64
+	failedIDs     []int64
+	maxBatches    int
+	maxOperations int
+}
+
+func (f *fakeCoalescingProjectionStore) ClaimNextBatch(context.Context, string, time.Duration) (*Batch, error) {
+	if len(f.batches) == 0 {
+		return nil, nil
+	}
+	return f.batches[0], nil
+}
+
+func (f *fakeCoalescingProjectionStore) ClaimNextBatches(
+	_ context.Context,
+	_ string,
+	_ time.Duration,
+	maxBatches int,
+	maxOperations int,
+) ([]*Batch, error) {
+	if f.claimed {
+		return nil, nil
+	}
+	f.claimed = true
+	f.maxBatches = maxBatches
+	f.maxOperations = maxOperations
+	return f.batches, nil
+}
+
+func (f *fakeCoalescingProjectionStore) MarkDelivered(context.Context, int64, string) error {
+	return errors.New("single-batch delivery should not be used")
+}
+
+func (f *fakeCoalescingProjectionStore) MarkDeliveredBatches(_ context.Context, ids []int64, _ string) error {
+	f.deliveredIDs = append([]int64(nil), ids...)
+	return nil
+}
+
+func (f *fakeCoalescingProjectionStore) MarkFailed(context.Context, int64, string, string, time.Time) error {
+	return errors.New("single-batch failure should not be used")
+}
+
+func (f *fakeCoalescingProjectionStore) MarkFailedBatches(
+	_ context.Context,
+	ids []int64,
+	_ string,
+	_ string,
+	_ time.Time,
+) error {
+	f.failedIDs = append([]int64(nil), ids...)
+	return nil
+}
+
+func (f *fakeCoalescingProjectionStore) DeleteDeliveredBefore(context.Context, time.Time, int) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeCoalescingProjectionStore) Stats(context.Context) (*Stats, error) {
+	return &Stats{}, nil
+}
+
+func TestProjectorCoalescesConsecutiveTransactionsForBatchSink(t *testing.T) {
+	now := time.Date(2026, 7, 28, 10, 0, 0, 0, time.UTC)
+	event := &metering.Event{
+		EventID:     "event-1",
+		Producer:    "producer-1",
+		EventType:   metering.EventTypeSandboxClaimed,
+		SubjectType: metering.SubjectTypeSandbox,
+		SubjectID:   "sandbox-1",
+		OccurredAt:  now,
+		RecordedAt:  now,
+	}
+	window := &metering.Window{
+		WindowID:    "window-1",
+		Producer:    "producer-1",
+		WindowType:  metering.WindowTypeSandboxEgressBytes,
+		SubjectType: metering.SubjectTypeSandbox,
+		SubjectID:   "sandbox-1",
+		WindowStart: now,
+		WindowEnd:   now.Add(time.Minute),
+		Value:       1,
+		Unit:        metering.WindowUnitBytes,
+		RecordedAt:  now,
+	}
+	watermark := &WatermarkOperation{
+		Producer:       "producer-1",
+		RegionID:       "region-1",
+		CompleteBefore: now.Add(time.Minute),
+	}
+	storageState := &metering.StorageProjectionState{
+		SubjectType: metering.SubjectTypeVolume,
+		SubjectID:   "volume-1",
+		ObservedAt:  now,
+	}
+	store := &fakeCoalescingProjectionStore{batches: []*Batch{
+		{
+			ID: 10,
+			Operations: []*Operation{
+				{Sequence: 2, BatchID: 10, Type: OperationWindow, Payload: mustMarshal(t, window), Attempts: 1},
+				{Sequence: 1, BatchID: 10, Type: OperationEvent, Payload: mustMarshal(t, event), Attempts: 1},
+			},
+		},
+		{
+			ID: 11,
+			Operations: []*Operation{
+				{
+					Sequence: 3,
+					BatchID:  11,
+					Type:     OperationStorageStateDelete,
+					Payload: mustMarshal(t, &StorageStateDeleteOperation{
+						State:     storageState,
+						DeletedAt: now,
+					}),
+					Attempts: 1,
+				},
+				{Sequence: 4, BatchID: 11, Type: OperationStorageState, Payload: mustMarshal(t, storageState), Attempts: 1},
+				{Sequence: 5, BatchID: 11, Type: OperationWatermark, Payload: mustMarshal(t, watermark), Attempts: 1},
+			},
+		},
+	}}
+	sink := &fakeBatchSink{fakeSink: &fakeSink{}}
+	projector := NewProjector(store, sink, ProjectorConfig{WorkerID: "worker-1"}, nil)
+
+	if processed, err := projector.ProjectOnce(context.Background()); !processed || err != nil {
+		t.Fatalf("ProjectOnce() = (%v, %v)", processed, err)
+	}
+	if store.maxBatches != defaultDeliveryBatches || store.maxOperations != defaultDeliveryOperations {
+		t.Fatalf("claim limits = (%d, %d)", store.maxBatches, store.maxOperations)
+	}
+	if len(store.deliveredIDs) != 2 || store.deliveredIDs[0] != 10 || store.deliveredIDs[1] != 11 {
+		t.Fatalf("delivered batch IDs = %v", store.deliveredIDs)
+	}
+	if len(sink.batches) != 1 {
+		t.Fatalf("projection batch calls = %d, want 1", len(sink.batches))
+	}
+	batch := sink.batches[0]
+	if len(batch.Events) != 1 || batch.Events[0].Sequence != 1 ||
+		len(batch.Windows) != 1 || batch.Windows[0].Sequence != 2 ||
+		len(batch.StorageMutations) != 2 || !batch.StorageMutations[0].Deleted || batch.StorageMutations[1].Deleted ||
+		len(batch.Watermarks) != 1 || batch.Watermarks[0].Producer != watermark.Producer {
+		t.Fatalf("decoded projection batch = %#v", batch)
+	}
+}
+
+func TestProjectorReleasesEveryCoalescedTransactionOnBatchFailure(t *testing.T) {
+	now := time.Date(2026, 7, 28, 10, 0, 0, 0, time.UTC)
+	event := &metering.Event{
+		EventID:     "event-1",
+		Producer:    "producer-1",
+		EventType:   metering.EventTypeSandboxClaimed,
+		SubjectType: metering.SubjectTypeSandbox,
+		SubjectID:   "sandbox-1",
+		OccurredAt:  now,
+		RecordedAt:  now,
+	}
+	store := &fakeCoalescingProjectionStore{batches: []*Batch{
+		{
+			ID: 10,
+			Operations: []*Operation{{
+				Sequence: 1,
+				BatchID:  10,
+				Type:     OperationEvent,
+				Payload:  mustMarshal(t, event),
+				Attempts: 1,
+			}},
+		},
+		{
+			ID: 11,
+			Operations: []*Operation{{
+				Sequence: 2,
+				BatchID:  11,
+				Type:     OperationWatermark,
+				Payload: mustMarshal(t, &WatermarkOperation{
+					Producer:       "producer-1",
+					CompleteBefore: now,
+				}),
+				Attempts: 1,
+			}},
+		},
+	}}
+	sink := &fakeBatchSink{
+		fakeSink: &fakeSink{},
+		err:      errors.New("clickhouse unavailable"),
+	}
+	projector := NewProjector(store, sink, ProjectorConfig{WorkerID: "worker-1"}, nil)
+	projector.now = func() time.Time { return now }
+
+	processed, err := projector.ProjectOnce(context.Background())
+	if !processed || err == nil {
+		t.Fatalf("ProjectOnce() = (%v, %v), want processed failure", processed, err)
+	}
+	if len(store.failedIDs) != 2 || store.failedIDs[0] != 10 || store.failedIDs[1] != 11 {
+		t.Fatalf("failed batch IDs = %v", store.failedIDs)
+	}
+	if len(store.deliveredIDs) != 0 {
+		t.Fatalf("delivered batch IDs = %v, want none", store.deliveredIDs)
 	}
 }
 

--- a/pkg/metering/outbox/repository.go
+++ b/pkg/metering/outbox/repository.go
@@ -396,6 +396,23 @@ func (r *Repository) FlushStorageProjectionWindows(ctx context.Context, before t
 }
 
 func (r *Repository) ClaimNextBatch(ctx context.Context, workerID string, lease time.Duration) (*Batch, error) {
+	batches, err := r.ClaimNextBatches(ctx, workerID, lease, 1, 1)
+	if err != nil || len(batches) == 0 {
+		return nil, err
+	}
+	return batches[0], nil
+}
+
+// ClaimNextBatches leases consecutive ready transaction batches without
+// skipping the global outbox head. The first transaction is always claimed in
+// full, even when it contains more than maxOperations operations.
+func (r *Repository) ClaimNextBatches(
+	ctx context.Context,
+	workerID string,
+	lease time.Duration,
+	maxBatches int,
+	maxOperations int,
+) ([]*Batch, error) {
 	if r == nil || r.pool == nil {
 		return nil, fmt.Errorf("metering outbox pool is not configured")
 	}
@@ -405,111 +422,266 @@ func (r *Repository) ClaimNextBatch(ctx context.Context, workerID string, lease 
 	if lease <= 0 {
 		lease = 30 * time.Second
 	}
-	var batch *Batch
+	if maxBatches <= 0 {
+		maxBatches = 1
+	}
+	if maxOperations <= 0 {
+		maxOperations = 1
+	}
+	var batches []*Batch
 	err := r.InTx(ctx, func(tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, claimLockID); err != nil {
 			return fmt.Errorf("lock metering outbox claim: %w", err)
 		}
-		var batchID int64
-		var availableAt time.Time
-		var claimExpiresAt *time.Time
-		err := tx.QueryRow(ctx, `
-			SELECT batch_id, available_at, claim_expires_at
+
+		candidateRows, err := tx.Query(ctx, `
+			SELECT batch_id
 			FROM metering.projection_outbox
 			WHERE delivered_at IS NULL
 			ORDER BY sequence ASC
-			LIMIT 1
-			FOR UPDATE
-		`).Scan(&batchID, &availableAt, &claimExpiresAt)
-		if err == pgx.ErrNoRows {
-			return nil
-		}
+			LIMIT $1
+		`, max(maxBatches, maxOperations))
 		if err != nil {
-			return fmt.Errorf("select oldest metering outbox batch: %w", err)
+			return fmt.Errorf("select oldest metering outbox batches: %w", err)
 		}
-		now := r.timestamp()
-		if availableAt.After(now) || (claimExpiresAt != nil && claimExpiresAt.After(now)) {
+		defer candidateRows.Close()
+
+		candidateIDs := make([]int64, 0, maxBatches)
+		seenCandidates := make(map[int64]struct{}, maxBatches)
+		for candidateRows.Next() {
+			var batchID int64
+			if err := candidateRows.Scan(&batchID); err != nil {
+				return fmt.Errorf("scan oldest metering outbox batch ID: %w", err)
+			}
+			if _, seen := seenCandidates[batchID]; seen {
+				continue
+			}
+			seenCandidates[batchID] = struct{}{}
+			candidateIDs = append(candidateIDs, batchID)
+			if len(candidateIDs) >= maxBatches {
+				break
+			}
+		}
+		if err := candidateRows.Err(); err != nil {
+			return fmt.Errorf("iterate oldest metering outbox batch IDs: %w", err)
+		}
+		candidateRows.Close()
+		if len(candidateIDs) == 0 {
 			return nil
 		}
-		rows, err := tx.Query(ctx, `
+
+		now := r.timestamp()
+		type candidateState struct {
+			count          int
+			availableAt    time.Time
+			claimExpiresAt *time.Time
+		}
+		states := make(map[int64]candidateState, len(candidateIDs))
+		stateRows, err := tx.Query(ctx, `
+			SELECT
+				batch_id,
+				COUNT(*),
+				MAX(available_at),
+				MAX(claim_expires_at)
+			FROM metering.projection_outbox
+			WHERE batch_id = ANY($1::bigint[]) AND delivered_at IS NULL
+			GROUP BY batch_id
+		`, candidateIDs)
+		if err != nil {
+			return fmt.Errorf("inspect oldest metering outbox batches: %w", err)
+		}
+		defer stateRows.Close()
+		for stateRows.Next() {
+			var (
+				batchID int64
+				state   candidateState
+			)
+			if err := stateRows.Scan(&batchID, &state.count, &state.availableAt, &state.claimExpiresAt); err != nil {
+				return fmt.Errorf("scan oldest metering outbox batch: %w", err)
+			}
+			states[batchID] = state
+		}
+		if err := stateRows.Err(); err != nil {
+			return fmt.Errorf("iterate oldest metering outbox batches: %w", err)
+		}
+		stateRows.Close()
+
+		batchIDs := make([]int64, 0, maxBatches)
+		operationCount := 0
+		for _, batchID := range candidateIDs {
+			state, ok := states[batchID]
+			if !ok {
+				continue
+			}
+			if state.availableAt.After(now) || (state.claimExpiresAt != nil && state.claimExpiresAt.After(now)) {
+				break
+			}
+			if len(batchIDs) > 0 && operationCount+state.count > maxOperations {
+				break
+			}
+			batchIDs = append(batchIDs, batchID)
+			operationCount += state.count
+			if operationCount >= maxOperations {
+				break
+			}
+		}
+		if len(batchIDs) == 0 {
+			return nil
+		}
+
+		claimedRows, err := tx.Query(ctx, `
 			UPDATE metering.projection_outbox
 			SET claimed_by = $2,
 				claim_expires_at = $3,
 				attempts = attempts + 1
-			WHERE batch_id = $1 AND delivered_at IS NULL
+			WHERE batch_id = ANY($1::bigint[]) AND delivered_at IS NULL
 			RETURNING sequence, batch_id, operation_type, dedupe_key, payload,
 				attempts, created_at, claim_expires_at
-		`, batchID, workerID, now.Add(lease))
+		`, batchIDs, workerID, now.Add(lease))
 		if err != nil {
-			return fmt.Errorf("claim metering outbox batch: %w", err)
+			return fmt.Errorf("claim metering outbox batches: %w", err)
 		}
-		defer rows.Close()
-		operations := make([]*Operation, 0, 4)
-		for rows.Next() {
+		defer claimedRows.Close()
+		byID := make(map[int64][]*Operation, len(batchIDs))
+		for claimedRows.Next() {
 			operation := &Operation{}
-			if err := rows.Scan(
+			if err := claimedRows.Scan(
 				&operation.Sequence, &operation.BatchID, &operation.Type,
 				&operation.DedupeKey, &operation.Payload, &operation.Attempts,
 				&operation.CreatedAt, &operation.ClaimExpiresAt,
 			); err != nil {
 				return fmt.Errorf("scan claimed metering operation: %w", err)
 			}
-			operations = append(operations, operation)
+			byID[operation.BatchID] = append(byID[operation.BatchID], operation)
 		}
-		if err := rows.Err(); err != nil {
+		if err := claimedRows.Err(); err != nil {
 			return fmt.Errorf("iterate claimed metering operations: %w", err)
 		}
-		if len(operations) > 0 {
+		for _, batchID := range batchIDs {
+			operations := byID[batchID]
+			if len(operations) == 0 {
+				return fmt.Errorf("claimed metering outbox batch %d has no operations", batchID)
+			}
 			sort.Slice(operations, func(i, j int) bool {
 				return operations[i].Sequence < operations[j].Sequence
 			})
-			batch = &Batch{ID: batchID, Operations: operations}
+			batches = append(batches, &Batch{ID: batchID, Operations: operations})
 		}
 		return nil
 	})
-	return batch, err
+	return batches, err
 }
 
 func (r *Repository) MarkDelivered(ctx context.Context, batchID int64, workerID string) error {
+	return r.MarkDeliveredBatches(ctx, []int64{batchID}, workerID)
+}
+
+// MarkDeliveredBatches atomically acknowledges every claimed transaction.
+func (r *Repository) MarkDeliveredBatches(ctx context.Context, batchIDs []int64, workerID string) error {
 	if r == nil || r.pool == nil {
 		return fmt.Errorf("metering outbox pool is not configured")
 	}
-	tag, err := r.pool.Exec(ctx, `
-		UPDATE metering.projection_outbox
-		SET delivered_at = NOW(),
-			claimed_by = '',
-			claim_expires_at = NULL,
-			last_error = ''
-		WHERE batch_id = $1 AND delivered_at IS NULL AND claimed_by = $2
-	`, batchID, workerID)
-	if err != nil {
-		return fmt.Errorf("mark metering outbox batch delivered: %w", err)
+	if len(batchIDs) == 0 {
+		return nil
 	}
-	if tag.RowsAffected() == 0 {
-		return fmt.Errorf("metering outbox batch %d is not claimed by %q", batchID, workerID)
-	}
-	return nil
+	return r.InTx(ctx, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			UPDATE metering.projection_outbox
+			SET delivered_at = NOW(),
+				claimed_by = '',
+				claim_expires_at = NULL,
+				last_error = ''
+			WHERE batch_id = ANY($1::bigint[])
+				AND delivered_at IS NULL
+				AND claimed_by = $2
+			RETURNING batch_id
+		`, batchIDs, workerID)
+		if err != nil {
+			return fmt.Errorf("mark metering outbox batches delivered: %w", err)
+		}
+		delivered, err := returnedBatchIDs(rows)
+		if err != nil {
+			return fmt.Errorf("read delivered metering outbox batches: %w", err)
+		}
+		if missing := missingBatchIDs(batchIDs, delivered); len(missing) > 0 {
+			return fmt.Errorf("metering outbox batches %v are not claimed by %q", missing, workerID)
+		}
+		return nil
+	})
 }
 
 func (r *Repository) MarkFailed(ctx context.Context, batchID int64, workerID, message string, retryAt time.Time) error {
+	return r.MarkFailedBatches(ctx, []int64{batchID}, workerID, message, retryAt)
+}
+
+// MarkFailedBatches atomically releases every transaction in a failed
+// ClickHouse delivery attempt.
+func (r *Repository) MarkFailedBatches(
+	ctx context.Context,
+	batchIDs []int64,
+	workerID string,
+	message string,
+	retryAt time.Time,
+) error {
 	if r == nil || r.pool == nil {
 		return fmt.Errorf("metering outbox pool is not configured")
+	}
+	if len(batchIDs) == 0 {
+		return nil
 	}
 	if retryAt.IsZero() {
 		retryAt = r.timestamp()
 	}
-	_, err := r.pool.Exec(ctx, `
-		UPDATE metering.projection_outbox
-		SET available_at = $3,
-			claimed_by = '',
-			claim_expires_at = NULL,
-			last_error = $4
-		WHERE batch_id = $1 AND delivered_at IS NULL AND claimed_by = $2
-	`, batchID, workerID, retryAt.UTC(), truncateError(message))
-	if err != nil {
-		return fmt.Errorf("release failed metering outbox batch: %w", err)
+	return r.InTx(ctx, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			UPDATE metering.projection_outbox
+			SET available_at = $3,
+				claimed_by = '',
+				claim_expires_at = NULL,
+				last_error = $4
+			WHERE batch_id = ANY($1::bigint[])
+				AND delivered_at IS NULL
+				AND claimed_by = $2
+			RETURNING batch_id
+		`, batchIDs, workerID, retryAt.UTC(), truncateError(message))
+		if err != nil {
+			return fmt.Errorf("release failed metering outbox batches: %w", err)
+		}
+		released, err := returnedBatchIDs(rows)
+		if err != nil {
+			return fmt.Errorf("read released metering outbox batches: %w", err)
+		}
+		if missing := missingBatchIDs(batchIDs, released); len(missing) > 0 {
+			return fmt.Errorf("metering outbox batches %v are not claimed by %q", missing, workerID)
+		}
+		return nil
+	})
+}
+
+func returnedBatchIDs(rows pgx.Rows) (map[int64]struct{}, error) {
+	defer rows.Close()
+	result := make(map[int64]struct{})
+	for rows.Next() {
+		var batchID int64
+		if err := rows.Scan(&batchID); err != nil {
+			return nil, err
+		}
+		result[batchID] = struct{}{}
 	}
-	return nil
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func missingBatchIDs(expected []int64, actual map[int64]struct{}) []int64 {
+	missing := make([]int64, 0)
+	for _, batchID := range expected {
+		if _, ok := actual[batchID]; !ok {
+			missing = append(missing, batchID)
+		}
+	}
+	return missing
 }
 
 func (r *Repository) Stats(ctx context.Context) (*Stats, error) {

--- a/pkg/metering/outbox/repository_integration_test.go
+++ b/pkg/metering/outbox/repository_integration_test.go
@@ -196,6 +196,86 @@ func TestRepositoryStorageProjectionIsAtomicWithCallerTransaction(t *testing.T) 
 	}
 }
 
+func TestRepositoryClaimsAndAcknowledgesConsecutiveBatchesAtomically(t *testing.T) {
+	pool := newMeteringTestDatabase(t)
+	ctx := context.Background()
+	if err := RunMigrations(ctx, pool, nil); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+	repo := NewRepository(pool)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	for index := 0; index < 3; index++ {
+		window := &metering.Window{
+			WindowID:    "window-" + string(rune('1'+index)),
+			Producer:    "producer-1",
+			WindowType:  metering.WindowTypeSandboxEgressBytes,
+			SubjectType: metering.SubjectTypeSandbox,
+			SubjectID:   "sandbox-1",
+			WindowStart: now,
+			WindowEnd:   now.Add(time.Minute),
+			Value:       1,
+			Unit:        metering.WindowUnitBytes,
+		}
+		if err := repo.AppendWindow(ctx, window); err != nil {
+			t.Fatalf("AppendWindow(%d): %v", index, err)
+		}
+	}
+
+	batches, err := repo.ClaimNextBatches(ctx, "worker-1", 30*time.Second, 10, 2)
+	if err != nil {
+		t.Fatalf("ClaimNextBatches: %v", err)
+	}
+	if len(batches) != 2 || len(batches[0].Operations) != 1 || len(batches[1].Operations) != 1 {
+		t.Fatalf("claimed batches = %#v", batches)
+	}
+	ids := []int64{batches[0].ID, batches[1].ID}
+	if err := repo.MarkDeliveredBatches(ctx, []int64{ids[0], -1}, "worker-1"); err == nil {
+		t.Fatal("MarkDeliveredBatches accepted a missing batch")
+	}
+	assertCount(t, pool, `
+		SELECT COUNT(*)
+		FROM metering.projection_outbox
+		WHERE batch_id = ANY($1::bigint[]) AND delivered_at IS NULL
+	`, 2, ids)
+	if err := repo.MarkDeliveredBatches(ctx, ids, "worker-1"); err != nil {
+		t.Fatalf("MarkDeliveredBatches: %v", err)
+	}
+
+	remaining, err := repo.ClaimNextBatches(ctx, "worker-1", 30*time.Second, 10, 10)
+	if err != nil || len(remaining) != 1 {
+		t.Fatalf("remaining ClaimNextBatches = (%#v, %v)", remaining, err)
+	}
+	if err := repo.MarkFailedBatches(
+		ctx,
+		[]int64{remaining[0].ID},
+		"worker-1",
+		"retry later",
+		time.Now().UTC().Add(time.Hour),
+	); err != nil {
+		t.Fatalf("MarkFailedBatches: %v", err)
+	}
+	if err := repo.AppendWindow(ctx, &metering.Window{
+		WindowID:    "window-4",
+		Producer:    "producer-1",
+		WindowType:  metering.WindowTypeSandboxEgressBytes,
+		SubjectType: metering.SubjectTypeSandbox,
+		SubjectID:   "sandbox-1",
+		WindowStart: now,
+		WindowEnd:   now.Add(time.Minute),
+		Value:       1,
+		Unit:        metering.WindowUnitBytes,
+	}); err != nil {
+		t.Fatalf("AppendWindow(4): %v", err)
+	}
+	blocked, err := repo.ClaimNextBatches(ctx, "worker-2", 30*time.Second, 10, 10)
+	if err != nil {
+		t.Fatalf("blocked ClaimNextBatches: %v", err)
+	}
+	if len(blocked) != 0 {
+		t.Fatalf("ClaimNextBatches skipped the retrying global head: %#v", blocked)
+	}
+}
+
 func TestMigrationsUpgradeLegacyVersionFiveSchema(t *testing.T) {
 	pool := newMeteringTestDatabase(t)
 	ctx := context.Background()
@@ -236,9 +316,14 @@ func TestMigrationsUpgradeLegacyVersionFiveSchema(t *testing.T) {
 		t.Fatalf("upgrade legacy schema: %v", err)
 	}
 	assertCount(t, pool, `SELECT COUNT(*) FROM metering.goose_db_version WHERE version_id = 6 AND is_applied`, 1)
+	assertCount(t, pool, `SELECT COUNT(*) FROM metering.goose_db_version WHERE version_id = 7 AND is_applied`, 1)
 	var tableName string
 	if err := pool.QueryRow(ctx, `SELECT to_regclass('metering.projection_outbox')::text`).Scan(&tableName); err != nil || tableName == "" {
 		t.Fatalf("projection_outbox after migration = %q, %v", tableName, err)
+	}
+	var indexName string
+	if err := pool.QueryRow(ctx, `SELECT to_regclass('metering.idx_projection_outbox_pending_batch')::text`).Scan(&indexName); err != nil || indexName == "" {
+		t.Fatalf("pending batch index after migration = %q, %v", indexName, err)
 	}
 }
 
@@ -350,10 +435,10 @@ func newMeteringTestDatabase(t *testing.T) *pgxpool.Pool {
 	return pool
 }
 
-func assertCount(t *testing.T, pool *pgxpool.Pool, query string, want int64) {
+func assertCount(t *testing.T, pool *pgxpool.Pool, query string, want int64, args ...any) {
 	t.Helper()
 	var got int64
-	if err := pool.QueryRow(context.Background(), query).Scan(&got); err != nil {
+	if err := pool.QueryRow(context.Background(), query, args...).Scan(&got); err != nil {
 		t.Fatalf("query count %q: %v", query, err)
 	}
 	if got != want {

--- a/pkg/metering/outbox/types.go
+++ b/pkg/metering/outbox/types.go
@@ -24,10 +24,7 @@ type WatermarkOperation struct {
 	CompleteBefore time.Time `json:"complete_before"`
 }
 
-type StorageStateDeleteOperation struct {
-	State     *metering.StorageProjectionState `json:"state"`
-	DeletedAt time.Time                        `json:"deleted_at"`
-}
+type StorageStateDeleteOperation = metering.StorageProjectionStateTombstone
 
 // Operation is one idempotent ClickHouse mutation captured in PostgreSQL.
 type Operation struct {
@@ -55,6 +52,13 @@ type Sink interface {
 	UpsertSandboxProjectionState(context.Context, *metering.SandboxProjectionState) error
 	UpsertStorageProjectionState(context.Context, *metering.StorageProjectionState) error
 	DeleteStorageProjectionState(context.Context, *metering.StorageProjectionState, time.Time) error
+}
+
+// BatchSink applies several ordered outbox transactions with a bounded number
+// of ClickHouse INSERT statements. Implementations must be idempotent because
+// a partially accepted batch is retried in full.
+type BatchSink interface {
+	ApplyProjectionBatch(context.Context, *metering.ProjectionBatch) error
 }
 
 // Stats summarizes outstanding delivery work.

--- a/pkg/metering/types.go
+++ b/pkg/metering/types.go
@@ -146,6 +146,32 @@ type StorageProjectionState struct {
 	UnbilledByteNanoseconds int64     `json:"unbilled_byte_nanoseconds,omitempty"`
 }
 
+// StorageProjectionStateTombstone records a versioned deletion in the
+// ClickHouse storage projection.
+type StorageProjectionStateTombstone struct {
+	State     *StorageProjectionState `json:"state"`
+	DeletedAt time.Time               `json:"deleted_at"`
+}
+
+// StorageProjectionMutation preserves the outbox order of upserts and
+// tombstones that target the same ClickHouse projection table.
+type StorageProjectionMutation struct {
+	State     *StorageProjectionState
+	Deleted   bool
+	DeletedAt time.Time
+}
+
+// ProjectionBatch is one or more ordered PostgreSQL outbox transactions
+// decoded for an idempotent ClickHouse delivery attempt. Watermarks are
+// applied only after every data and state row in the batch.
+type ProjectionBatch struct {
+	Events           []*Event
+	Windows          []*Window
+	Watermarks       []*ProducerWatermark
+	SandboxStates    []*SandboxProjectionState
+	StorageMutations []*StorageProjectionMutation
+}
+
 type StorageObservation struct {
 	SubjectType       string    `json:"subject_type"`
 	SubjectID         string    `json:"subject_id"`

--- a/tools/clickhouse-oss-gc/main.go
+++ b/tools/clickhouse-oss-gc/main.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/sandbox0-ai/sandbox0/internal/clickhouseobjectgc"
+)
+
+type options struct {
+	mode              string
+	bucket            string
+	prefix            string
+	region            string
+	endpoint          string
+	pathStyle         bool
+	livePathsFile     string
+	manifestFile      string
+	minObjectAge      time.Duration
+	minManifestAge    time.Duration
+	maxDeleteFraction float64
+	minLivePaths      int
+	confirmPrefix     string
+	overwriteManifest bool
+}
+
+func main() {
+	if err := run(context.Background(), parseOptions()); err != nil {
+		fmt.Fprintln(os.Stderr, "clickhouse-oss-gc:", err)
+		os.Exit(1)
+	}
+}
+
+func parseOptions() options {
+	var cfg options
+	flag.StringVar(&cfg.mode, "mode", "scan", "scan or apply")
+	flag.StringVar(&cfg.bucket, "bucket", "", "object storage bucket")
+	flag.StringVar(&cfg.prefix, "prefix", "", "non-root ClickHouse object prefix")
+	flag.StringVar(&cfg.region, "region", "us-east-1", "S3 signing region")
+	flag.StringVar(&cfg.endpoint, "endpoint", "", "S3-compatible endpoint")
+	flag.BoolVar(&cfg.pathStyle, "path-style", true, "use path-style S3 requests")
+	flag.StringVar(&cfg.livePathsFile, "live-paths", "", "newline-delimited union of ClickHouse live remote paths")
+	flag.StringVar(&cfg.manifestFile, "manifest", "", "candidate manifest path")
+	flag.DurationVar(&cfg.minObjectAge, "min-object-age", 72*time.Hour, "minimum orphan object age")
+	flag.DurationVar(&cfg.minManifestAge, "min-manifest-age", time.Hour, "minimum delay between scan and apply")
+	flag.Float64Var(&cfg.maxDeleteFraction, "max-delete-fraction", 0.25, "maximum candidate/listed object ratio allowed on apply")
+	flag.IntVar(&cfg.minLivePaths, "min-live-paths", 1, "minimum live paths required on apply")
+	flag.StringVar(&cfg.confirmPrefix, "confirm-prefix", "", "must exactly match --prefix in apply mode")
+	flag.BoolVar(&cfg.overwriteManifest, "overwrite-manifest", false, "replace an existing scan manifest")
+	flag.Parse()
+	return cfg
+}
+
+func run(ctx context.Context, cfg options) error {
+	cfg.mode = strings.ToLower(strings.TrimSpace(cfg.mode))
+	if cfg.mode != "scan" && cfg.mode != "apply" {
+		return fmt.Errorf("unsupported mode %q", cfg.mode)
+	}
+	if strings.TrimSpace(cfg.livePathsFile) == "" {
+		return fmt.Errorf("--live-paths is required")
+	}
+	if strings.TrimSpace(cfg.manifestFile) == "" {
+		return fmt.Errorf("--manifest is required")
+	}
+	livePaths, err := readLivePaths(cfg.livePathsFile, cfg.bucket)
+	if err != nil {
+		return err
+	}
+
+	awsCfg, err := awsconfig.LoadDefaultConfig(
+		ctx,
+		awsconfig.WithRegion(strings.TrimSpace(cfg.region)),
+		awsconfig.WithRequestChecksumCalculation(aws.RequestChecksumCalculationWhenRequired),
+		awsconfig.WithResponseChecksumValidation(aws.ResponseChecksumValidationWhenRequired),
+	)
+	if err != nil {
+		return fmt.Errorf("load S3 configuration: %w", err)
+	}
+	client := s3.NewFromConfig(awsCfg, func(options *s3.Options) {
+		options.UsePathStyle = cfg.pathStyle
+		if endpoint := strings.TrimRight(strings.TrimSpace(cfg.endpoint), "/"); endpoint != "" {
+			options.BaseEndpoint = aws.String(endpoint)
+		}
+	})
+	reconciler, err := clickhouseobjectgc.New(client, cfg.bucket, cfg.prefix)
+	if err != nil {
+		return err
+	}
+
+	if cfg.mode == "scan" {
+		manifest, err := reconciler.Scan(ctx, livePaths, cfg.minObjectAge)
+		if err != nil {
+			return err
+		}
+		if err := writeManifest(cfg.manifestFile, manifest, cfg.overwriteManifest); err != nil {
+			return err
+		}
+		return printJSON(struct {
+			Mode             string    `json:"mode"`
+			Bucket           string    `json:"bucket"`
+			Prefix           string    `json:"prefix"`
+			GeneratedAt      time.Time `json:"generated_at"`
+			Cutoff           time.Time `json:"cutoff"`
+			LivePaths        int       `json:"live_paths"`
+			ListedObjects    int       `json:"listed_objects"`
+			ListedBytes      int64     `json:"listed_bytes"`
+			CandidateObjects int       `json:"candidate_objects"`
+			CandidateBytes   int64     `json:"candidate_bytes"`
+			Manifest         string    `json:"manifest"`
+		}{
+			Mode:             "scan",
+			Bucket:           manifest.Bucket,
+			Prefix:           manifest.Prefix,
+			GeneratedAt:      manifest.GeneratedAt,
+			Cutoff:           manifest.Cutoff,
+			LivePaths:        manifest.LivePathCount,
+			ListedObjects:    manifest.ListedObjectCount,
+			ListedBytes:      manifest.ListedBytes,
+			CandidateObjects: len(manifest.Candidates),
+			CandidateBytes:   manifest.CandidateBytes,
+			Manifest:         cfg.manifestFile,
+		})
+	}
+
+	if strings.Trim(strings.TrimSpace(cfg.confirmPrefix), "/") != strings.Trim(strings.TrimSpace(cfg.prefix), "/") {
+		return fmt.Errorf("--confirm-prefix must exactly match --prefix")
+	}
+	manifest, err := readManifest(cfg.manifestFile)
+	if err != nil {
+		return err
+	}
+	result, err := reconciler.Delete(ctx, manifest, livePaths, clickhouseobjectgc.DeleteOptions{
+		Now:               time.Now().UTC(),
+		MinObjectAge:      cfg.minObjectAge,
+		MinManifestAge:    cfg.minManifestAge,
+		MaxDeleteFraction: cfg.maxDeleteFraction,
+		MinLivePaths:      cfg.minLivePaths,
+	})
+	if err != nil {
+		return err
+	}
+	return printJSON(struct {
+		Mode   string                           `json:"mode"`
+		Result *clickhouseobjectgc.DeleteResult `json:"result"`
+	}{
+		Mode:   "apply",
+		Result: result,
+	})
+}
+
+func readLivePaths(path, bucket string) (map[string]struct{}, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open live paths: %w", err)
+	}
+	defer file.Close()
+	prefix := "oss://" + strings.TrimSpace(bucket) + "/"
+	paths := make(map[string]struct{})
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		path := strings.TrimSpace(scanner.Text())
+		path = strings.TrimPrefix(path, prefix)
+		if path != "" {
+			paths[path] = struct{}{}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read live paths: %w", err)
+	}
+	return paths, nil
+}
+
+func writeManifest(path string, manifest *clickhouseobjectgc.Manifest, overwrite bool) error {
+	if !overwrite {
+		if _, err := os.Stat(path); err == nil {
+			return fmt.Errorf("manifest %q already exists; use --overwrite-manifest to replace it", path)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("inspect manifest path: %w", err)
+		}
+	}
+	dir := filepath.Dir(path)
+	temp, err := os.CreateTemp(dir, ".clickhouse-oss-gc-*.json")
+	if err != nil {
+		return fmt.Errorf("create manifest: %w", err)
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+	if err := temp.Chmod(0o600); err != nil {
+		temp.Close()
+		return fmt.Errorf("protect manifest: %w", err)
+	}
+	encoder := json.NewEncoder(temp)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(manifest); err != nil {
+		temp.Close()
+		return fmt.Errorf("encode manifest: %w", err)
+	}
+	if err := temp.Sync(); err != nil {
+		temp.Close()
+		return fmt.Errorf("sync manifest: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("close manifest: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("commit manifest: %w", err)
+	}
+	return nil
+}
+
+func readManifest(path string) (*clickhouseobjectgc.Manifest, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open manifest: %w", err)
+	}
+	defer file.Close()
+	manifest := &clickhouseobjectgc.Manifest{}
+	if err := json.NewDecoder(file).Decode(manifest); err != nil {
+		return nil, fmt.Errorf("decode manifest: %w", err)
+	}
+	return manifest, nil
+}
+
+func printJSON(value any) error {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(value)
+}


### PR DESCRIPTION
## Summary

- coalesce consecutive PostgreSQL metering outbox transactions into bounded batches of at most 500 operations
- issue multi-row ClickHouse inserts per projection table, preserve storage mutation order, and advance watermarks only after all data/state writes succeed
- keep PostgreSQL as the synchronous producer boundary; audit delivery code and its canonical-sync acknowledgement contract are unchanged
- add a concurrent pending-batch index so batching does not block producer writes
- add a guarded, exact-key OSS reconciler with separate scan/apply phases, live-path rechecks, age/fraction bounds, and 1,000-key delete batches

## Production evidence

The one-time guarded reconciliation for `clickhouse/ali-ue1/` removed 147,740 confirmed orphan objects (4,466,232,139 bytes). A fresh two-snapshot scan found zero remaining candidates older than 72 hours, while recent metering and audit rows remained queryable. This PR does not deploy or restart any service.

## Verification

- `go test ./pkg/metering/... ./internal/clickhouseobjectgc ./tools/clickhouse-oss-gc`
- PostgreSQL 16 integration tests for migrations, coalesced claims, strict head ordering, retries, and atomic acknowledgement
- `go vet ./pkg/metering/... ./internal/clickhouseobjectgc ./tools/clickhouse-oss-gc`
- full `go test -p 2 ./...` package/unit run passed until the Kind e2e suite, which could not start because `kind` is not installed in this workspace