### PR TITLE
Fix audited chunked proxy responses

### DIFF
--- a/cluster-gateway/pkg/http/audit.go
+++ b/cluster-gateway/pkg/http/audit.go
@@ -464,14 +464,15 @@ func (w *auditBufferedResponseWriter) WriteString(value string) (int, error) {
 	return w.Write([]byte(value))
 }
 
-// Streaming and connection takeover would expose a response before its audit
-// result reaches canonical storage. Record those attempts as delivery errors
-// instead of forwarding them to the underlying writer.
+// Flush records the response status but keeps all bytes buffered. ReverseProxy
+// uses Flush as a transport hint for chunked responses, so rejecting it would
+// turn a successful upstream mutation into a response-copy failure.
 func (w *auditBufferedResponseWriter) Flush() {
 	w.WriteHeaderNow()
-	w.setUnsupportedError("streaming flush")
 }
 
+// Connection takeover would expose a response before its audit result reaches
+// canonical storage, so it remains unsupported.
 func (w *auditBufferedResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	err := w.setUnsupportedError("connection hijacking")
 	return nil, nil, err

--- a/cluster-gateway/pkg/http/audit_test.go
+++ b/cluster-gateway/pkg/http/audit_test.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -268,7 +270,46 @@ func TestAuditBufferedResponseWriterCommitsHeadersAtomically(t *testing.T) {
 	}
 }
 
-func TestAuditBufferedResponseWriterRejectsBypassInterfaces(t *testing.T) {
+func TestAuditBufferedResponseWriterBuffersChunkedReverseProxyResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		_, _ = w.Write([]byte(`{"status":"updated"}`))
+	}))
+	defer upstream.Close()
+
+	target, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	buffered := newAuditBufferedResponseWriter(c.Writer, 1024)
+	request := httptest.NewRequest(http.MethodPut, "/api/v1/sandboxes/sb-1", nil)
+	requestContext, cancel := context.WithCancel(request.Context())
+	defer cancel()
+	request = request.WithContext(context.WithValue(requestContext, http.ServerContextKey, &http.Server{}))
+
+	proxy.ServeHTTP(buffered, request)
+
+	if buffered.err != nil {
+		t.Fatalf("buffered response error = %v", buffered.err)
+	}
+	if recorder.Body.Len() != 0 {
+		t.Fatalf("response reached client before commit: %q", recorder.Body.String())
+	}
+	if err := buffered.commit(); err != nil {
+		t.Fatalf("commit() error = %v", err)
+	}
+	if recorder.Code != http.StatusOK || recorder.Body.String() != `{"status":"updated"}` {
+		t.Fatalf("committed response = %d %q", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestAuditBufferedResponseWriterControlsOptionalInterfaces(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	t.Run("flush", func(t *testing.T) {
@@ -276,8 +317,14 @@ func TestAuditBufferedResponseWriterRejectsBypassInterfaces(t *testing.T) {
 		c, _ := gin.CreateTestContext(recorder)
 		buffered := newAuditBufferedResponseWriter(c.Writer, 1024)
 		buffered.Flush()
-		if buffered.err == nil || !strings.Contains(buffered.err.Error(), "streaming flush") {
+		if buffered.err != nil {
 			t.Fatalf("Flush() error = %v", buffered.err)
+		}
+		if _, err := buffered.WriteString("buffered"); err != nil {
+			t.Fatalf("WriteString() after Flush() error = %v", err)
+		}
+		if buffered.body.String() != "buffered" {
+			t.Fatalf("buffered body = %q", buffered.body.String())
 		}
 		if c.Writer.Written() {
 			t.Fatal("Flush() reached the underlying response writer")


### PR DESCRIPTION
Companion Sandpi reconciliation protection: sandbox0-ai/sandpi#5.

## What changed

- Treat `ResponseWriter.Flush` as an advisory hint while mutation responses remain buffered for canonical audit delivery.
- Keep connection hijacking blocked and preserve the existing 8 MiB response limit.
- Add a regression test that sends a chunked upstream response through `httputil.ReverseProxy` and verifies it remains atomic until commit.

## Why

Go's reverse proxy automatically flushes chunked responses. The audit buffer previously recorded that flush as an unsupported streaming error, so copying a successful manager response ended with `net/http: abort Handler`. The mutation had already completed, but the caller received a 500.

## Impact

Audited mutation responses can now pass through the cluster gateway without turning successful operations into ambiguous failures. Canonical audit acknowledgement still precedes delivery to the client.

## Validation

- `go test ./cluster-gateway/... -count=1`
