### PR TITLE
Serialize session exit after input receipts

### DIFF
--- a/manager/procd/pkg/session/supervisor.go
+++ b/manager/procd/pkg/session/supervisor.go
@@ -1059,6 +1059,12 @@ func (s *Supervisor) handleStartFailure(managed *managedSession, runtime *attemp
 }
 
 func (s *Supervisor) handleExit(managed *managedSession, runtime *attemptRuntime, event process.ExitEvent) {
+	// EOF can make the child exit before WriteInput persists its receipt.
+	// Serialize exit handling behind in-flight input so acceptance stays durable
+	// and the journal preserves input.accepted before attempt.exited.
+	managed.inputMu.Lock()
+	defer managed.inputMu.Unlock()
+
 	managed.mu.Lock()
 	if managed.runtime != runtime {
 		managed.mu.Unlock()

--- a/manager/procd/pkg/session/supervisor_test.go
+++ b/manager/procd/pkg/session/supervisor_test.go
@@ -12,8 +12,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sandbox0-ai/sandbox0/manager/procd/pkg/process"
 	"go.uber.org/zap"
 )
+
+type blockingCloseInputProcess struct {
+	process.Process
+	closeStarted chan struct{}
+	closeRelease chan struct{}
+}
+
+func (p *blockingCloseInputProcess) CloseInput() error {
+	close(p.closeStarted)
+	<-p.closeRelease
+	return nil
+}
 
 func TestSupervisorConcurrentCreateDeduplicatesByKey(t *testing.T) {
 	supervisor := newTestSupervisor(t)
@@ -295,6 +308,110 @@ func TestSupervisorSerializesConcurrentDuplicateInput(t *testing.T) {
 	}
 	if stdout != "once\n" {
 		t.Fatalf("stdout = %q, want one input", stdout)
+	}
+}
+
+func TestSupervisorPersistsEOFReceiptBeforeAttemptExit(t *testing.T) {
+	supervisor := newTestSupervisor(t)
+	value, _, err := supervisor.Create(SessionSpec{
+		Command: []string{"/bin/cat"},
+		IO:      IOSpec{Mode: IOModePipes},
+	}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForSessionPhase(t, supervisor, value.ID, PhaseRunning)
+
+	managed, err := supervisor.getManaged(value.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	closeStarted := make(chan struct{})
+	closeRelease := make(chan struct{})
+	managed.mu.Lock()
+	runtime := managed.runtime
+	if runtime == nil {
+		managed.mu.Unlock()
+		t.Fatal("session runtime is missing")
+	}
+	originalProcess := runtime.proc
+	runtime.proc = &blockingCloseInputProcess{
+		Process:      originalProcess,
+		closeStarted: closeStarted,
+		closeRelease: closeRelease,
+	}
+	attemptID := runtime.attemptID
+	managed.mu.Unlock()
+	t.Cleanup(func() { _ = originalProcess.Stop() })
+
+	type inputResult struct {
+		response *InputResponse
+		err      error
+	}
+	inputDone := make(chan inputResult, 1)
+	go func() {
+		response, err := supervisor.WriteInput(value.ID, InputRequest{
+			InputID:           "eof",
+			ExpectedAttemptID: attemptID,
+			EOF:               true,
+		})
+		inputDone <- inputResult{response: response, err: err}
+	}()
+	<-closeStarted
+
+	exitDone := make(chan struct{})
+	go func() {
+		supervisor.handleExit(managed, runtime, process.ExitEvent{
+			ProcessID: runtime.attemptID,
+			ExitCode:  0,
+			State:     process.ProcessStateStopped,
+		})
+		close(exitDone)
+	}()
+	exitCompletedBeforeReceipt := false
+	select {
+	case <-exitDone:
+		exitCompletedBeforeReceipt = true
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(closeRelease)
+
+	var result inputResult
+	select {
+	case result = <-inputDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for EOF input")
+	}
+	select {
+	case <-exitDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for attempt exit")
+	}
+	if exitCompletedBeforeReceipt {
+		t.Fatal("attempt exit completed before the EOF receipt")
+	}
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if result.response == nil || !result.response.Accepted {
+		t.Fatalf("input response = %#v, want accepted", result.response)
+	}
+
+	page, err := supervisor.Events(value.ID, 0, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inputIndex, exitIndex := -1, -1
+	for index, event := range page.Events {
+		switch event.Type {
+		case "input.accepted":
+			inputIndex = index
+		case "attempt.exited":
+			exitIndex = index
+		}
+	}
+	if inputIndex < 0 || exitIndex <= inputIndex {
+		t.Fatalf("event order = input %d, exit %d; want input before exit", inputIndex, exitIndex)
 	}
 }
 


### PR DESCRIPTION
## Summary

- serialize attempt exit handling behind in-flight session input
- preserve the accepted EOF receipt before clearing the attempt runtime
- add a deterministic regression test for the EOF/exit race

## Root cause

Closing stdin can make a child exit before `WriteInput` reacquires the session
lock to persist its idempotency receipt. The exit handler could clear the
runtime first, so an EOF that had already reached the process returned
`ErrAttemptMismatch` and lost its receipt.

## Validation

- `make proto manifests apispec`
- `go mod tidy`
- `helm lint infra-operator/chart`
- `GOFLAGS=-buildvcs=false go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0 run ./...`
- PR Quick Check unit-test command across all non-e2e/non-integration packages with `-race -count=1`
- EOF/concurrent-input regression tests with `-race -count=100`
