### PR TITLE
fix: isolate and recover stalled sandbox runtimes

### DIFF
--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -25,6 +25,7 @@ import (
 	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/dbpool"
+	"github.com/sandbox0-ai/sandbox0/pkg/fuseportal"
 	"github.com/sandbox0-ai/sandbox0/pkg/k8s"
 	meteringoutbox "github.com/sandbox0-ai/sandbox0/pkg/metering/outbox"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
@@ -306,8 +307,15 @@ func runPrimary(parent context.Context, options primaryRunOptions) error {
 	serviceErrors := make(chan error, 1)
 	networkRequired := options.networkFactory != nil
 	var networkHandle *primaryServiceHandle
+	multiplexerHealth := fuseportal.SharedMultiplexerHealth
+	if err := multiplexerHealth(); err != nil {
+		return fmt.Errorf("initialize shared FUSE multiplexer health: %w", err)
+	}
+	serviceHealthy := func() bool {
+		return ctx.Err() == nil && multiplexerHealth() == nil
+	}
 	serviceReady := func() bool {
-		return ctx.Err() == nil && portalManager.RecoveryError() == nil &&
+		return serviceHealthy() && portalManager.RecoveryError() == nil &&
 			(registrationServer == nil || registrationServer.Registered()) &&
 			(!networkRequired || (networkHandle != nil && networkHandle.Ready()))
 	}
@@ -318,10 +326,11 @@ func runPrimary(parent context.Context, options primaryRunOptions) error {
 	defer containerdRuntime.Close()
 	runtimeMetricsHandle := startCtldRuntimeMetrics(ctx, ctldCfg, containerdRuntime, podCache, obsProvider, zapLogger)
 	httpServer := newHTTPServer(httpAddr, combinedController{
-		Controller: probeController,
-		Portal:     portalManager,
-		RootFS:     buildRootFSController(ctx, storageCfg, objectStoreRequestMeter, portalManager, containerdRuntime),
-		ReadyCheck: serviceReady,
+		Controller:  probeController,
+		Portal:      portalManager,
+		RootFS:      buildRootFSController(ctx, storageCfg, objectStoreRequestMeter, portalManager, containerdRuntime),
+		ReadyCheck:  serviceReady,
+		HealthCheck: serviceHealthy,
 	})
 	if obsProvider != nil {
 		httpServer.Handler = httpobs.ServerMiddleware(obsProvider.HTTPServerConfig(zapLogger))(httpServer.Handler)
@@ -349,6 +358,7 @@ func runPrimary(parent context.Context, options primaryRunOptions) error {
 			serviceErrors <- fmt.Errorf("ctld HTTP server: %w", err)
 		}
 	}()
+	go monitorPrimaryServiceHealth(ctx, time.Second, multiplexerHealth, serviceErrors)
 
 	if options.setReady != nil {
 		options.setReady(serviceReady())
@@ -661,13 +671,43 @@ func newPortalStorageObserver(
 
 type combinedController struct {
 	ctldserver.Controller
-	Portal     volumePortalHandler
-	RootFS     rootFSHandler
-	ReadyCheck func() bool
+	Portal      volumePortalHandler
+	RootFS      rootFSHandler
+	ReadyCheck  func() bool
+	HealthCheck func() bool
 }
 
 func (c combinedController) Ready() bool {
 	return c.ReadyCheck == nil || c.ReadyCheck()
+}
+
+func (c combinedController) Healthy() bool {
+	return c.HealthCheck == nil || c.HealthCheck()
+}
+
+func monitorPrimaryServiceHealth(ctx context.Context, interval time.Duration, check func() error, failures chan<- error) {
+	if check == nil || failures == nil {
+		return
+	}
+	if interval <= 0 {
+		interval = time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		if err := check(); err != nil {
+			select {
+			case failures <- fmt.Errorf("ctld primary health: %w", err):
+			case <-ctx.Done():
+			}
+			return
+		}
+	}
 }
 
 func (c combinedController) BindVolumePortal(r *http.Request, req ctldapi.BindVolumePortalRequest) (ctldapi.BindVolumePortalResponse, int) {

--- a/ctld/cmd/ctld/main_test.go
+++ b/ctld/cmd/ctld/main_test.go
@@ -60,6 +60,47 @@ func TestCtldHealthEndpoints(t *testing.T) {
 	assert.Equal(t, "ok", rec.Body.String())
 }
 
+func TestCombinedControllerExposesPrimaryHealth(t *testing.T) {
+	healthy := false
+	server := newHTTPServer(":0", combinedController{
+		Controller:  ctldserver.NotImplementedController{},
+		ReadyCheck:  func() bool { return healthy },
+		HealthCheck: func() bool { return healthy },
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	server.Handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+
+	healthy = true
+	rec = httptest.NewRecorder()
+	server.Handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestMonitorPrimaryServiceHealthReportsFailure(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	failures := make(chan error, 1)
+	checks := 0
+	go monitorPrimaryServiceHealth(ctx, time.Millisecond, func() error {
+		checks++
+		if checks < 2 {
+			return nil
+		}
+		return fmt.Errorf("multiplexer stalled")
+	}, failures)
+
+	select {
+	case err := <-failures:
+		require.ErrorContains(t, err, "ctld primary health")
+		require.ErrorContains(t, err, "multiplexer stalled")
+	case <-time.After(time.Second):
+		t.Fatal("primary service health failure was not reported")
+	}
+}
+
 func TestCtldPauseResumeStubsReturnNotImplemented(t *testing.T) {
 	server := newHTTPServer(":0", nil)
 

--- a/ctld/internal/ctld/rootfs/containerd_runtime.go
+++ b/ctld/internal/ctld/rootfs/containerd_runtime.go
@@ -42,6 +42,8 @@ const (
 
 type criRuntimeService interface {
 	ListContainers(ctx context.Context, in *runtimeapi.ListContainersRequest, opts ...grpc.CallOption) (*runtimeapi.ListContainersResponse, error)
+	ListPodSandbox(ctx context.Context, in *runtimeapi.ListPodSandboxRequest, opts ...grpc.CallOption) (*runtimeapi.ListPodSandboxResponse, error)
+	PodSandboxStats(ctx context.Context, in *runtimeapi.PodSandboxStatsRequest, opts ...grpc.CallOption) (*runtimeapi.PodSandboxStatsResponse, error)
 	ListPodSandboxStats(ctx context.Context, in *runtimeapi.ListPodSandboxStatsRequest, opts ...grpc.CallOption) (*runtimeapi.ListPodSandboxStatsResponse, error)
 }
 
@@ -422,6 +424,40 @@ func (r *ContainerdRuntime) ListPodSandboxStats(ctx context.Context) ([]*runtime
 	resp, err := client.ListPodSandboxStats(ctx, &runtimeapi.ListPodSandboxStatsRequest{})
 	if err != nil {
 		return nil, fmt.Errorf("list CRI pod sandbox stats: %w", err)
+	}
+	return resp.GetStats(), nil
+}
+
+// ListPodSandboxes returns ready node-local CRI sandboxes for isolated stats
+// fallback after a bulk stats failure.
+func (r *ContainerdRuntime) ListPodSandboxes(ctx context.Context) ([]*runtimeapi.PodSandbox, error) {
+	client, err := r.runtimeClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.ListPodSandbox(ctx, &runtimeapi.ListPodSandboxRequest{
+		Filter: &runtimeapi.PodSandboxFilter{
+			State: &runtimeapi.PodSandboxStateValue{State: runtimeapi.PodSandboxState_SANDBOX_READY},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list CRI pod sandboxes: %w", err)
+	}
+	return resp.GetItems(), nil
+}
+
+// PodSandboxStats returns one isolated CRI sandbox stats sample.
+func (r *ContainerdRuntime) PodSandboxStats(ctx context.Context, sandboxID string) (*runtimeapi.PodSandboxStats, error) {
+	client, err := r.runtimeClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.PodSandboxStats(ctx, &runtimeapi.PodSandboxStatsRequest{PodSandboxId: sandboxID})
+	if err != nil {
+		return nil, fmt.Errorf("get CRI pod sandbox %s stats: %w", sandboxID, err)
+	}
+	if resp.GetStats() == nil {
+		return nil, fmt.Errorf("get CRI pod sandbox %s stats: empty response", sandboxID)
 	}
 	return resp.GetStats(), nil
 }

--- a/ctld/internal/ctld/rootfs/containerd_runtime_test.go
+++ b/ctld/internal/ctld/rootfs/containerd_runtime_test.go
@@ -213,6 +213,40 @@ func TestListPodSandboxStatsWrapsCRIError(t *testing.T) {
 	require.ErrorContains(t, err, "list CRI pod sandbox stats")
 }
 
+func TestListPodSandboxesReturnsReadyCRIItems(t *testing.T) {
+	want := []*runtimeapi.PodSandbox{{
+		Id:       "sandbox-1",
+		Metadata: &runtimeapi.PodSandboxMetadata{Namespace: "ns-a", Name: "pod-a", Uid: "uid-a"},
+		State:    runtimeapi.PodSandboxState_SANDBOX_READY,
+	}}
+	runtime := NewContainerdRuntime(ContainerdRuntimeConfig{CRIClient: fakeCRIClient{sandboxes: want}})
+
+	got, err := runtime.ListPodSandboxes(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestPodSandboxStatsUsesIsolatedCRIRequest(t *testing.T) {
+	want := minimalRuntimePodStats("sandbox-1")
+	runtime := NewContainerdRuntime(ContainerdRuntimeConfig{CRIClient: fakeCRIClient{
+		statsByID: map[string]*runtimeapi.PodSandboxStats{"sandbox-1": want},
+	}})
+
+	got, err := runtime.PodSandboxStats(context.Background(), "sandbox-1")
+
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestPodSandboxStatsRejectsEmptyCRIResponse(t *testing.T) {
+	runtime := NewContainerdRuntime(ContainerdRuntimeConfig{CRIClient: fakeCRIClient{}})
+
+	_, err := runtime.PodSandboxStats(context.Background(), "sandbox-1")
+
+	require.ErrorContains(t, err, "empty response")
+}
+
 func TestContainerdRuntimeReusesAndClosesCRIConnection(t *testing.T) {
 	listener := bufconn.Listen(1024 * 1024)
 	server := grpc.NewServer()
@@ -327,7 +361,9 @@ func TestNormalizeContainerID(t *testing.T) {
 
 type fakeCRIClient struct {
 	containers []*runtimeapi.Container
+	sandboxes  []*runtimeapi.PodSandbox
 	stats      []*runtimeapi.PodSandboxStats
+	statsByID  map[string]*runtimeapi.PodSandboxStats
 	err        error
 }
 
@@ -348,11 +384,32 @@ func (c fakeCRIClient) ListContainers(_ context.Context, _ *runtimeapi.ListConta
 	return &runtimeapi.ListContainersResponse{Containers: c.containers}, nil
 }
 
+func (c fakeCRIClient) ListPodSandbox(_ context.Context, _ *runtimeapi.ListPodSandboxRequest, _ ...grpc.CallOption) (*runtimeapi.ListPodSandboxResponse, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	return &runtimeapi.ListPodSandboxResponse{Items: c.sandboxes}, nil
+}
+
+func (c fakeCRIClient) PodSandboxStats(_ context.Context, req *runtimeapi.PodSandboxStatsRequest, _ ...grpc.CallOption) (*runtimeapi.PodSandboxStatsResponse, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	return &runtimeapi.PodSandboxStatsResponse{Stats: c.statsByID[req.PodSandboxId]}, nil
+}
+
 func (c fakeCRIClient) ListPodSandboxStats(_ context.Context, _ *runtimeapi.ListPodSandboxStatsRequest, _ ...grpc.CallOption) (*runtimeapi.ListPodSandboxStatsResponse, error) {
 	if c.err != nil {
 		return nil, c.err
 	}
 	return &runtimeapi.ListPodSandboxStatsResponse{Stats: c.stats}, nil
+}
+
+func minimalRuntimePodStats(id string) *runtimeapi.PodSandboxStats {
+	return &runtimeapi.PodSandboxStats{
+		Attributes: &runtimeapi.PodSandboxAttributes{Id: id},
+		Linux:      &runtimeapi.LinuxPodSandboxStats{},
+	}
 }
 
 func writeTaskConfig(t *testing.T, taskDir string, annotations map[string]string) {

--- a/ctld/internal/ctld/runtimemetrics/collector.go
+++ b/ctld/internal/ctld/runtimemetrics/collector.go
@@ -2,8 +2,10 @@ package runtimemetrics
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
+	"sort"
 	"sync"
 	"time"
 
@@ -18,6 +20,13 @@ type StatsClient interface {
 	ListPodSandboxStats(context.Context) ([]*runtimeapi.PodSandboxStats, error)
 }
 
+// PerSandboxStatsClient provides the bounded fallback used when a node-wide
+// CRI stats request is poisoned by one unresponsive runtime.
+type PerSandboxStatsClient interface {
+	ListPodSandboxes(context.Context) ([]*runtimeapi.PodSandbox, error)
+	PodSandboxStats(context.Context, string) (*runtimeapi.PodSandboxStats, error)
+}
+
 // SampleSink is the bounded asynchronous handoff used by the collector.
 type SampleSink interface {
 	TryEnqueue(sandboxobservability.RuntimeSample) bool
@@ -25,34 +34,45 @@ type SampleSink interface {
 
 // CollectorConfig configures node identity, cadence, and producer dependencies.
 type CollectorConfig struct {
-	RegionID    string
-	ClusterID   string
-	NodeName    string
-	Interval    time.Duration
-	Jitter      time.Duration
-	Now         func() time.Time
-	Random      func() float64
-	Logger      *zap.Logger
-	StatsClient StatsClient
-	PodLister   corelisters.PodLister
-	Sink        SampleSink
+	RegionID                 string
+	ClusterID                string
+	NodeName                 string
+	Interval                 time.Duration
+	Jitter                   time.Duration
+	BulkRequestTimeout       time.Duration
+	FallbackMaxConcurrency   int
+	FallbackMaxSandboxes     int
+	FallbackRequestTimeout   time.Duration
+	FallbackCollectionBudget time.Duration
+	Now                      func() time.Time
+	Random                   func() float64
+	Logger                   *zap.Logger
+	StatsClient              StatsClient
+	PodLister                corelisters.PodLister
+	Sink                     SampleSink
 }
 
 // Collector maps CRI pod sandbox stats to sandbox runtime samples.
 type Collector struct {
-	collectMu   sync.Mutex
-	regionID    string
-	clusterID   string
-	nodeName    string
-	interval    time.Duration
-	jitter      time.Duration
-	now         func() time.Time
-	random      func() float64
-	logger      *zap.Logger
-	statsClient StatsClient
-	podLister   corelisters.PodLister
-	sink        SampleSink
-	cpuUsage    *cpuUsageTracker
+	collectMu                sync.Mutex
+	regionID                 string
+	clusterID                string
+	nodeName                 string
+	interval                 time.Duration
+	jitter                   time.Duration
+	bulkRequestTimeout       time.Duration
+	fallbackMaxConcurrency   int
+	fallbackMaxSandboxes     int
+	fallbackRequestTimeout   time.Duration
+	fallbackCollectionBudget time.Duration
+	fallbackCursor           int
+	now                      func() time.Time
+	random                   func() float64
+	logger                   *zap.Logger
+	statsClient              StatsClient
+	podLister                corelisters.PodLister
+	sink                     SampleSink
+	cpuUsage                 *cpuUsageTracker
 }
 
 // CollectResult summarizes one bulk collection attempt.
@@ -61,6 +81,20 @@ type CollectResult struct {
 	Matched       int
 	Enqueued      int
 	Dropped       int
+	Failed        int
+	Fallback      bool
+}
+
+const (
+	defaultBulkRequestTimeout       = 3 * time.Second
+	defaultFallbackMaxConcurrency   = 4
+	defaultFallbackMaxSandboxes     = 16
+	defaultFallbackRequestTimeout   = 2 * time.Second
+	defaultFallbackCollectionBudget = 10 * time.Second
+)
+
+type fallbackTarget struct {
+	id string
 }
 
 // NewCollector creates a node-local bulk CRI runtime metric collector.
@@ -86,6 +120,21 @@ func NewCollector(cfg CollectorConfig) (*Collector, error) {
 	if cfg.Jitter >= cfg.Interval {
 		cfg.Jitter = cfg.Interval / 2
 	}
+	if cfg.BulkRequestTimeout <= 0 {
+		cfg.BulkRequestTimeout = defaultBulkRequestTimeout
+	}
+	if cfg.FallbackMaxConcurrency <= 0 {
+		cfg.FallbackMaxConcurrency = defaultFallbackMaxConcurrency
+	}
+	if cfg.FallbackMaxSandboxes <= 0 {
+		cfg.FallbackMaxSandboxes = defaultFallbackMaxSandboxes
+	}
+	if cfg.FallbackRequestTimeout <= 0 {
+		cfg.FallbackRequestTimeout = defaultFallbackRequestTimeout
+	}
+	if cfg.FallbackCollectionBudget <= 0 {
+		cfg.FallbackCollectionBudget = defaultFallbackCollectionBudget
+	}
 	if cfg.Now == nil {
 		cfg.Now = time.Now
 	}
@@ -96,18 +145,23 @@ func NewCollector(cfg CollectorConfig) (*Collector, error) {
 		cfg.Logger = zap.NewNop()
 	}
 	return &Collector{
-		regionID:    cfg.RegionID,
-		clusterID:   cfg.ClusterID,
-		nodeName:    cfg.NodeName,
-		interval:    cfg.Interval,
-		jitter:      cfg.Jitter,
-		now:         cfg.Now,
-		random:      cfg.Random,
-		logger:      cfg.Logger,
-		statsClient: cfg.StatsClient,
-		podLister:   cfg.PodLister,
-		sink:        cfg.Sink,
-		cpuUsage:    &cpuUsageTracker{},
+		regionID:                 cfg.RegionID,
+		clusterID:                cfg.ClusterID,
+		nodeName:                 cfg.NodeName,
+		interval:                 cfg.Interval,
+		jitter:                   cfg.Jitter,
+		bulkRequestTimeout:       cfg.BulkRequestTimeout,
+		fallbackMaxConcurrency:   cfg.FallbackMaxConcurrency,
+		fallbackMaxSandboxes:     cfg.FallbackMaxSandboxes,
+		fallbackRequestTimeout:   cfg.FallbackRequestTimeout,
+		fallbackCollectionBudget: cfg.FallbackCollectionBudget,
+		now:                      cfg.Now,
+		random:                   cfg.Random,
+		logger:                   cfg.Logger,
+		statsClient:              cfg.StatsClient,
+		podLister:                cfg.PodLister,
+		sink:                     cfg.Sink,
+		cpuUsage:                 &cpuUsageTracker{},
 	}, nil
 }
 
@@ -119,7 +173,13 @@ func (c *Collector) Run(ctx context.Context) {
 	for {
 		result, err := c.Collect(ctx)
 		if err != nil && ctx.Err() == nil {
-			c.logger.Warn("Failed to collect sandbox runtime metrics", zap.Error(err))
+			c.logger.Warn("Failed to collect some sandbox runtime metrics",
+				zap.Error(err),
+				zap.Bool("fallback", result.Fallback),
+				zap.Int("matched", result.Matched),
+				zap.Int("enqueued", result.Enqueued),
+				zap.Int("failed", result.Failed),
+			)
 		} else if result.Dropped > 0 {
 			c.logger.Warn("Dropped sandbox runtime metric samples", zap.Int("dropped", result.Dropped))
 		}
@@ -147,11 +207,18 @@ func (c *Collector) Collect(ctx context.Context) (CollectResult, error) {
 	if err != nil {
 		return CollectResult{}, err
 	}
-	stats, err := c.statsClient.ListPodSandboxStats(ctx)
+	bulkCtx, cancel := context.WithTimeout(ctx, c.bulkRequestTimeout)
+	stats, err := c.statsClient.ListPodSandboxStats(bulkCtx)
+	cancel()
 	if err != nil {
-		return CollectResult{}, fmt.Errorf("list CRI pod sandbox stats: %w", err)
+		return c.collectFallback(ctx, identities, fmt.Errorf("list CRI pod sandbox stats: %w", err))
 	}
+	return c.projectStats(identities, stats, false)
+}
+
+func (c *Collector) projectStats(identities identityIndex, stats []*runtimeapi.PodSandboxStats, fallback bool) (CollectResult, error) {
 	result := CollectResult{StatsReceived: len(stats)}
+	result.Fallback = fallback
 	collectedAt := c.now().UTC()
 	activeCPUSeries := make(map[cpuSeriesKey]struct{})
 	if c.cpuUsage == nil {
@@ -183,8 +250,119 @@ func (c *Collector) Collect(ctx context.Context) (CollectResult, error) {
 			result.Dropped++
 		}
 	}
-	c.cpuUsage.prune(activeCPUSeries)
+	if !fallback {
+		c.cpuUsage.prune(activeCPUSeries)
+	}
 	return result, nil
+}
+
+func (c *Collector) collectFallback(ctx context.Context, identities identityIndex, bulkErr error) (CollectResult, error) {
+	result := CollectResult{Fallback: true}
+	client, ok := c.statsClient.(PerSandboxStatsClient)
+	if !ok {
+		return result, bulkErr
+	}
+	budgetCtx, cancel := context.WithTimeout(ctx, c.fallbackCollectionBudget)
+	defer cancel()
+	sandboxes, err := client.ListPodSandboxes(budgetCtx)
+	if err != nil {
+		return result, errors.Join(bulkErr, fmt.Errorf("list CRI pod sandboxes for fallback: %w", err))
+	}
+	allTargets := fallbackTargets(identities, sandboxes)
+	targets := c.nextFallbackTargets(allTargets)
+	result.Matched = len(targets)
+	if len(targets) == 0 {
+		return result, bulkErr
+	}
+
+	type fallbackResult struct {
+		stats *runtimeapi.PodSandboxStats
+		err   error
+	}
+	results := make([]fallbackResult, len(targets))
+	semaphore := make(chan struct{}, c.fallbackMaxConcurrency)
+	var wg sync.WaitGroup
+dispatch:
+	for i := range targets {
+		select {
+		case semaphore <- struct{}{}:
+		case <-budgetCtx.Done():
+			for j := i; j < len(results); j++ {
+				results[j].err = budgetCtx.Err()
+			}
+			break dispatch
+		}
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			defer func() { <-semaphore }()
+			requestCtx, requestCancel := context.WithTimeout(budgetCtx, c.fallbackRequestTimeout)
+			results[index].stats, results[index].err = client.PodSandboxStats(requestCtx, targets[index].id)
+			requestCancel()
+			if results[index].stats == nil && results[index].err == nil {
+				results[index].err = fmt.Errorf("empty CRI pod sandbox stats")
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	stats := make([]*runtimeapi.PodSandboxStats, 0, len(results))
+	var fallbackErr error
+	for i := range results {
+		if results[i].err != nil {
+			result.Failed++
+			fallbackErr = errors.Join(fallbackErr, fmt.Errorf("collect CRI pod sandbox %s stats: %w", targets[i].id, results[i].err))
+			continue
+		}
+		stats = append(stats, results[i].stats)
+	}
+	projected, projectErr := c.projectStats(identities, stats, true)
+	result.StatsReceived = projected.StatsReceived
+	result.Enqueued = projected.Enqueued
+	result.Dropped = projected.Dropped
+	return result, errors.Join(bulkErr, fallbackErr, projectErr)
+}
+
+func fallbackTargets(identities identityIndex, sandboxes []*runtimeapi.PodSandbox) []fallbackTarget {
+	targets := make([]fallbackTarget, 0, len(sandboxes))
+	seen := make(map[string]struct{}, len(sandboxes))
+	for _, sandbox := range sandboxes {
+		if sandbox == nil || sandbox.Id == "" || sandbox.Metadata == nil ||
+			sandbox.State != runtimeapi.PodSandboxState_SANDBOX_READY {
+			continue
+		}
+		if _, ok := seen[sandbox.Id]; ok {
+			continue
+		}
+		_, ok := identities.resolve(&runtimeapi.PodSandboxAttributes{Metadata: sandbox.Metadata})
+		if !ok {
+			continue
+		}
+		seen[sandbox.Id] = struct{}{}
+		targets = append(targets, fallbackTarget{id: sandbox.Id})
+	}
+	sort.Slice(targets, func(i, j int) bool {
+		return targets[i].id < targets[j].id
+	})
+	return targets
+}
+
+func (c *Collector) nextFallbackTargets(targets []fallbackTarget) []fallbackTarget {
+	if len(targets) == 0 {
+		return nil
+	}
+	limit := c.fallbackMaxSandboxes
+	if limit <= 0 || limit >= len(targets) {
+		c.fallbackCursor = 0
+		return targets
+	}
+	start := c.fallbackCursor % len(targets)
+	selected := make([]fallbackTarget, 0, limit)
+	for i := 0; i < limit; i++ {
+		selected = append(selected, targets[(start+i)%len(targets)])
+	}
+	c.fallbackCursor = (start + limit) % len(targets)
+	return selected
 }
 
 func (c *Collector) nextDelay() time.Duration {

--- a/ctld/internal/ctld/runtimemetrics/collector_test.go
+++ b/ctld/internal/ctld/runtimemetrics/collector_test.go
@@ -92,6 +92,162 @@ func TestCollectorReportsCRIErrorWithoutEnqueuing(t *testing.T) {
 	assert.Empty(t, sink.samples)
 }
 
+func TestCollectorFallsBackToIsolatedStatsAfterBulkFailure(t *testing.T) {
+	podA := runtimeMetricPod("ns-a", "pod-a", "uid-a", "node-a", "team-a", "sandbox-a", "1")
+	podB := runtimeMetricPod("ns-a", "pod-b", "uid-b", "node-a", "team-a", "sandbox-b", "1")
+	client := &fakeStatsClient{
+		err: errors.New("one runtime poisoned bulk stats"),
+		sandboxes: []*runtimeapi.PodSandbox{
+			podSandbox("cri-a", "ns-a", "pod-a", "uid-a"),
+			podSandbox("cri-b", "ns-a", "pod-b", "uid-b"),
+		},
+		statsByID: map[string]*runtimeapi.PodSandboxStats{
+			"cri-b": minimalPodStats("cri-b", "ns-a", "pod-b", "uid-b"),
+		},
+		statsErrByID: map[string]error{"cri-a": errors.New("runtime unavailable")},
+	}
+	sink := &recordingSampleSink{}
+	collector, err := NewCollector(CollectorConfig{
+		StatsClient: client,
+		PodLister:   podLister(t, podA, podB),
+		Sink:        sink,
+		NodeName:    "node-a",
+	})
+	require.NoError(t, err)
+
+	result, err := collector.Collect(context.Background())
+	require.ErrorContains(t, err, "one runtime poisoned bulk stats")
+	require.ErrorContains(t, err, "runtime unavailable")
+	assert.Equal(t, CollectResult{
+		StatsReceived: 1,
+		Matched:       2,
+		Enqueued:      1,
+		Failed:        1,
+		Fallback:      true,
+	}, result)
+	require.Len(t, sink.samples, 1)
+	assert.Equal(t, "sandbox-b", sink.samples[0].SandboxID)
+	assert.ElementsMatch(t, []string{"cri-a", "cri-b"}, client.perSandboxCalls)
+}
+
+func TestCollectorFallsBackWhenBulkStatsTimesOut(t *testing.T) {
+	pod := runtimeMetricPod("ns-a", "pod-a", "uid-a", "node-a", "team-a", "sandbox-a", "1")
+	client := &fakeStatsClient{
+		bulkBlock: make(chan struct{}),
+		sandboxes: []*runtimeapi.PodSandbox{
+			podSandbox("cri-a", "ns-a", "pod-a", "uid-a"),
+		},
+		statsByID: map[string]*runtimeapi.PodSandboxStats{
+			"cri-a": minimalPodStats("cri-a", "ns-a", "pod-a", "uid-a"),
+		},
+	}
+	sink := &recordingSampleSink{}
+	collector, err := NewCollector(CollectorConfig{
+		StatsClient:        client,
+		PodLister:          podLister(t, pod),
+		Sink:               sink,
+		NodeName:           "node-a",
+		BulkRequestTimeout: 10 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	result, err := collector.Collect(context.Background())
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.True(t, result.Fallback)
+	assert.Equal(t, 1, result.Enqueued)
+	require.Len(t, sink.samples, 1)
+	assert.Equal(t, "sandbox-a", sink.samples[0].SandboxID)
+}
+
+func TestCollectorBoundsFallbackConcurrency(t *testing.T) {
+	const sandboxCount = 6
+	pods := make([]*corev1.Pod, 0, sandboxCount)
+	client := &fakeStatsClient{
+		err:       errors.New("bulk unavailable"),
+		statsByID: make(map[string]*runtimeapi.PodSandboxStats, sandboxCount),
+		block:     make(chan struct{}),
+	}
+	for i := 0; i < sandboxCount; i++ {
+		suffix := string(rune('a' + i))
+		name := "pod-" + suffix
+		uid := "uid-" + suffix
+		id := "cri-" + suffix
+		pods = append(pods, runtimeMetricPod("ns-a", name, uid, "node-a", "team-a", "sandbox-"+suffix, "1"))
+		client.sandboxes = append(client.sandboxes, podSandbox(id, "ns-a", name, uid))
+		client.statsByID[id] = minimalPodStats(id, "ns-a", name, uid)
+	}
+	collector, err := NewCollector(CollectorConfig{
+		StatsClient:            client,
+		PodLister:              podLister(t, pods...),
+		Sink:                   &recordingSampleSink{},
+		NodeName:               "node-a",
+		FallbackMaxConcurrency: 2,
+		FallbackRequestTimeout: time.Second,
+	})
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = collector.Collect(context.Background())
+		close(done)
+	}()
+	deadline := time.Now().Add(time.Second)
+	for {
+		client.mu.Lock()
+		active := client.active
+		maxActive := client.maxActive
+		client.mu.Unlock()
+		if active == 2 {
+			assert.LessOrEqual(t, maxActive, 2)
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("fallback collector did not reach configured concurrency")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	close(client.block)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("fallback collection did not complete")
+	}
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	assert.LessOrEqual(t, client.maxActive, 2)
+}
+
+func TestCollectorRotatesBoundedFallbackTargets(t *testing.T) {
+	pods := make([]*corev1.Pod, 0, 3)
+	client := &fakeStatsClient{
+		err:       errors.New("bulk unavailable"),
+		statsByID: make(map[string]*runtimeapi.PodSandboxStats, 3),
+	}
+	for _, suffix := range []string{"a", "b", "c"} {
+		name := "pod-" + suffix
+		uid := "uid-" + suffix
+		id := "cri-" + suffix
+		pods = append(pods, runtimeMetricPod("ns-a", name, uid, "node-a", "team-a", "sandbox-"+suffix, "1"))
+		client.sandboxes = append(client.sandboxes, podSandbox(id, "ns-a", name, uid))
+		client.statsByID[id] = minimalPodStats(id, "ns-a", name, uid)
+	}
+	collector, err := NewCollector(CollectorConfig{
+		StatsClient:            client,
+		PodLister:              podLister(t, pods...),
+		Sink:                   &recordingSampleSink{},
+		NodeName:               "node-a",
+		FallbackMaxSandboxes:   2,
+		FallbackMaxConcurrency: 1,
+	})
+	require.NoError(t, err)
+
+	_, _ = collector.Collect(context.Background())
+	_, _ = collector.Collect(context.Background())
+
+	assert.Equal(t, []string{"cri-a", "cri-b", "cri-c", "cri-a"}, client.perSandboxCalls)
+}
+
 func TestCollectorCountsFullQueueDrops(t *testing.T) {
 	sink := &recordingSampleSink{accept: func(sandboxobservability.RuntimeSample) bool { return false }}
 	collector, err := NewCollector(CollectorConfig{
@@ -159,6 +315,7 @@ func TestCollectorUsesSharedRuntimeSampleCadenceDefaults(t *testing.T) {
 
 	assert.Equal(t, sandboxobservability.DefaultRuntimeSampleInterval, collector.interval)
 	assert.Equal(t, sandboxobservability.DefaultRuntimeSampleJitter, collector.jitter)
+	assert.Equal(t, defaultBulkRequestTimeout, collector.bulkRequestTimeout)
 }
 
 func minimalPodStats(epoch, namespace, name, uid string) *runtimeapi.PodSandboxStats {
@@ -168,6 +325,14 @@ func minimalPodStats(epoch, namespace, name, uid string) *runtimeapi.PodSandboxS
 			Metadata: &runtimeapi.PodSandboxMetadata{Namespace: namespace, Name: name, Uid: uid},
 		},
 		Linux: &runtimeapi.LinuxPodSandboxStats{},
+	}
+}
+
+func podSandbox(id, namespace, name, uid string) *runtimeapi.PodSandbox {
+	return &runtimeapi.PodSandbox{
+		Id:       id,
+		Metadata: &runtimeapi.PodSandboxMetadata{Namespace: namespace, Name: name, Uid: uid},
+		State:    runtimeapi.PodSandboxState_SANDBOX_READY,
 	}
 }
 
@@ -181,22 +346,71 @@ func cpuOnlyPodStats(epoch, namespace, name, uid string, timestamp int64, cumula
 }
 
 type fakeStatsClient struct {
-	mu     sync.Mutex
-	stats  []*runtimeapi.PodSandboxStats
-	err    error
-	calls  int
-	onCall func()
+	mu              sync.Mutex
+	stats           []*runtimeapi.PodSandboxStats
+	err             error
+	calls           int
+	onCall          func()
+	sandboxes       []*runtimeapi.PodSandbox
+	listErr         error
+	statsByID       map[string]*runtimeapi.PodSandboxStats
+	statsErrByID    map[string]error
+	perSandboxCalls []string
+	bulkBlock       chan struct{}
+	block           chan struct{}
+	active          int
+	maxActive       int
 }
 
-func (c *fakeStatsClient) ListPodSandboxStats(context.Context) ([]*runtimeapi.PodSandboxStats, error) {
+func (c *fakeStatsClient) ListPodSandboxStats(ctx context.Context) ([]*runtimeapi.PodSandboxStats, error) {
 	c.mu.Lock()
 	c.calls++
 	onCall := c.onCall
 	stats := c.stats
 	err := c.err
+	bulkBlock := c.bulkBlock
 	c.mu.Unlock()
 	if onCall != nil {
 		onCall()
+	}
+	if bulkBlock != nil {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-bulkBlock:
+		}
+	}
+	return stats, err
+}
+
+func (c *fakeStatsClient) ListPodSandboxes(context.Context) ([]*runtimeapi.PodSandbox, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]*runtimeapi.PodSandbox(nil), c.sandboxes...), c.listErr
+}
+
+func (c *fakeStatsClient) PodSandboxStats(ctx context.Context, id string) (*runtimeapi.PodSandboxStats, error) {
+	c.mu.Lock()
+	c.perSandboxCalls = append(c.perSandboxCalls, id)
+	c.active++
+	if c.active > c.maxActive {
+		c.maxActive = c.active
+	}
+	block := c.block
+	stats := c.statsByID[id]
+	err := c.statsErrByID[id]
+	c.mu.Unlock()
+	defer func() {
+		c.mu.Lock()
+		c.active--
+		c.mu.Unlock()
+	}()
+	if block != nil {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-block:
+		}
 	}
 	return stats, err
 }

--- a/ctld/internal/ctld/server/server.go
+++ b/ctld/internal/ctld/server/server.go
@@ -50,6 +50,13 @@ type ReadinessController interface {
 	Ready() bool
 }
 
+// HealthController contributes fatal primary service state to the ctld health
+// endpoint. A failed health check causes the HA liveness probe to restart the
+// primary so its peer can take over.
+type HealthController interface {
+	Healthy() bool
+}
+
 type NotImplementedController struct{}
 
 func (NotImplementedController) Pause(_ *http.Request, _ string) (ctldapi.PauseResponse, int) {
@@ -98,6 +105,11 @@ func NewMux(controller Controller) http.Handler {
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		if healthController, ok := controller.(HealthController); ok && !healthController.Healthy() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("unhealthy"))
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	})

--- a/ctld/internal/ctld/server/server_test.go
+++ b/ctld/internal/ctld/server/server_test.go
@@ -115,7 +115,7 @@ func TestNewMuxDefaultsToNotImplementedController(t *testing.T) {
 }
 
 func TestNewMuxReadinessIncludesControllerState(t *testing.T) {
-	controller := &readinessTestController{}
+	controller := &readinessTestController{healthy: true}
 	handler := NewMux(controller)
 
 	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
@@ -133,12 +133,35 @@ func TestNewMuxReadinessIncludesControllerState(t *testing.T) {
 	}
 }
 
+func TestNewMuxHealthIncludesControllerState(t *testing.T) {
+	controller := &readinessTestController{ready: true}
+	handler := NewMux(controller)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("unhealthy status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+
+	controller.healthy = true
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("healthy status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
 type readinessTestController struct {
 	NotImplementedController
-	ready bool
+	ready   bool
+	healthy bool
 }
 
 func (c *readinessTestController) Ready() bool { return c.ready }
+func (c *readinessTestController) Healthy() bool {
+	return c.healthy
+}
 
 func TestNewMuxRoutesRootFS(t *testing.T) {
 	controller := &recordingController{}

--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -40,11 +40,15 @@ Runtime access paths do not expose `pausing` or `resuming` states. File, context
 
 Automatic pause from `ttl` is opportunistic. If supported runtime access arrives before an automatic pause reaches its commit point, Sandbox0 cancels that automatic pause, releases the runtime barrier, and continues on the existing runtime generation. Explicit pause requests are not canceled by runtime access; those requests wait for the committed pause and then resume if auto-resume is allowed.
 
-## Unexpected Runtime Termination
+## Runtime Failure Recovery
 
 If the `procd` container in a claimed sandbox exits unexpectedly, including an OOM termination, Sandbox0 leaves that container attempt stopped while `manager` starts a non-cancelable crash-recovery pause. `ctld` checkpoints the exact terminated containerd snapshot, then `manager` atomically commits the new rootfs head and paused state before deleting the old runtime pod. A supported runtime request waits for this transaction and can resume from the recovered checkpoint when auto-resume is allowed.
 
 Explicit sandbox deletion and `hard_ttl` still take precedence over crash recovery. Recovery also depends on the terminated snapshot remaining available on the same node. If the old runtime pod or containerd snapshot disappears before `ctld` can read it, Sandbox0 records the degraded recovery and falls back to the last committed rootfs checkpoint. Files written after that checkpoint may be lost. Mounted Sandbox Volumes keep their independently durable state.
+
+Sandbox0 treats a sustained runtime liveness failure as an internal platform fault. A transient failure does not replace the runtime, but after the failure continues for 90 seconds, manager starts the same durable pause flow and reconstructs the runtime as a new `runtime_generation`. This recovery is independent of the sandbox `auto_resume` access policy.
+
+For an unresponsive runtime, `ctld` gets a bounded checkpoint attempt. If the runtime cannot produce a new checkpoint, recovery preserves the last committed rootfs head and continues so a stuck runtime cannot block replacement indefinitely. Mounted Sandbox Volumes remain independently durable.
 
 <Endpoint method="POST">
 /api/v1/sandboxes/{'{id}'}/pause

--- a/manager/pkg/service/sandbox_crash_recovery.go
+++ b/manager/pkg/service/sandbox_crash_recovery.go
@@ -100,6 +100,75 @@ func (s *SandboxService) RecoverTerminatedSandboxRuntime(ctx context.Context, po
 	return nil
 }
 
+// RecoverUnhealthySandboxRuntime starts a durable pause-and-resume transition
+// after the runtime liveness probe has failed continuously beyond the recovery
+// threshold. Runtime failure recovery is a platform responsibility and does
+// not depend on the sandbox auto-resume access policy.
+func (s *SandboxService) RecoverUnhealthySandboxRuntime(ctx context.Context, pod *corev1.Pod) error {
+	if s == nil || s.sandboxStore == nil || pod == nil || pod.DeletionTimestamp != nil ||
+		!sandboxCrashRecoveryPodEligible(pod) || pod.Status.Phase != corev1.PodRunning {
+		return nil
+	}
+	if _, terminated := terminatedProcdContainer(pod); terminated != nil {
+		return s.RecoverTerminatedSandboxRuntime(ctx, pod)
+	}
+	liveness := sandboxRuntimeLivenessCondition(pod)
+	if !sandboxRuntimeLivenessFailureSustained(liveness, s.now(), defaultSandboxRuntimeUnhealthyAfter) {
+		return nil
+	}
+
+	sandboxID := sandboxIDFromPod(pod)
+	enqueue := false
+	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
+		if record == nil || record.Status == SandboxStatusDeleted || !record.DeletedAt.IsZero() ||
+			sandboxHardExpired(record.HardExpiresAt, s.now()) || !sandboxRecordReferencesPod(record, pod) {
+			return nil
+		}
+		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sandboxID)
+		if err != nil {
+			return err
+		}
+		if activeTxn != nil {
+			if healthRecoveryTxnReferencesPod(activeTxn, pod) {
+				enqueue = true
+				return nil
+			}
+			return fmt.Errorf("%w: active %s transaction %s", errSandboxCrashRecoveryBlocked, activeTxn.Kind, activeTxn.ID)
+		}
+		if record.Status == SandboxStatusPaused {
+			return nil
+		}
+		if err := beginHealthRecoveryTxn(lockCtx, tx, record, pod); err != nil {
+			return err
+		}
+		enqueue = true
+		return nil
+	})
+	if errors.Is(err, ErrSandboxRecordNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !enqueue {
+		return nil
+	}
+	if s.logger != nil {
+		s.logger.Error("Queued unhealthy sandbox runtime reconstruction",
+			zap.String("sandboxID", sandboxID),
+			zap.String("namespace", pod.Namespace),
+			zap.String("pod", pod.Name),
+			zap.String("podUID", string(pod.UID)),
+			zap.Int64("runtimeGeneration", runtimeGenerationFromPod(pod)),
+			zap.String("reason", liveness.Reason),
+			zap.String("message", liveness.Message),
+			zap.Time("unhealthySince", liveness.LastTransitionTime.Time),
+		)
+	}
+	s.enqueueSandboxRecovery(sandboxID)
+	return nil
+}
+
 func beginCrashRecoveryTxn(ctx context.Context, tx SandboxStoreTx, record *SandboxRecord, pod *corev1.Pod) error {
 	if tx == nil || record == nil || pod == nil {
 		return nil
@@ -124,6 +193,30 @@ func beginCrashRecoveryTxn(ctx context.Context, tx SandboxStoreTx, record *Sandb
 	})
 }
 
+func beginHealthRecoveryTxn(ctx context.Context, tx SandboxStoreTx, record *SandboxRecord, pod *corev1.Pod) error {
+	if tx == nil || record == nil || pod == nil {
+		return nil
+	}
+	condition := sandboxRuntimeLivenessCondition(pod)
+	if condition == nil || condition.Status != corev1.ConditionFalse {
+		return fmt.Errorf("pod %s/%s has no failed liveness condition to recover", pod.Namespace, pod.Name)
+	}
+	if !sandboxRecordReferencesPod(record, pod) {
+		return fmt.Errorf("sandbox runtime identity changed before health recovery")
+	}
+	return tx.BeginLifecycleTxn(ctx, &SandboxLifecycleTxn{
+		ID:               uuid.NewString(),
+		SandboxID:        record.ID,
+		Kind:             SandboxLifecycleKindPause,
+		Phase:            SandboxLifecyclePhasePreparing,
+		Source:           SandboxLifecycleSourceHealth,
+		Cancelable:       false,
+		FromGeneration:   runtimeGenerationFromPod(pod),
+		FromPodNamespace: pod.Namespace,
+		FromPodName:      pod.Name,
+	})
+}
+
 func sandboxRecordReferencesPod(record *SandboxRecord, pod *corev1.Pod) bool {
 	if record == nil || pod == nil {
 		return false
@@ -136,7 +229,15 @@ func sandboxRecordReferencesPod(record *SandboxRecord, pod *corev1.Pod) bool {
 }
 
 func crashRecoveryTxnReferencesPod(txn *SandboxLifecycleTxn, pod *corev1.Pod) bool {
-	if txn == nil || pod == nil || txn.Kind != SandboxLifecycleKindPause || txn.Source != SandboxLifecycleSourceCrash {
+	return runtimeRecoveryTxnReferencesPod(txn, pod, SandboxLifecycleSourceCrash)
+}
+
+func healthRecoveryTxnReferencesPod(txn *SandboxLifecycleTxn, pod *corev1.Pod) bool {
+	return runtimeRecoveryTxnReferencesPod(txn, pod, SandboxLifecycleSourceHealth)
+}
+
+func runtimeRecoveryTxnReferencesPod(txn *SandboxLifecycleTxn, pod *corev1.Pod, source string) bool {
+	if txn == nil || pod == nil || txn.Kind != SandboxLifecycleKindPause || txn.Source != source {
 		return false
 	}
 	return txn.FromGeneration == runtimeGenerationFromPod(pod) &&

--- a/manager/pkg/service/sandbox_crash_recovery_controller.go
+++ b/manager/pkg/service/sandbox_crash_recovery_controller.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -18,40 +19,55 @@ import (
 	"k8s.io/client-go/util/workqueue"
 )
 
-type terminatedSandboxRuntimeRecoverer interface {
+type sandboxRuntimeRecoverer interface {
 	RecoverTerminatedSandboxRuntime(ctx context.Context, pod *corev1.Pod) error
+	RecoverUnhealthySandboxRuntime(ctx context.Context, pod *corev1.Pod) error
 }
+
+const (
+	sandboxRecoveryCauseTerminated = "terminated"
+	sandboxRecoveryCauseUnhealthy  = "unhealthy"
+
+	defaultSandboxCrashRecoveryResyncPeriod = 30 * time.Second
+)
 
 type sandboxCrashRecoveryItem struct {
 	Namespace string
 	PodName   string
 	PodUID    string
+	Cause     string
 }
 
-// SandboxCrashRecoveryController starts durable rootfs recovery as soon as a
-// claimed procd container terminates.
+// SandboxCrashRecoveryController starts durable rootfs recovery when a claimed
+// procd container terminates or remains unresponsive past the health threshold.
 type SandboxCrashRecoveryController struct {
-	k8sClient kubernetes.Interface
-	podLister corelisters.PodLister
-	recoverer terminatedSandboxRuntimeRecoverer
-	logger    *zap.Logger
-	queue     workqueue.TypedRateLimitingInterface[sandboxCrashRecoveryItem]
+	k8sClient      kubernetes.Interface
+	podLister      corelisters.PodLister
+	recoverer      sandboxRuntimeRecoverer
+	logger         *zap.Logger
+	queue          workqueue.TypedRateLimitingInterface[sandboxCrashRecoveryItem]
+	unhealthyAfter time.Duration
+	resyncPeriod   time.Duration
+	now            func() time.Time
 }
 
 func NewSandboxCrashRecoveryController(
 	k8sClient kubernetes.Interface,
 	podLister corelisters.PodLister,
-	recoverer terminatedSandboxRuntimeRecoverer,
+	recoverer sandboxRuntimeRecoverer,
 	logger *zap.Logger,
 ) *SandboxCrashRecoveryController {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
 	return &SandboxCrashRecoveryController{
-		k8sClient: k8sClient,
-		podLister: podLister,
-		recoverer: recoverer,
-		logger:    logger,
+		k8sClient:      k8sClient,
+		podLister:      podLister,
+		recoverer:      recoverer,
+		logger:         logger,
+		unhealthyAfter: defaultSandboxRuntimeUnhealthyAfter,
+		resyncPeriod:   defaultSandboxCrashRecoveryResyncPeriod,
+		now:            time.Now,
 		queue: workqueue.NewTypedRateLimitingQueue(
 			workqueue.NewTypedItemExponentialFailureRateLimiter[sandboxCrashRecoveryItem](100*time.Millisecond, 5*time.Second),
 		),
@@ -64,10 +80,10 @@ func (c *SandboxCrashRecoveryController) ResourceEventHandler() cache.ResourceEv
 	}
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj any) {
-			c.enqueueTerminatedPod(nil, extractPod(obj))
+			c.enqueueRuntimeRecovery(nil, extractPod(obj))
 		},
 		UpdateFunc: func(oldObj, newObj any) {
-			c.enqueueTerminatedPod(extractPod(oldObj), extractPod(newObj))
+			c.enqueueRuntimeRecovery(extractPod(oldObj), extractPod(newObj))
 		},
 	}
 }
@@ -86,34 +102,75 @@ func (c *SandboxCrashRecoveryController) Run(ctx context.Context, workers int) e
 	for i := 0; i < workers; i++ {
 		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
 	}
-	<-ctx.Done()
-	c.logger.Info("Sandbox crash recovery controller stopped")
-	return ctx.Err()
+	c.enqueueRecoveryCandidates()
+	resyncPeriod := c.resyncPeriod
+	if resyncPeriod <= 0 {
+		resyncPeriod = defaultSandboxCrashRecoveryResyncPeriod
+	}
+	ticker := time.NewTicker(resyncPeriod)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			c.logger.Info("Sandbox crash recovery controller stopped")
+			return ctx.Err()
+		case <-ticker.C:
+			c.enqueueRecoveryCandidates()
+		}
+	}
 }
 
-func (c *SandboxCrashRecoveryController) enqueueTerminatedPod(oldPod, newPod *corev1.Pod) {
+func (c *SandboxCrashRecoveryController) enqueueRecoveryCandidates() {
+	if c == nil || c.podLister == nil {
+		return
+	}
+	pods, err := c.podLister.List(labels.Everything())
+	if err != nil {
+		c.logger.Warn("Failed to list sandbox pods for crash recovery resync", zap.Error(err))
+		return
+	}
+	for _, pod := range pods {
+		c.enqueueRuntimeRecovery(nil, pod)
+	}
+}
+
+func (c *SandboxCrashRecoveryController) enqueueRuntimeRecovery(oldPod, newPod *corev1.Pod) {
 	if c == nil || c.queue == nil || !sandboxCrashRecoveryPodEligible(newPod) {
 		return
 	}
 	newStatus, newTerminated := terminatedProcdContainer(newPod)
-	if newTerminated == nil && !sandboxRuntimePodTerminal(newPod) {
-		return
-	}
-	if oldPod != nil && oldPod.UID == newPod.UID {
-		oldStatus, oldTerminated := terminatedProcdContainer(oldPod)
-		if newStatus != nil && newTerminated != nil && oldStatus != nil && oldTerminated != nil &&
-			oldStatus.ContainerID == newStatus.ContainerID &&
-			oldTerminated.FinishedAt.Equal(&newTerminated.FinishedAt) {
+	cause := sandboxRecoveryCauseUnhealthy
+	if newTerminated != nil || sandboxRuntimePodTerminal(newPod) {
+		cause = sandboxRecoveryCauseTerminated
+		if oldPod != nil && oldPod.UID == newPod.UID {
+			oldStatus, oldTerminated := terminatedProcdContainer(oldPod)
+			if newStatus != nil && newTerminated != nil && oldStatus != nil && oldTerminated != nil &&
+				oldStatus.ContainerID == newStatus.ContainerID &&
+				oldTerminated.FinishedAt.Equal(&newTerminated.FinishedAt) {
+				return
+			}
+			if newTerminated == nil && oldTerminated == nil && oldPod.Status.Phase == newPod.Status.Phase {
+				return
+			}
+		}
+	} else {
+		newLiveness := sandboxRuntimeLivenessCondition(newPod)
+		if newLiveness == nil || newLiveness.Status != corev1.ConditionFalse {
 			return
 		}
-		if newTerminated == nil && oldTerminated == nil && oldPod.Status.Phase == newPod.Status.Phase {
-			return
+		if oldPod != nil && oldPod.UID == newPod.UID {
+			oldLiveness := sandboxRuntimeLivenessCondition(oldPod)
+			if oldLiveness != nil && oldLiveness.Status == corev1.ConditionFalse &&
+				oldLiveness.LastTransitionTime.Equal(&newLiveness.LastTransitionTime) {
+				return
+			}
 		}
 	}
 	c.queue.Add(sandboxCrashRecoveryItem{
 		Namespace: newPod.Namespace,
 		PodName:   newPod.Name,
 		PodUID:    string(newPod.UID),
+		Cause:     cause,
 	})
 }
 
@@ -129,7 +186,8 @@ func (c *SandboxCrashRecoveryController) processNextWorkItem(ctx context.Context
 	}
 	defer c.queue.Done(item)
 
-	if err := c.reconcile(ctx, item); err != nil {
+	requeueAfter, err := c.reconcile(ctx, item)
+	if err != nil {
 		c.logger.Warn("Sandbox crash recovery reconcile failed, requeueing",
 			zap.String("namespace", item.Namespace),
 			zap.String("pod", item.PodName),
@@ -140,27 +198,60 @@ func (c *SandboxCrashRecoveryController) processNextWorkItem(ctx context.Context
 		return true
 	}
 	c.queue.Forget(item)
+	if requeueAfter > 0 {
+		c.queue.AddAfter(item, requeueAfter)
+	}
 	return true
 }
 
-func (c *SandboxCrashRecoveryController) reconcile(ctx context.Context, item sandboxCrashRecoveryItem) error {
+func (c *SandboxCrashRecoveryController) reconcile(ctx context.Context, item sandboxCrashRecoveryItem) (time.Duration, error) {
 	if c == nil || c.recoverer == nil || strings.TrimSpace(item.Namespace) == "" || strings.TrimSpace(item.PodName) == "" {
-		return nil
+		return 0, nil
 	}
 	pod, err := c.getPod(ctx, item.Namespace, item.PodName)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil
+			return 0, nil
 		}
-		return fmt.Errorf("get terminated sandbox pod: %w", err)
+		return 0, fmt.Errorf("get sandbox pod for runtime recovery: %w", err)
 	}
 	if item.PodUID != "" && string(pod.UID) != item.PodUID {
-		return nil
+		return 0, nil
 	}
-	if _, terminated := terminatedProcdContainer(pod); (terminated == nil && !sandboxRuntimePodTerminal(pod)) || pod.DeletionTimestamp != nil {
-		return nil
+	if pod.DeletionTimestamp != nil {
+		return 0, nil
 	}
-	return c.recoverer.RecoverTerminatedSandboxRuntime(ctx, pod)
+	switch item.Cause {
+	case sandboxRecoveryCauseUnhealthy:
+		if _, terminated := terminatedProcdContainer(pod); terminated != nil || sandboxRuntimePodTerminal(pod) {
+			return 0, c.recoverer.RecoverTerminatedSandboxRuntime(ctx, pod)
+		}
+		condition := sandboxRuntimeLivenessCondition(pod)
+		if condition == nil || condition.Status != corev1.ConditionFalse {
+			return 0, nil
+		}
+		unhealthyAfter := c.unhealthyAfter
+		if unhealthyAfter <= 0 {
+			unhealthyAfter = defaultSandboxRuntimeUnhealthyAfter
+		}
+		now := time.Now()
+		if c.now != nil {
+			now = c.now()
+		}
+		if !sandboxRuntimeLivenessFailureSustained(condition, now, unhealthyAfter) {
+			transitionedAt := condition.LastTransitionTime.Time
+			if transitionedAt.IsZero() {
+				return unhealthyAfter, nil
+			}
+			return max(transitionedAt.Add(unhealthyAfter).Sub(now), time.Millisecond), nil
+		}
+		return 0, c.recoverer.RecoverUnhealthySandboxRuntime(ctx, pod)
+	default:
+		if _, terminated := terminatedProcdContainer(pod); terminated == nil && !sandboxRuntimePodTerminal(pod) {
+			return 0, nil
+		}
+		return 0, c.recoverer.RecoverTerminatedSandboxRuntime(ctx, pod)
+	}
 }
 
 func (c *SandboxCrashRecoveryController) getPod(ctx context.Context, namespace, name string) (*corev1.Pod, error) {

--- a/manager/pkg/service/sandbox_crash_recovery_test.go
+++ b/manager/pkg/service/sandbox_crash_recovery_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -55,6 +57,54 @@ func TestSandboxRuntimePodNeedsReplacementWhenProcdTerminatedWhilePodRunning(t *
 	pod := crashRecoveryTestPod(corev1.PodRunning, 137, "OOMKilled")
 
 	assert.True(t, sandboxRuntimePodNeedsReplacement(pod))
+}
+
+func TestRecoverUnhealthySandboxRuntimeStartsDurableReconstruction(t *testing.T) {
+	now := time.Date(2026, time.July, 28, 4, 0, 0, 0, time.UTC)
+	pod := unhealthyRecoveryTestPod(now.Add(-2 * time.Minute))
+	store := crashRecoveryTestStore(pod)
+	enqueuer := &recordingPauseEnqueuer{}
+	svc := &SandboxService{
+		sandboxStore:  store,
+		pauseEnqueuer: enqueuer,
+		clock:         fixedClock{now: now},
+		logger:        zap.NewNop(),
+	}
+
+	require.NoError(t, svc.RecoverUnhealthySandboxRuntime(context.Background(), pod))
+	require.NoError(t, svc.RecoverUnhealthySandboxRuntime(context.Background(), pod))
+
+	require.Len(t, store.lifecycleTxns, 1)
+	txn := activeLifecycleTxnForTest(store, "sandbox-1")
+	require.NotNil(t, txn)
+	assert.Equal(t, SandboxLifecycleSourceHealth, txn.Source)
+	assert.False(t, txn.Cancelable)
+	assert.Equal(t, int64(3), txn.FromGeneration)
+	assert.Equal(t, []string{"sandbox-1", "sandbox-1"}, enqueuer.recoveryCalls)
+	assert.Empty(t, enqueuer.calls)
+}
+
+func TestRecoverUnhealthySandboxRuntimeIgnoresAutoResumeAccessPolicy(t *testing.T) {
+	now := time.Date(2026, time.July, 28, 4, 0, 0, 0, time.UTC)
+	pod := unhealthyRecoveryTestPod(now.Add(-2 * time.Minute))
+	store := crashRecoveryTestStore(pod)
+	autoResume := false
+	store.records["sandbox-1"].Config.AutoResume = &autoResume
+	enqueuer := &recordingPauseEnqueuer{}
+	svc := &SandboxService{
+		sandboxStore:  store,
+		pauseEnqueuer: enqueuer,
+		clock:         fixedClock{now: now},
+		logger:        zap.NewNop(),
+	}
+
+	require.NoError(t, svc.RecoverUnhealthySandboxRuntime(context.Background(), pod))
+
+	require.Len(t, store.lifecycleTxns, 1)
+	txn := activeLifecycleTxnForTest(store, "sandbox-1")
+	require.NotNil(t, txn)
+	assert.Equal(t, SandboxLifecycleSourceHealth, txn.Source)
+	assert.Equal(t, []string{"sandbox-1"}, enqueuer.recoveryCalls)
 }
 
 func TestRecoverTerminatedSandboxRuntimeIgnoresStalePod(t *testing.T) {
@@ -184,6 +234,55 @@ func TestCompleteCrashRecoveryRetainsPodAndTransactionOnTransientCheckpointFailu
 	for _, action := range client.Actions() {
 		assert.False(t, action.GetVerb() == "delete" && action.GetResource().Resource == "pods")
 	}
+}
+
+func TestCompleteHealthRecoveryFallsBackAndFencesBeforeDeletingPod(t *testing.T) {
+	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(ctldapi.PrepareRootFSSnapshotResponse{Error: "runtime is unresponsive"})
+	}))
+	defer ctld.Close()
+	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
+
+	now := time.Date(2026, time.July, 28, 4, 0, 0, 0, time.UTC)
+	pod := unhealthyRecoveryTestPod(now.Add(-2 * time.Minute))
+	pod.Status.HostIP = ctldURL.Hostname()
+	store := crashRecoveryTestStore(pod)
+	store.rootFSStates = map[string]*SandboxRootFSState{
+		"sandbox-1": {
+			SandboxID:         "sandbox-1",
+			TeamID:            "team-1",
+			LayerID:           "previous-head",
+			RuntimeGeneration: 2,
+		},
+	}
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	deleted := false
+	client.PrependReactor("delete", "pods", func(ktesting.Action) (bool, runtime.Object, error) {
+		record, err := store.GetSandbox(context.Background(), "sandbox-1")
+		require.NoError(t, err)
+		require.Equal(t, SandboxStatusPaused, record.Status, "runtime must be fenced before pod deletion")
+		deleted = true
+		return true, nil, nil
+	})
+	svc := &SandboxService{
+		k8sClient:     client,
+		podLister:     newTestPodLister(t, pod),
+		sandboxStore:  store,
+		ctldClient:    NewCtldClientWithHTTPClient(ctld.Client()),
+		pauseEnqueuer: &recordingPauseEnqueuer{},
+		config:        SandboxServiceConfig{CtldEnabled: true, CtldPort: ctldPort},
+		clock:         fixedClock{now: now},
+		logger:        zap.NewNop(),
+	}
+
+	require.NoError(t, svc.RecoverUnhealthySandboxRuntime(context.Background(), pod))
+	require.NoError(t, svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"))
+
+	assert.True(t, deleted)
+	assert.Equal(t, SandboxStatusPaused, store.records["sandbox-1"].Status)
+	assert.Equal(t, "previous-head", store.rootFSStates["sandbox-1"].LayerID)
+	assert.Nil(t, activeLifecycleTxnForTest(store, "sandbox-1"))
 }
 
 func TestCompleteCrashRecoveryFallsBackToLastCommittedHeadWhenSnapshotWasRemoved(t *testing.T) {
@@ -346,6 +445,105 @@ func TestCrashRecoveryControllerRetriesRecovererFailure(t *testing.T) {
 	}))
 }
 
+func TestCrashRecoveryControllerWaitsForSustainedLivenessFailure(t *testing.T) {
+	now := time.Date(2026, time.July, 28, 4, 0, 0, 0, time.UTC)
+	pod := unhealthyRecoveryTestPod(now.Add(-10 * time.Second))
+	recoverer := &recordingCrashRecoverer{}
+	controller := NewSandboxCrashRecoveryController(nil, newTestPodLister(t, pod), recoverer, zap.NewNop())
+	controller.now = func() time.Time { return now }
+
+	requeueAfter, err := controller.reconcile(context.Background(), sandboxCrashRecoveryItem{
+		Namespace: pod.Namespace,
+		PodName:   pod.Name,
+		PodUID:    string(pod.UID),
+		Cause:     sandboxRecoveryCauseUnhealthy,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 80*time.Second, requeueAfter)
+	assert.Empty(t, recoverer.unhealthyPods)
+}
+
+func TestCrashRecoveryControllerCancelsRecoveredLivenessFailure(t *testing.T) {
+	now := time.Date(2026, time.July, 28, 4, 0, 0, 0, time.UTC)
+	pod := unhealthyRecoveryTestPod(now.Add(-2 * time.Minute))
+	for i := range pod.Status.Conditions {
+		if pod.Status.Conditions[i].Type == v1alpha1.SandboxPodLivenessConditionType {
+			pod.Status.Conditions[i].Status = corev1.ConditionTrue
+		}
+	}
+	recoverer := &recordingCrashRecoverer{}
+	controller := NewSandboxCrashRecoveryController(nil, newTestPodLister(t, pod), recoverer, zap.NewNop())
+	controller.now = func() time.Time { return now }
+
+	requeueAfter, err := controller.reconcile(context.Background(), sandboxCrashRecoveryItem{
+		Namespace: pod.Namespace,
+		PodName:   pod.Name,
+		PodUID:    string(pod.UID),
+		Cause:     sandboxRecoveryCauseUnhealthy,
+	})
+
+	require.NoError(t, err)
+	assert.Zero(t, requeueAfter)
+	assert.Empty(t, recoverer.unhealthyPods)
+}
+
+func TestCrashRecoveryControllerRecoversSustainedLivenessFailure(t *testing.T) {
+	now := time.Date(2026, time.July, 28, 4, 0, 0, 0, time.UTC)
+	pod := unhealthyRecoveryTestPod(now.Add(-2 * time.Minute))
+	recoverer := &recordingCrashRecoverer{}
+	controller := NewSandboxCrashRecoveryController(nil, newTestPodLister(t, pod), recoverer, zap.NewNop())
+	controller.now = func() time.Time { return now }
+
+	controller.ResourceEventHandler().AddFunc(pod)
+	require.True(t, controller.processNextWorkItem(context.Background()))
+
+	require.Len(t, recoverer.unhealthyPods, 1)
+	assert.Equal(t, pod.Name, recoverer.unhealthyPods[0].Name)
+	assert.Empty(t, recoverer.pods)
+}
+
+func TestCrashRecoveryControllerResyncsExistingUnhealthyPod(t *testing.T) {
+	now := time.Date(2026, time.July, 28, 4, 0, 0, 0, time.UTC)
+	pod := unhealthyRecoveryTestPod(now.Add(-2 * time.Minute))
+	recoverer := &recordingCrashRecoverer{}
+	controller := NewSandboxCrashRecoveryController(nil, newTestPodLister(t, pod), recoverer, zap.NewNop())
+	controller.now = func() time.Time { return now }
+
+	controller.enqueueRecoveryCandidates()
+	require.True(t, controller.processNextWorkItem(context.Background()))
+
+	require.Len(t, recoverer.unhealthyPods, 1)
+	assert.Equal(t, pod.Name, recoverer.unhealthyPods[0].Name)
+}
+
+func TestSandboxPauseControllerReconstructsHealthRecoveryRegardlessOfAutoResume(t *testing.T) {
+	autoResume := false
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-1": {
+			ID:     "sandbox-1",
+			Status: SandboxStatusRunning,
+			Config: SandboxConfig{AutoResume: &autoResume},
+		},
+	}}
+	controller := NewSandboxPauseController(&SandboxService{sandboxStore: store}, zap.NewNop())
+	t.Cleanup(controller.queue.ShutDown)
+	var calls []string
+	controller.complete = func(_ context.Context, sandboxID string) error {
+		calls = append(calls, "pause:"+sandboxID)
+		return nil
+	}
+	controller.resume = func(_ context.Context, sandboxID string) error {
+		calls = append(calls, "resume:"+sandboxID)
+		return nil
+	}
+	controller.EnqueueSandboxRecovery("sandbox-1")
+
+	require.True(t, controller.processNextWorkItem(context.Background()))
+
+	assert.Equal(t, []string{"pause:sandbox-1", "resume:sandbox-1"}, calls)
+}
+
 func TestSandboxPauseControllerFindsCrashRecoveryAfterManagerRestart(t *testing.T) {
 	pod := crashRecoveryTestPod(corev1.PodFailed, 137, "OOMKilled")
 	store := crashRecoveryTestStore(pod)
@@ -364,11 +562,90 @@ func TestSandboxPauseControllerFindsCrashRecoveryAfterManagerRestart(t *testing.
 	controller.enqueuePausingSandboxes(context.Background())
 
 	require.Equal(t, 1, controller.queue.Len())
-	sandboxID, shutdown := controller.queue.Get()
+	item, shutdown := controller.queue.Get()
 	require.False(t, shutdown)
-	controller.queue.Done(sandboxID)
-	controller.queue.Forget(sandboxID)
-	assert.Equal(t, "sandbox-1", sandboxID)
+	controller.queue.Done(item)
+	controller.queue.Forget(item)
+	assert.Equal(t, "sandbox-1", item.SandboxID)
+	assert.False(t, item.Resume)
+}
+
+func TestSandboxPauseControllerFindsHealthRecoveryAfterManagerRestart(t *testing.T) {
+	pod := unhealthyRecoveryTestPod(time.Now().Add(-2 * time.Minute))
+	store := crashRecoveryTestStore(pod)
+	store.lifecycleTxns = map[string]*SandboxLifecycleTxn{
+		"health-pause": {
+			ID:        "health-pause",
+			SandboxID: "sandbox-1",
+			Kind:      SandboxLifecycleKindPause,
+			Phase:     SandboxLifecyclePhasePublishing,
+			Source:    SandboxLifecycleSourceHealth,
+		},
+	}
+	controller := NewSandboxPauseController(&SandboxService{sandboxStore: store}, zap.NewNop())
+	t.Cleanup(controller.queue.ShutDown)
+
+	controller.enqueuePausingSandboxes(context.Background())
+
+	require.Equal(t, 1, controller.queue.Len())
+	item, shutdown := controller.queue.Get()
+	require.False(t, shutdown)
+	controller.queue.Done(item)
+	controller.queue.Forget(item)
+	assert.Equal(t, "sandbox-1", item.SandboxID)
+	assert.True(t, item.Resume)
+}
+
+func TestSandboxPauseControllerResumesCommittedHealthRecoveryAfterManagerRestart(t *testing.T) {
+	pod := unhealthyRecoveryTestPod(time.Now().Add(-2 * time.Minute))
+	store := crashRecoveryTestStore(pod)
+	store.records["sandbox-1"].Status = SandboxStatusPaused
+	store.lifecycleTxns = map[string]*SandboxLifecycleTxn{
+		"health-pause": {
+			ID:        "health-pause",
+			SandboxID: "sandbox-1",
+			Kind:      SandboxLifecycleKindPause,
+			Phase:     SandboxLifecyclePhaseCommitted,
+			Source:    SandboxLifecycleSourceHealth,
+			Epoch:     4,
+		},
+		"failed-resume": {
+			ID:        "failed-resume",
+			SandboxID: "sandbox-1",
+			Kind:      SandboxLifecycleKindResume,
+			Phase:     SandboxLifecyclePhaseAborted,
+			Epoch:     5,
+		},
+	}
+	controller := NewSandboxPauseController(&SandboxService{sandboxStore: store}, zap.NewNop())
+	t.Cleanup(controller.queue.ShutDown)
+
+	controller.enqueuePausingSandboxes(context.Background())
+
+	require.Equal(t, 1, controller.queue.Len())
+	item, shutdown := controller.queue.Get()
+	require.False(t, shutdown)
+	controller.queue.Done(item)
+	controller.queue.Forget(item)
+	assert.Equal(t, "sandbox-1", item.SandboxID)
+	assert.True(t, item.Resume)
+}
+
+func unhealthyRecoveryTestPod(transitionedAt time.Time) *corev1.Pod {
+	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
+	pod.UID = types.UID("unhealthy-pod-uid")
+	pod.Spec.ReadinessGates = []corev1.PodReadinessGate{{
+		ConditionType: v1alpha1.SandboxPodReadinessConditionType,
+	}}
+	pod.Status.Conditions = []corev1.PodCondition{{
+		Type:               v1alpha1.SandboxPodLivenessConditionType,
+		Status:             corev1.ConditionFalse,
+		Reason:             "SandboxProbeFailed",
+		Message:            "procd liveness request timed out",
+		LastTransitionTime: metav1.NewTime(transitionedAt),
+	}}
+	pod.Annotations[controller.AnnotationRuntimeGeneration] = "3"
+	return pod
 }
 
 func crashRecoveryTestPod(phase corev1.PodPhase, exitCode int32, reason string) *corev1.Pod {
@@ -437,14 +714,22 @@ func activeLifecycleTxnForTest(store *memorySandboxStore, sandboxID string) *San
 }
 
 type recordingCrashRecoverer struct {
-	mu   sync.Mutex
-	pods []*corev1.Pod
-	err  error
+	mu            sync.Mutex
+	pods          []*corev1.Pod
+	unhealthyPods []*corev1.Pod
+	err           error
 }
 
 func (r *recordingCrashRecoverer) RecoverTerminatedSandboxRuntime(_ context.Context, pod *corev1.Pod) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.pods = append(r.pods, pod.DeepCopy())
+	return r.err
+}
+
+func (r *recordingCrashRecoverer) RecoverUnhealthySandboxRuntime(_ context.Context, pod *corev1.Pod) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.unhealthyPods = append(r.unhealthyPods, pod.DeepCopy())
 	return r.err
 }

--- a/manager/pkg/service/sandbox_pause_controller.go
+++ b/manager/pkg/service/sandbox_pause_controller.go
@@ -16,26 +16,45 @@ const (
 	defaultSandboxPauseScanLimit    = 500
 )
 
+type sandboxPauseItem struct {
+	SandboxID string
+	Resume    bool
+}
+
+type pendingHealthRecoveryStore interface {
+	ListPendingHealthRecoverySandboxIDs(ctx context.Context, limit int) ([]string, error)
+}
+
 // SandboxPauseController completes durable pause transactions outside the API request path.
 type SandboxPauseController struct {
 	service        *SandboxService
 	logger         *zap.Logger
-	queue          workqueue.TypedRateLimitingInterface[string]
+	queue          workqueue.TypedRateLimitingInterface[sandboxPauseItem]
 	resyncInterval time.Duration
 	scanLimit      int
+	complete       func(context.Context, string) error
+	resume         func(context.Context, string) error
 }
 
 func NewSandboxPauseController(service *SandboxService, logger *zap.Logger) *SandboxPauseController {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
-	return &SandboxPauseController{
+	controller := &SandboxPauseController{
 		service:        service,
 		logger:         logger,
-		queue:          workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+		queue:          workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[sandboxPauseItem]()),
 		resyncInterval: defaultSandboxPauseResyncPeriod,
 		scanLimit:      defaultSandboxPauseScanLimit,
 	}
+	if service != nil {
+		controller.complete = service.CompletePausingSandboxRuntime
+		controller.resume = func(ctx context.Context, sandboxID string) error {
+			_, err := service.ResumePausedSandboxRuntime(ctx, sandboxID)
+			return err
+		}
+	}
+	return controller
 }
 
 func (c *SandboxPauseController) EnqueueSandboxPause(sandboxID string) {
@@ -46,7 +65,19 @@ func (c *SandboxPauseController) EnqueueSandboxPause(sandboxID string) {
 	if sandboxID == "" {
 		return
 	}
-	c.queue.Add(sandboxID)
+	c.queue.Add(sandboxPauseItem{SandboxID: sandboxID})
+}
+
+// EnqueueSandboxRecovery completes the pause transaction and reconstructs the runtime.
+func (c *SandboxPauseController) EnqueueSandboxRecovery(sandboxID string) {
+	if c == nil || c.queue == nil {
+		return
+	}
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return
+	}
+	c.queue.Add(sandboxPauseItem{SandboxID: sandboxID, Resume: true})
 }
 
 func (c *SandboxPauseController) Run(ctx context.Context, workers int) error {
@@ -57,7 +88,7 @@ func (c *SandboxPauseController) Run(ctx context.Context, workers int) error {
 		workers = 1
 	}
 	if c.queue == nil {
-		c.queue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
+		c.queue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[sandboxPauseItem]())
 	}
 	if c.scanLimit <= 0 {
 		c.scanLimit = defaultSandboxPauseScanLimit
@@ -99,8 +130,24 @@ func (c *SandboxPauseController) enqueuePausingSandboxes(ctx context.Context) {
 	}
 	for _, txn := range txns {
 		if txn != nil {
-			c.EnqueueSandboxPause(txn.SandboxID)
+			if txn.Source == SandboxLifecycleSourceHealth {
+				c.EnqueueSandboxRecovery(txn.SandboxID)
+			} else {
+				c.EnqueueSandboxPause(txn.SandboxID)
+			}
 		}
+	}
+	recoveryStore, ok := c.service.sandboxStore.(pendingHealthRecoveryStore)
+	if !ok {
+		return
+	}
+	sandboxIDs, err := recoveryStore.ListPendingHealthRecoverySandboxIDs(ctx, c.scanLimit)
+	if err != nil {
+		c.logger.Warn("Failed to list pending sandbox health recoveries", zap.Error(err))
+		return
+	}
+	for _, sandboxID := range sandboxIDs {
+		c.EnqueueSandboxRecovery(sandboxID)
 	}
 }
 
@@ -110,24 +157,38 @@ func (c *SandboxPauseController) runWorker(ctx context.Context) {
 }
 
 func (c *SandboxPauseController) processNextWorkItem(ctx context.Context) bool {
-	sandboxID, shutdown := c.queue.Get()
+	item, shutdown := c.queue.Get()
 	if shutdown {
 		return false
 	}
-	defer c.queue.Done(sandboxID)
+	defer c.queue.Done(item)
 
-	if c.service == nil {
-		c.queue.Forget(sandboxID)
+	if c.complete == nil {
+		c.queue.Forget(item)
 		return true
 	}
-	if err := c.service.CompletePausingSandboxRuntime(ctx, sandboxID); err != nil {
+	if err := c.complete(ctx, item.SandboxID); err != nil {
 		c.logger.Warn("Sandbox pause completion failed, requeueing",
-			zap.String("sandboxID", sandboxID),
+			zap.String("sandboxID", item.SandboxID),
 			zap.Error(err),
 		)
-		c.queue.AddRateLimited(sandboxID)
+		c.queue.AddRateLimited(item)
 		return true
 	}
-	c.queue.Forget(sandboxID)
+	if item.Resume {
+		if c.resume == nil {
+			c.queue.Forget(item)
+			return true
+		}
+		if err := c.resume(ctx, item.SandboxID); err != nil {
+			c.logger.Warn("Sandbox runtime reconstruction failed, requeueing",
+				zap.String("sandboxID", item.SandboxID),
+				zap.Error(err),
+			)
+			c.queue.AddRateLimited(item)
+			return true
+		}
+	}
+	c.queue.Forget(item)
 	return true
 }

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -122,6 +122,40 @@ func (s *memorySandboxStore) ListActiveLifecycleTxns(_ context.Context, kind str
 	return txns, nil
 }
 
+func (s *memorySandboxStore) ListPendingHealthRecoverySandboxIDs(_ context.Context, limit int) ([]string, error) {
+	if s == nil {
+		return nil, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if limit <= 0 {
+		limit = len(s.records)
+	}
+	var sandboxIDs []string
+	for sandboxID, record := range s.records {
+		if record == nil || record.Status != SandboxStatusPaused || !record.DeletedAt.IsZero() {
+			continue
+		}
+		var latest *SandboxLifecycleTxn
+		for _, txn := range s.lifecycleTxns {
+			if txn == nil || txn.SandboxID != sandboxID || txn.Phase != SandboxLifecyclePhaseCommitted {
+				continue
+			}
+			if latest == nil || txn.Epoch > latest.Epoch {
+				latest = txn
+			}
+		}
+		if latest == nil || latest.Kind != SandboxLifecycleKindPause || latest.Source != SandboxLifecycleSourceHealth {
+			continue
+		}
+		sandboxIDs = append(sandboxIDs, sandboxID)
+		if len(sandboxIDs) >= limit {
+			break
+		}
+	}
+	return sandboxIDs, nil
+}
+
 func (s *memorySandboxStore) GetActiveLifecycleTxn(_ context.Context, sandboxID string) (*SandboxLifecycleTxn, error) {
 	if s == nil {
 		return nil, nil
@@ -592,6 +626,66 @@ func TestResumePausedSandboxRuntimeWaitsWhileRuntimeDeleting(t *testing.T) {
 	}
 	if store.saves != 0 {
 		t.Fatalf("store saves = %d, want 0", store.saves)
+	}
+}
+
+func TestResumePausedSandboxRuntimeDeletesStaleUnhealthyRuntimeBeforeIdentityCheck(t *testing.T) {
+	now := time.Date(2026, time.July, 28, 4, 0, 0, 0, time.UTC)
+	pod := runtimeIdentityPod("ns-a", "pod-a", "sandbox-a")
+	pod.UID = "stale-runtime"
+	pod.Status.Conditions = []corev1.PodCondition{{
+		Type:               v1alpha1.SandboxPodLivenessConditionType,
+		Status:             corev1.ConditionFalse,
+		LastTransitionTime: metav1.NewTime(now.Add(-2 * time.Minute)),
+	}}
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-a": {
+			ID:                "sandbox-a",
+			TeamID:            "team-a",
+			UserID:            "user-a",
+			TemplateID:        "default",
+			TemplateName:      "default",
+			TemplateNamespace: "tpl-default",
+			Status:            SandboxStatusPaused,
+			RuntimeGeneration: 1,
+			TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
+		},
+	}}
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	client.PrependReactor("delete", "pods", func(ktesting.Action) (bool, runtime.Object, error) {
+		deletionTime := metav1.NewTime(now)
+		pod.DeletionTimestamp = &deletionTime
+		return true, nil, nil
+	})
+	svc := &SandboxService{
+		k8sClient:    client,
+		podLister:    runtimeIdentityPodLister(t, pod),
+		sandboxStore: store,
+		clock:        fixedClock{now: now},
+		logger:       zap.NewNop(),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*sandboxLifecycleWaitInterval)
+	defer cancel()
+	_, err := svc.ResumePausedSandboxRuntime(ctx, "sandbox-a")
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("ResumePausedSandboxRuntime() error = %v, want context deadline while stale pod deletion is observed", err)
+	}
+	if strings.Contains(err.Error(), "runtime identity changed") {
+		t.Fatalf("ResumePausedSandboxRuntime() checked stale runtime identity before deletion: %v", err)
+	}
+	var deleted bool
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "delete" && action.GetResource().Resource == "pods" {
+			deleted = true
+		}
+	}
+	if !deleted {
+		t.Fatal("stale unhealthy runtime pod was not deleted")
+	}
+	if len(store.lifecycleTxns) != 0 {
+		t.Fatalf("lifecycle transactions = %#v, want none", store.lifecycleTxns)
 	}
 }
 

--- a/manager/pkg/service/sandbox_runtime_liveness.go
+++ b/manager/pkg/service/sandbox_runtime_liveness.go
@@ -1,0 +1,36 @@
+package service
+
+import (
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	defaultSandboxRuntimeUnhealthyAfter      = 90 * time.Second
+	defaultSandboxUnhealthyCheckpointTimeout = 30 * time.Second
+)
+
+func sandboxRuntimeLivenessCondition(pod *corev1.Pod) *corev1.PodCondition {
+	if pod == nil {
+		return nil
+	}
+	for i := range pod.Status.Conditions {
+		if pod.Status.Conditions[i].Type == v1alpha1.SandboxPodLivenessConditionType {
+			return &pod.Status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+func sandboxRuntimeLivenessFailureSustained(condition *corev1.PodCondition, now time.Time, after time.Duration) bool {
+	if condition == nil || condition.Status != corev1.ConditionFalse {
+		return false
+	}
+	if after <= 0 {
+		return true
+	}
+	transitionedAt := condition.LastTransitionTime.Time
+	return !transitionedAt.IsZero() && !transitionedAt.Add(after).After(now)
+}

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -146,6 +146,11 @@ type SandboxPauseEnqueuer interface {
 	EnqueueSandboxPause(sandboxID string)
 }
 
+// SandboxRecoveryEnqueuer schedules a durable pause followed by runtime reconstruction.
+type SandboxRecoveryEnqueuer interface {
+	EnqueueSandboxRecovery(sandboxID string)
+}
+
 // HotClaimReservationEnqueuer schedules a completed hot claim for warm-pool detachment.
 type HotClaimReservationEnqueuer interface {
 	EnqueueHotClaimReservation(namespace, podName string)

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -204,6 +204,35 @@ func (s *SandboxService) enqueueSandboxPause(sandboxID string) {
 	}()
 }
 
+func (s *SandboxService) enqueueSandboxRecovery(sandboxID string) {
+	if s == nil || strings.TrimSpace(sandboxID) == "" {
+		return
+	}
+	if enqueuer, ok := s.pauseEnqueuer.(SandboxRecoveryEnqueuer); ok {
+		enqueuer.EnqueueSandboxRecovery(sandboxID)
+		return
+	}
+	go func() {
+		if err := s.CompletePausingSandboxRuntime(context.Background(), sandboxID); err != nil {
+			if s.logger != nil {
+				s.logger.Warn("Async sandbox recovery pause failed",
+					zap.String("sandboxID", sandboxID),
+					zap.Error(err),
+				)
+			}
+			return
+		}
+		restoreCtx, cancel := sandboxRestoreContext(context.Background())
+		defer cancel()
+		if _, err := s.ResumePausedSandboxRuntime(restoreCtx, sandboxID); err != nil && s.logger != nil {
+			s.logger.Warn("Async sandbox runtime reconstruction failed",
+				zap.String("sandboxID", sandboxID),
+				zap.Error(err),
+			)
+		}
+	}()
+}
+
 func (s *SandboxService) abortPauseIfCancelRequested(ctx context.Context, sandboxID, txnID string) (bool, error) {
 	if s == nil || s.sandboxStore == nil || strings.TrimSpace(txnID) == "" {
 		return false, nil
@@ -322,8 +351,10 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 		return nil
 	}
 	crashRecovery := txn.Source == SandboxLifecycleSourceCrash
+	healthRecovery := txn.Source == SandboxLifecycleSourceHealth
+	runtimeRecovery := crashRecovery || healthRecovery
 	abortOnError := func(completionErr error) {
-		if !crashRecovery && completionErr != nil {
+		if !runtimeRecovery && completionErr != nil {
 			_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, completionErr.Error())
 		}
 	}
@@ -334,10 +365,11 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 	pod, err := s.getSandboxPod(ctx, sandboxID)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			if crashRecovery && s.logger != nil {
-				s.logger.Error("Terminated runtime disappeared before rootfs recovery",
+			if runtimeRecovery && s.logger != nil {
+				s.logger.Error("Runtime disappeared before rootfs recovery",
 					zap.String("sandboxID", sandboxID),
 					zap.Int64("runtimeGeneration", txn.FromGeneration),
+					zap.String("source", txn.Source),
 				)
 			}
 			_, commitErr := s.commitPausingRuntimePaused(ctx, sandboxID, txn, record.RuntimeGeneration, nil)
@@ -359,13 +391,16 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 		_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, "runtime deletion requested during crash recovery")
 		return nil
 	}
+	if healthRecovery && pod.DeletionTimestamp != nil {
+		return errSandboxRuntimeDeleting
+	}
 	if crashRecovery {
 		_, terminated := terminatedProcdContainer(pod)
 		if terminated == nil && !sandboxRuntimePodTerminal(pod) {
 			return fmt.Errorf("crash recovery expected terminated procd container in pod %s/%s", pod.Namespace, pod.Name)
 		}
 	}
-	if !crashRecovery && (!s.config.CtldEnabled || s.ctldClient == nil) {
+	if !runtimeRecovery && (!s.config.CtldEnabled || s.ctldClient == nil) {
 		return ErrSandboxCheckpointRequiresCtld
 	}
 	if canceled, err := s.abortPauseIfCancelRequested(ctx, sandboxID, txn.ID); err != nil || canceled {
@@ -380,7 +415,7 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 	procdAddress := ""
 	internalToken := ""
 	barrierActive := false
-	if !crashRecovery {
+	if !runtimeRecovery {
 		procdAddress, internalToken, err = s.activatePauseRuntimeBarrier(ctx, pod, record, txn)
 		if err != nil {
 			abortOnError(err)
@@ -408,22 +443,40 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 	if !s.config.CtldEnabled || s.ctldClient == nil {
 		rootFSSnapshotMissing = true
 	} else {
-		rootFSState, err = s.prepareSandboxRootFSCheckpoint(ctx, pod, record)
+		checkpointCtx := ctx
+		cancelCheckpoint := func() {}
+		if healthRecovery {
+			checkpointCtx, cancelCheckpoint = context.WithTimeout(ctx, defaultSandboxUnhealthyCheckpointTimeout)
+		}
+		rootFSState, err = s.prepareSandboxRootFSCheckpoint(checkpointCtx, pod, record)
+		cancelCheckpoint()
 		if err != nil {
 			if crashRecovery && rootFSTerminatedSnapshotMissing(err) {
 				rootFSSnapshotMissing = true
+			} else if healthRecovery && ctx.Err() == nil {
+				rootFSSnapshotMissing = true
+				if s.logger != nil {
+					s.logger.Error("Unhealthy runtime checkpoint failed; preserving the last committed rootfs head",
+						zap.String("sandboxID", sandboxID),
+						zap.String("namespace", pod.Namespace),
+						zap.String("pod", pod.Name),
+						zap.Int64("runtimeGeneration", generation),
+						zap.Error(err),
+					)
+				}
 			} else {
 				abortOnError(err)
 				return err
 			}
 		}
 	}
-	if rootFSSnapshotMissing && crashRecovery && s.logger != nil {
-		s.logger.Error("Terminated runtime snapshot is unavailable; preserving the last committed rootfs head",
+	if rootFSSnapshotMissing && runtimeRecovery && s.logger != nil {
+		s.logger.Error("Runtime snapshot is unavailable; preserving the last committed rootfs head",
 			zap.String("sandboxID", sandboxID),
 			zap.String("namespace", pod.Namespace),
 			zap.String("pod", pod.Name),
 			zap.Int64("runtimeGeneration", generation),
+			zap.String("source", txn.Source),
 		)
 	}
 	rootFSCommitted := false
@@ -479,13 +532,14 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 			)
 		}
 	}
-	if crashRecovery && s.logger != nil {
-		s.logger.Info("Recovered terminated sandbox runtime rootfs",
+	if runtimeRecovery && s.logger != nil {
+		s.logger.Info("Recovered sandbox runtime rootfs",
 			zap.String("sandboxID", sandboxID),
 			zap.String("namespace", pod.Namespace),
 			zap.String("pod", pod.Name),
 			zap.Int64("runtimeGeneration", generation),
 			zap.Bool("snapshotRecovered", rootFSState != nil),
+			zap.String("source", txn.Source),
 		)
 	}
 	return nil

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -33,7 +33,7 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 	var txn *SandboxLifecycleTxn
 	var req *ClaimRequest
 	var deletingPodRef *sandboxRuntimePodRef
-	crashRecoveryRequested := false
+	runtimeRecoveryRequested := false
 	claimType := "hot"
 	restoreNeeded := false
 	for {
@@ -43,7 +43,7 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 		txn = nil
 		req = nil
 		deletingPodRef = nil
-		crashRecoveryRequested = false
+		runtimeRecoveryRequested = false
 		restoreNeeded = false
 		var waitErr error
 		err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, locked *SandboxRecord) error {
@@ -87,21 +87,35 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 					}
 					return errSandboxRuntimeDeleting
 				}
-				if sandboxRuntimePodNeedsReplacement(existing) {
-					if err := beginCrashRecoveryTxn(lockCtx, tx, locked, existing); err != nil {
-						return err
-					}
-					crashRecoveryRequested = true
-					waitErr = errSandboxLifecyclePausing
-					return nil
-				}
 				if locked.Status == SandboxStatusPaused {
 					deletingPodRef = &sandboxRuntimePodRef{
 						namespace: existing.Namespace,
 						name:      existing.Name,
 					}
-					_ = s.k8sClient.CoreV1().Pods(existing.Namespace).Delete(lockCtx, existing.Name, metav1.DeleteOptions{})
+					if err := s.k8sClient.CoreV1().Pods(existing.Namespace).Delete(lockCtx, existing.Name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+						return fmt.Errorf("delete stale sandbox runtime pod: %w", err)
+					}
 					return errSandboxRuntimeDeleting
+				}
+				if sandboxRuntimePodNeedsReplacement(existing) {
+					if err := beginCrashRecoveryTxn(lockCtx, tx, locked, existing); err != nil {
+						return err
+					}
+					runtimeRecoveryRequested = true
+					waitErr = errSandboxLifecyclePausing
+					return nil
+				}
+				if sandboxRuntimeLivenessFailureSustained(
+					sandboxRuntimeLivenessCondition(existing),
+					s.now(),
+					defaultSandboxRuntimeUnhealthyAfter,
+				) {
+					if err := beginHealthRecoveryTxn(lockCtx, tx, locked, existing); err != nil {
+						return err
+					}
+					runtimeRecoveryRequested = true
+					waitErr = errSandboxLifecyclePausing
+					return nil
 				}
 				pod = existing
 				record = nil
@@ -149,7 +163,7 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 			}
 			return tx.BeginLifecycleTxn(lockCtx, txn)
 		})
-		if err == nil && crashRecoveryRequested {
+		if err == nil && runtimeRecoveryRequested {
 			s.enqueueSandboxPause(sandboxID)
 			err = waitErr
 		}
@@ -352,25 +366,20 @@ func (s *SandboxService) waitForSandboxRuntimePodDeletion(ctx context.Context, n
 	defer ticker.Stop()
 	for {
 		if s != nil && s.podLister != nil {
-			pod, err := s.podLister.Pods(namespace).Get(name)
+			_, err := s.podLister.Pods(namespace).Get(name)
 			if k8serrors.IsNotFound(err) {
 				return nil
 			}
 			if err != nil {
 				return err
 			}
-			if pod != nil && pod.DeletionTimestamp == nil {
-				return nil
-			}
 		} else if s != nil && s.k8sClient != nil {
-			pod, err := s.k8sClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+			_, err := s.k8sClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
 			switch {
 			case k8serrors.IsNotFound(err):
 				return nil
 			case err != nil:
 				return err
-			case pod != nil && pod.DeletionTimestamp == nil:
-				return nil
 			}
 		} else {
 			return nil

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -1097,11 +1097,16 @@ func addRootFSTestPauseTxn(store *memorySandboxStore, pod *corev1.Pod, phase str
 }
 
 type recordingPauseEnqueuer struct {
-	calls []string
+	calls         []string
+	recoveryCalls []string
 }
 
 func (r *recordingPauseEnqueuer) EnqueueSandboxPause(sandboxID string) {
 	r.calls = append(r.calls, sandboxID)
+}
+
+func (r *recordingPauseEnqueuer) EnqueueSandboxRecovery(sandboxID string) {
+	r.recoveryCalls = append(r.recoveryCalls, sandboxID)
 }
 
 func metav1ObjectMeta(name, sandboxID, teamID string) metav1.ObjectMeta {

--- a/manager/pkg/service/sandbox_store.go
+++ b/manager/pkg/service/sandbox_store.go
@@ -115,6 +115,7 @@ const (
 	SandboxLifecycleSourceManual = "manual"
 	SandboxLifecycleSourceAuto   = "auto"
 	SandboxLifecycleSourceCrash  = "crash"
+	SandboxLifecycleSourceHealth = "health"
 
 	SandboxLifecyclePhasePreparing  = "preparing"
 	SandboxLifecyclePhaseBarriered  = "barriered"
@@ -357,6 +358,51 @@ func (s *PGSandboxStore) ListActiveLifecycleTxns(ctx context.Context, kind strin
 		return nil, fmt.Errorf("iterate active lifecycle txns: %w", err)
 	}
 	return txns, nil
+}
+
+// ListPendingHealthRecoverySandboxIDs returns paused sandboxes whose latest
+// committed lifecycle transition was an automatic health-recovery pause.
+func (s *PGSandboxStore) ListPendingHealthRecoverySandboxIDs(ctx context.Context, limit int) ([]string, error) {
+	if s == nil || s.pool == nil {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 500
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT s.sandbox_id
+		FROM manager.sandboxes s
+		JOIN LATERAL (
+			SELECT kind, source
+			FROM manager.sandbox_lifecycle_txns
+			WHERE sandbox_id = s.sandbox_id
+				AND phase = $1
+			ORDER BY epoch DESC
+			LIMIT 1
+		) latest ON TRUE
+		WHERE s.deleted_at IS NULL
+			AND s.status = $2
+			AND latest.kind = $3
+			AND latest.source = $4
+		ORDER BY s.updated_at ASC
+		LIMIT $5
+	`, SandboxLifecyclePhaseCommitted, SandboxStatusPaused, SandboxLifecycleKindPause, SandboxLifecycleSourceHealth, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list pending health recovery sandboxes: %w", err)
+	}
+	defer rows.Close()
+	var sandboxIDs []string
+	for rows.Next() {
+		var sandboxID string
+		if err := rows.Scan(&sandboxID); err != nil {
+			return nil, fmt.Errorf("scan pending health recovery sandbox: %w", err)
+		}
+		sandboxIDs = append(sandboxIDs, sandboxID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate pending health recovery sandboxes: %w", err)
+	}
+	return sandboxIDs, nil
 }
 
 func (s *PGSandboxStore) GetActiveLifecycleTxn(ctx context.Context, sandboxID string) (*SandboxLifecycleTxn, error) {

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -4905,8 +4905,9 @@ components:
           type: boolean
           default: true
           description: |
-            Sandbox-level runtime recovery gate. When false, inbound API or public exposure
-            requests must not automatically resume a paused sandbox or replace a failed runtime.
+            Controls whether supported inbound API or public exposure requests may automatically
+            make an inactive sandbox available. This setting does not control platform-initiated
+            runtime fault recovery.
         services:
           type: array
           items:
@@ -5286,8 +5287,9 @@ components:
           type: boolean
           default: true
           description: |
-            Sandbox-level runtime recovery gate. When false, inbound API or public exposure
-            requests must not automatically resume a paused sandbox or replace a failed runtime.
+            Controls whether supported inbound API or public exposure requests may automatically
+            make an inactive sandbox available. This setting does not control platform-initiated
+            runtime fault recovery.
         services:
           type: array
           items:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -2252,8 +2252,9 @@ type SandboxAuditResource struct {
 
 // SandboxConfig defines model for SandboxConfig.
 type SandboxConfig struct {
-	// AutoResume Sandbox-level runtime recovery gate. When false, inbound API or public exposure
-	// requests must not automatically resume a paused sandbox or replace a failed runtime.
+	// AutoResume Controls whether supported inbound API or public exposure requests may automatically
+	// make an inactive sandbox available. This setting does not control platform-initiated
+	// runtime fault recovery.
 	AutoResume *bool              `json:"auto_resume,omitempty"`
 	EnvVars    *map[string]string `json:"env_vars,omitempty"`
 
@@ -2631,8 +2632,9 @@ type SandboxTemplateStatus struct {
 // SandboxUpdateConfig Subset of SandboxConfig fields that can be updated at runtime without restarting the sandbox.
 // Note: env_vars only affect new processes. webhook is not included as it requires restart.
 type SandboxUpdateConfig struct {
-	// AutoResume Sandbox-level runtime recovery gate. When false, inbound API or public exposure
-	// requests must not automatically resume a paused sandbox or replace a failed runtime.
+	// AutoResume Controls whether supported inbound API or public exposure requests may automatically
+	// make an inactive sandbox available. This setting does not control platform-initiated
+	// runtime fault recovery.
 	AutoResume *bool `json:"auto_resume,omitempty"`
 
 	// EnvVars Sandbox-level environment variables used as defaults for new procd-managed

--- a/pkg/fuseportal/multiplexer_linux.go
+++ b/pkg/fuseportal/multiplexer_linux.go
@@ -3,14 +3,28 @@
 package fuseportal
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
 
-const epollBatchSize = 128
+const (
+	epollBatchSize                    = 128
+	multiplexerWatchdogInterval       = 5 * time.Second
+	multiplexerWatchdogTimeout        = 30 * time.Second
+	multiplexerWatchdogControlToken   = uint64(0)
+	multiplexerWatchdogEventValueSize = 8
+)
+
+type multiplexerConfig struct {
+	watchdogInterval time.Duration
+	watchdogTimeout  time.Duration
+}
 
 type epollRegistration struct {
 	server *Server
@@ -22,10 +36,16 @@ type epollRegistration struct {
 // no longer grows with the number of mounted portals.
 type epollMultiplexer struct {
 	fd            int
+	controlFD     int
 	mu            sync.Mutex
 	nextToken     uint64
 	registrations map[uint64]*epollRegistration
 	runErr        error
+	probeSequence atomic.Uint64
+	probeAck      chan uint64
+	stop          chan struct{}
+	done          chan struct{}
+	closeOnce     sync.Once
 }
 
 var (
@@ -36,23 +56,72 @@ var (
 
 func sharedEpollMultiplexer() (*epollMultiplexer, error) {
 	sharedMuxOnce.Do(func() {
-		fd, err := unix.EpollCreate1(unix.EPOLL_CLOEXEC)
-		if err != nil {
-			sharedMuxErr = fmt.Errorf("create shared FUSE epoll multiplexer: %w", err)
-			return
+		sharedMux, sharedMuxErr = newEpollMultiplexer(multiplexerConfig{
+			watchdogInterval: multiplexerWatchdogInterval,
+			watchdogTimeout:  multiplexerWatchdogTimeout,
+		})
+		if sharedMuxErr != nil {
+			sharedMuxErr = fmt.Errorf("create shared FUSE epoll multiplexer: %w", sharedMuxErr)
 		}
-		sharedMux = &epollMultiplexer{
-			fd:            fd,
-			registrations: make(map[uint64]*epollRegistration),
-		}
-		go sharedMux.run()
 	})
 	return sharedMux, sharedMuxErr
+}
+
+func newEpollMultiplexer(cfg multiplexerConfig) (*epollMultiplexer, error) {
+	if cfg.watchdogInterval <= 0 {
+		cfg.watchdogInterval = multiplexerWatchdogInterval
+	}
+	if cfg.watchdogTimeout <= cfg.watchdogInterval {
+		cfg.watchdogTimeout = multiplexerWatchdogTimeout
+	}
+	fd, err := unix.EpollCreate1(unix.EPOLL_CLOEXEC)
+	if err != nil {
+		return nil, fmt.Errorf("create epoll descriptor: %w", err)
+	}
+	controlFD, err := unix.Eventfd(0, unix.EFD_CLOEXEC|unix.EFD_NONBLOCK)
+	if err != nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("create watchdog event descriptor: %w", err)
+	}
+	controlEvent := unix.EpollEvent{Events: uint32(unix.EPOLLIN | unix.EPOLLERR | unix.EPOLLHUP)}
+	setEpollToken(&controlEvent, multiplexerWatchdogControlToken)
+	if err := unix.EpollCtl(fd, unix.EPOLL_CTL_ADD, controlFD, &controlEvent); err != nil {
+		_ = unix.Close(controlFD)
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("register watchdog event descriptor: %w", err)
+	}
+	m := &epollMultiplexer{
+		fd:            fd,
+		controlFD:     controlFD,
+		registrations: make(map[uint64]*epollRegistration),
+		probeAck:      make(chan uint64, 1),
+		stop:          make(chan struct{}),
+		done:          make(chan struct{}),
+	}
+	go m.run()
+	go m.watch(cfg.watchdogInterval, cfg.watchdogTimeout)
+	return m, nil
+}
+
+// SharedMultiplexerHealth reports whether the shared FUSE event loop is still
+// making progress. Calling it also initializes the process-wide multiplexer.
+func SharedMultiplexerHealth() error {
+	mux, err := sharedEpollMultiplexer()
+	if err != nil {
+		return err
+	}
+	return mux.health()
 }
 
 func (m *epollMultiplexer) add(server *Server) error {
 	server.fdMu.Lock()
 	fd := server.fd
+	if fd >= 0 {
+		if err := unix.SetNonblock(fd, true); err != nil {
+			server.fdMu.Unlock()
+			return fmt.Errorf("set FUSE channel nonblocking: %w", err)
+		}
+	}
 	server.fdMu.Unlock()
 	if fd < 0 {
 		return fmt.Errorf("FUSE channel is unavailable")
@@ -104,6 +173,7 @@ func (m *epollMultiplexer) remove(server *Server) {
 }
 
 func (m *epollMultiplexer) run() {
+	defer close(m.done)
 	events := make([]unix.EpollEvent, epollBatchSize)
 	for {
 		count, err := unix.EpollWait(m.fd, events, -1)
@@ -115,8 +185,98 @@ func (m *epollMultiplexer) run() {
 			return
 		}
 		for i := 0; i < count; i++ {
+			if epollToken(events[i]) == multiplexerWatchdogControlToken {
+				if m.handleControlEvent() {
+					return
+				}
+				continue
+			}
 			m.dispatch(events[i])
 		}
+	}
+}
+
+func (m *epollMultiplexer) handleControlEvent() bool {
+	var payload [multiplexerWatchdogEventValueSize]byte
+	for {
+		_, err := unix.Read(m.controlFD, payload[:])
+		if errors.Is(err, unix.EINTR) {
+			continue
+		}
+		if err != nil && !errors.Is(err, unix.EAGAIN) && !errors.Is(err, unix.EWOULDBLOCK) {
+			m.markUnhealthy(fmt.Errorf("read shared FUSE watchdog event: %w", err))
+		}
+		break
+	}
+	select {
+	case <-m.stop:
+		return true
+	default:
+	}
+	sequence := m.probeSequence.Load()
+	select {
+	case m.probeAck <- sequence:
+	default:
+		select {
+		case <-m.probeAck:
+		default:
+		}
+		select {
+		case m.probeAck <- sequence:
+		default:
+		}
+	}
+	return false
+}
+
+func (m *epollMultiplexer) watch(interval, timeout time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-m.stop:
+			return
+		case <-ticker.C:
+		}
+		sequence := m.probeSequence.Add(1)
+		if err := writeEventFD(m.controlFD); err != nil {
+			m.markUnhealthy(fmt.Errorf("signal shared FUSE watchdog: %w", err))
+			return
+		}
+		timer := time.NewTimer(timeout)
+		acked := false
+		for !acked {
+			select {
+			case <-m.stop:
+				if !timer.Stop() {
+					<-timer.C
+				}
+				return
+			case ack := <-m.probeAck:
+				acked = ack >= sequence
+			case <-timer.C:
+				m.markUnhealthy(fmt.Errorf("shared FUSE epoll multiplexer made no progress for %s", timeout))
+				return
+			}
+		}
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+	}
+}
+
+func writeEventFD(fd int) error {
+	var payload [multiplexerWatchdogEventValueSize]byte
+	binary.NativeEndian.PutUint64(payload[:], 1)
+	for {
+		_, err := unix.Write(fd, payload[:])
+		if errors.Is(err, unix.EINTR) {
+			continue
+		}
+		return err
 	}
 }
 
@@ -140,10 +300,8 @@ func (m *epollMultiplexer) dispatch(event unix.EpollEvent) {
 }
 
 func (m *epollMultiplexer) fail(err error) {
+	m.markUnhealthy(err)
 	m.mu.Lock()
-	if m.runErr == nil {
-		m.runErr = err
-	}
 	servers := make([]*Server, 0, len(m.registrations))
 	for _, registration := range m.registrations {
 		servers = append(servers, registration.server)
@@ -152,6 +310,39 @@ func (m *epollMultiplexer) fail(err error) {
 	for _, server := range servers {
 		server.requestStop(err)
 	}
+}
+
+func (m *epollMultiplexer) markUnhealthy(err error) {
+	if m == nil || err == nil {
+		return
+	}
+	m.mu.Lock()
+	if m.runErr == nil {
+		m.runErr = err
+	}
+	m.mu.Unlock()
+}
+
+func (m *epollMultiplexer) health() error {
+	if m == nil {
+		return fmt.Errorf("shared FUSE epoll multiplexer is unavailable")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.runErr
+}
+
+func (m *epollMultiplexer) close() {
+	if m == nil {
+		return
+	}
+	m.closeOnce.Do(func() {
+		close(m.stop)
+		_ = writeEventFD(m.controlFD)
+		<-m.done
+		_ = unix.Close(m.controlFD)
+		_ = unix.Close(m.fd)
+	})
 }
 
 func (m *epollMultiplexer) activeCount() int {

--- a/pkg/fuseportal/server_linux.go
+++ b/pkg/fuseportal/server_linux.go
@@ -331,6 +331,9 @@ func (s *Server) handleReady(events uint32) (bool, error) {
 		return true, nil
 	}
 	request, err := readRequest(channelFD, s.opts.MaxWrite)
+	if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EWOULDBLOCK) {
+		return false, nil
+	}
 	if errors.Is(err, unix.ENODEV) || errors.Is(err, unix.EBADF) {
 		return true, nil
 	}

--- a/pkg/fuseportal/server_linux_test.go
+++ b/pkg/fuseportal/server_linux_test.go
@@ -268,6 +268,188 @@ func TestHandleAndReplyReturnsProtocolErrorToKernel(t *testing.T) {
 	}
 }
 
+func TestHandleReadyIgnoresStaleReadiness(t *testing.T) {
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC|unix.SOCK_NONBLOCK, 0)
+	if err != nil {
+		t.Fatalf("Socketpair() error = %v", err)
+	}
+	defer unix.Close(fds[1])
+	server, err := newServer(fuse.NewDefaultRawFileSystem(), fds[0], "", &fuse.MountOptions{})
+	if err != nil {
+		_ = unix.Close(fds[0])
+		t.Fatalf("newServer() error = %v", err)
+	}
+	defer server.closeDescriptors()
+
+	done := make(chan struct{})
+	var stop bool
+	var readyErr error
+	go func() {
+		stop, readyErr = server.handleReady(uint32(unix.EPOLLIN))
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handleReady blocked on stale epoll readiness")
+	}
+	if stop {
+		t.Fatal("handleReady() stop = true for stale epoll readiness")
+	}
+	if readyErr != nil {
+		t.Fatalf("handleReady() error = %v", readyErr)
+	}
+}
+
+func TestSharedEpollStaleReadinessDoesNotBlockAnotherPortal(t *testing.T) {
+	mux, err := newEpollMultiplexer(multiplexerConfig{
+		watchdogInterval: 10 * time.Millisecond,
+		watchdogTimeout:  200 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("newEpollMultiplexer() error = %v", err)
+	}
+	defer mux.close()
+
+	first, firstPeer, firstDone := newMultiplexerTestServer(t, mux)
+	second, secondPeer, secondDone := newMultiplexerTestServer(t, mux)
+	defer unix.Close(firstPeer)
+	defer unix.Close(secondPeer)
+	defer func() {
+		_ = first.Detach()
+		_ = second.Detach()
+		<-firstDone
+		<-secondDone
+	}()
+	waitForMultiplexerRegistrations(t, mux, 2)
+
+	first.fdMu.Lock()
+	firstFD := first.fd
+	first.fdMu.Unlock()
+	flags, err := unix.FcntlInt(uintptr(firstFD), unix.F_GETFL, 0)
+	if err != nil {
+		t.Fatalf("FcntlInt(F_GETFL) error = %v", err)
+	}
+	if flags&unix.O_NONBLOCK == 0 {
+		t.Fatalf("FUSE channel flags = %#x, want O_NONBLOCK", flags)
+	}
+
+	stop, err := first.handleReady(uint32(unix.EPOLLIN))
+	if err != nil {
+		t.Fatalf("first handleReady() error = %v", err)
+	}
+	if stop {
+		t.Fatal("first handleReady() stop = true for stale readiness")
+	}
+
+	request := testGetattrRequest(99)
+	if _, err := unix.Write(secondPeer, request); err != nil {
+		t.Fatalf("Write(second request) error = %v", err)
+	}
+	response, err := readTestResponse(secondPeer)
+	if err != nil {
+		t.Fatalf("Read(second response) error = %v", err)
+	}
+	if got := binary.LittleEndian.Uint64(response[8:16]); got != 99 {
+		t.Fatalf("second response unique = %d, want 99", got)
+	}
+}
+
+func TestMultiplexerWatchdogDetectsBlockedDispatch(t *testing.T) {
+	mux, err := newEpollMultiplexer(multiplexerConfig{
+		watchdogInterval: 5 * time.Millisecond,
+		watchdogTimeout:  40 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("newEpollMultiplexer() error = %v", err)
+	}
+	defer mux.close()
+
+	server, peerFD, serveDone := newMultiplexerTestServer(t, mux)
+	defer unix.Close(peerFD)
+	waitForMultiplexerRegistrations(t, mux, 1)
+
+	server.fdMu.Lock()
+	locked := true
+	defer func() {
+		if locked {
+			server.fdMu.Unlock()
+		}
+		_ = server.Detach()
+		<-serveDone
+	}()
+	if _, err := unix.Write(peerFD, testGetattrRequest(7)); err != nil {
+		t.Fatalf("Write(request) error = %v", err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for mux.health() == nil {
+		if time.Now().After(deadline) {
+			t.Fatal("multiplexer watchdog did not report blocked dispatch")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if err := mux.health(); err == nil || !strings.Contains(err.Error(), "made no progress") {
+		t.Fatalf("multiplexer health error = %v, want progress timeout", err)
+	}
+
+	server.fdMu.Unlock()
+	locked = false
+}
+
+func TestMultiplexerDetachWaitsForInFlightDispatch(t *testing.T) {
+	mux, err := newEpollMultiplexer(multiplexerConfig{
+		watchdogInterval: 5 * time.Millisecond,
+		watchdogTimeout:  40 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("newEpollMultiplexer() error = %v", err)
+	}
+	defer mux.close()
+
+	server, peerFD, serveDone := newMultiplexerTestServer(t, mux)
+	defer unix.Close(peerFD)
+	waitForMultiplexerRegistrations(t, mux, 1)
+
+	server.fdMu.Lock()
+	if _, err := unix.Write(peerFD, testGetattrRequest(11)); err != nil {
+		server.fdMu.Unlock()
+		t.Fatalf("Write(request) error = %v", err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for mux.health() == nil {
+		if time.Now().After(deadline) {
+			server.fdMu.Unlock()
+			t.Fatal("dispatch did not enter the blocked critical section")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	detachDone := make(chan error, 1)
+	go func() {
+		detachDone <- server.Detach()
+	}()
+	select {
+	case err := <-detachDone:
+		server.fdMu.Unlock()
+		t.Fatalf("Detach() returned before in-flight dispatch completed: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	server.fdMu.Unlock()
+	select {
+	case err := <-detachDone:
+		if err != nil {
+			t.Fatalf("Detach() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Detach() did not complete after dispatch was released")
+	}
+	if err := <-serveDone; err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+}
+
 func TestSharedEpollMultiplexesPortalChannels(t *testing.T) {
 	mux, err := sharedEpollMultiplexer()
 	if err != nil {
@@ -365,6 +547,44 @@ func TestSharedEpollMultiplexesPortalChannels(t *testing.T) {
 	if got := mux.activeCount(); got != baseline {
 		t.Fatalf("active epoll registrations after detach = %d, want %d", got, baseline)
 	}
+}
+
+func newMultiplexerTestServer(t *testing.T, mux *epollMultiplexer) (*Server, int, <-chan error) {
+	t.Helper()
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		t.Fatalf("Socketpair() error = %v", err)
+	}
+	server, err := newServer(fuse.NewDefaultRawFileSystem(), fds[0], "", &fuse.MountOptions{})
+	if err != nil {
+		_ = unix.Close(fds[0])
+		_ = unix.Close(fds[1])
+		t.Fatalf("newServer() error = %v", err)
+	}
+	server.mux = mux
+	done := make(chan error, 1)
+	go func() { done <- server.Serve() }()
+	return server, fds[1], done
+}
+
+func waitForMultiplexerRegistrations(t *testing.T, mux *epollMultiplexer, want int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for mux.activeCount() != want {
+		if time.Now().After(deadline) {
+			t.Fatalf("active epoll registrations = %d, want %d", mux.activeCount(), want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func testGetattrRequest(unique uint64) []byte {
+	request := make([]byte, int(unsafe.Sizeof(fuse.GetAttrIn{})))
+	binary.LittleEndian.PutUint32(request[0:4], uint32(len(request)))
+	binary.LittleEndian.PutUint32(request[4:8], opGetattr)
+	binary.LittleEndian.PutUint64(request[8:16], unique)
+	binary.LittleEndian.PutUint64(request[16:24], fuseRootID)
+	return request
 }
 
 func readTestResponse(fd int) ([]byte, error) {


### PR DESCRIPTION
## Summary

- keep the process-wide FUSE epoll multiplexer nonblocking, tolerate stale readiness, and expose a progress watchdog through ctld readiness/liveness so HA can fail over a stalled primary
- bound CRI bulk stats with a 3s deadline and fall back to rotating, concurrency/request/budget-limited per-sandbox stats so one stuck gVisor runtime cannot stop healthy sandbox metrics
- treat sustained runtime liveness failure as an internal platform fault and reconstruct the runtime through the existing durable pause/rootfs flow, regardless of `auto_resume`
- keep liveness detection, recovery progress, logs, and metrics internal; do not add a public `health` response field
- make recovery restart-safe, informer-race-safe, and idempotent across repeated events

## Root cause

A stale epoll readiness event could enter a blocking FUSE read in the shared multiplexer, starving every portal owned by that ctld process. Separately, CRI node-wide stats can wait on one unresponsive gVisor shim, which stopped metrics for otherwise healthy sandboxes. Manager did not reconstruct a runtime that stayed Kubernetes `Running` while its sandbox process was no longer responsive.

## Validation

Local:

- `make apispec`
- `go test ./manager/... ./cluster-gateway/... ./ctld/... ./pkg/fuseportal/...`
- focused race tests and `go vet` for the changed FUSE, ctld, manager, and gateway packages
- `git diff --check`

Aliyun remote kind environment, deployed from `d86fbcf9`:

- created a sandbox with `auto_resume: false`, stopped PID 1, made no Sandbox API request during recovery, and observed natural liveness failure followed by runtime generation `1 -> 2`
- verified the old Pod was removed, the new Pod became Ready, the sandbox returned to `running`, and a rootfs sentinel survived reconstruction
- verified detail responses have no `health` field and still report `auto_resume: false`
- restored a transient liveness failure before 90s, then waited beyond the original deadline and confirmed the same Pod UID and generation remained active
- repeated sustained failure, restarted manager after liveness became false, and verified the replacement still completed as generation `2 -> 3` with the rootfs sentinel intact
- ran continuous same-node I/O through neighboring FUSE portals during stalled-runtime, detach, reconstruction, and ctld failover tests
- stopped one host `runsc-sandbox`; bulk CRI stats hit the 3s deadline, then fallback continued collecting healthy sandbox metrics
- removed the temporary sandbox, confirmed `Sandbox0Infra Ready 10/10`, and stopped the ECS instance in `StopCharging` mode

## Compatibility and failure behavior

- no public OpenAPI response field is added for internal runtime health
- `auto_resume` remains an inbound access policy and does not control platform-initiated fault recovery
- a transient failure does not replace the runtime; sustained liveness failure is debounced for 90s
- if an unresponsive runtime cannot produce a fresh rootfs checkpoint within 30s, recovery preserves the last committed rootfs head and continues; mounted Sandbox Volumes remain independently durable
