### PR TITLE
Document rootfs object encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ More examples:
 | SandboxVolume | Durable storage independent of one sandbox identity | Yes | Repos, caches, agent memory, artifacts, shared data, snapshots, forks |
 | Metering, quota, and policy state | Control-plane storage | Yes | Usage truth, policy audit, quota, showback, and export |
 
+By default, Sandbox0 encrypts persisted rootfs checkpoint objects and S0FS Volume objects at the application layer before writing them to S3-compatible storage. This is service-side rather than end-to-end encryption: manager and the active ctld hold the installation key and can decrypt these objects. Self-hosted deployments control this behavior with `spec.storage.runtime.objectEncryptionEnabled`.
+
 `ttl` pauses idle runtime compute after checkpointing the writable root filesystem. `hard_ttl` deletes the sandbox identity and state tied to it. Long-running agents should treat the runtime as replaceable and put durable state in volumes, rootfs checkpoints, event logs, or external storage.
 
 ## Network And Credentials

--- a/docs/sandbox/snapshot-restore/page.mdx
+++ b/docs/sandbox/snapshot-restore/page.mdx
@@ -41,6 +41,12 @@ Use [Volumes](/docs/sandbox/volume) when data must be mounted by multiple sandbo
 The rootfs snapshot API stores snapshot metadata including `name`, `description`, and optional `expires_at`. Delete snapshots explicitly when cleanup workflows no longer need them.
 </Callout>
 
+## Storage Encryption
+
+Application-layer object encryption is enabled by default. Before manager or ctld writes persisted rootfs layer and checkpoint objects to S3-compatible storage, Sandbox0 encrypts them with AES-256-GCM. Each object receives a random data key, its contents are stored in independently authenticated chunks, and the data key is wrapped with the installation's RSA key.
+
+This is service-side encryption, not end-to-end encryption: manager and the active ctld hold the installation key and can decrypt rootfs objects while serving sandbox operations. Existing plaintext objects remain readable after encryption is enabled, while new object writes use the encrypted format; enabling encryption does not rewrite historical objects automatically. Self-hosted deployments can configure this behavior with `spec.storage.runtime.objectEncryptionEnabled`; see [Service and Runtime Config](/docs/sandbox/self-hosted/configuration#service-and-runtime-config).
+
 ## Initialize Once, Claim Many
 
 Rootfs snapshots plus claim-time `snapshot_id` can act like a lightweight custom rootfs when your changes are ordinary filesystem state. Instead of building a custom image and maintaining a team-owned warm pool, start from a builtin template, initialize the sandbox, publish a rootfs snapshot, then claim new sandboxes from that snapshot.

--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -656,7 +656,7 @@ Examples:
 - `storage.runtime.s0fsSegmentTargetSize` sets the target S0FS segment size for materialized volume data; the default is `4Mi`
 - `storage.runtime.s0fsCompaction*` tunes background S0FS compaction for RWO volume owners; `s0fsCompactionInterval` accepts `0`, `off`, or `disabled` to turn it off
 - `storage.runtime.cacheSizeLimit` and `logSizeLimit` cap storage cache and logs in the manager Pod; `volumePortalCacheSizeLimit` and `volumePortalRootMinFree` tune the volume portals used by ctld
-- `storage.runtime.objectEncryptionEnabled` controls application-layer encryption for S0FS object storage and node-local volume cache files; it is enabled by default
+- `storage.runtime.objectEncryptionEnabled` controls application-layer encryption for persisted rootfs checkpoint objects, S0FS Volume objects, and node-local S0FS volume cache files; it is enabled by default
 - `network.config.egressBandwidthBytesPerSecond`, `ingressBandwidthBytesPerSecond`, and `bandwidthBurstBytes` apply per-sandbox bandwidth throttling when set above zero
 - `services.manager.config.defaultTeamQuotas` configures region-wide capacity, API request, and network bandwidth defaults; see [Team Quotas](/docs/sandbox/self-hosted/quotas)
 - `network.config.*` also controls proxy ports, policy enforcement, and node-level networking behavior


### PR DESCRIPTION
## What

- document that persisted rootfs checkpoint objects are encrypted before S3-compatible object storage by default
- describe the AES-256-GCM envelope format and installation-key trust boundary
- clarify the self-hosted configuration surface and plaintext backward compatibility
- extend the existing storage configuration description to cover rootfs objects

## Why

Rootfs persistence already uses Sandbox0's application-layer object encryption, but the README and rootfs snapshot documentation did not state that guarantee. This change makes the persisted-object boundary explicit without describing it as end-to-end encryption or extending the claim to node-local rootfs cache data.

## Impact

Documentation only. No runtime behavior or API contract changes.

## Checks

- `git diff --check`
- `go test ./storage-proxy/pkg/objectstore ./manager/cmd/manager ./infra-operator/internal/runtimeconfig`
