### PR TITLE
Allow duplicate team names and slugs

### DIFF
--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -803,12 +803,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
-        "409":
-          description: Team already exists
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorEnvelope"
   /teams/{id}:
     get:
       tags: [teams]
@@ -876,7 +870,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
         "409":
-          description: Team update conflicts with an immutable field or existing slug
+          description: Team update conflicts with an immutable field
           content:
             application/json:
               schema:
@@ -4484,8 +4478,10 @@ components:
           type: string
         name:
           type: string
+          description: Display name. Team names are not unique; use the team ID as the canonical identifier.
         slug:
           type: string
+          description: Human-readable alias. Team slugs are not unique; use the team ID as the canonical identifier.
         owner_id:
           type: string
           nullable: true
@@ -4636,8 +4632,10 @@ components:
       properties:
         name:
           type: string
+          description: Display name. Team names are not unique.
         slug:
           type: string
+          description: Human-readable alias. Team slugs are not unique.
         home_region_id:
           type: string
           nullable: true
@@ -4647,8 +4645,10 @@ components:
       properties:
         name:
           type: string
+          description: Display name. Team names are not unique.
         slug:
           type: string
+          description: Human-readable alias. Team slugs are not unique.
     TransferTeamOwnerRequest:
       type: object
       properties:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -1135,8 +1135,12 @@ type CreateSnapshotRequest struct {
 // CreateTeamRequest defines model for CreateTeamRequest.
 type CreateTeamRequest struct {
 	HomeRegionId *string `json:"home_region_id"`
-	Name         string  `json:"name"`
-	Slug         *string `json:"slug,omitempty"`
+
+	// Name Display name. Team names are not unique.
+	Name string `json:"name"`
+
+	// Slug Human-readable alias. Team slugs are not unique.
+	Slug *string `json:"slug,omitempty"`
 }
 
 // CredentialBinding defines model for CredentialBinding.
@@ -3427,10 +3431,14 @@ type Team struct {
 	CreatedAt    time.Time `json:"created_at"`
 	HomeRegionId *string   `json:"home_region_id"`
 	Id           string    `json:"id"`
-	Name         string    `json:"name"`
-	OwnerId      *string   `json:"owner_id"`
-	Slug         string    `json:"slug"`
-	UpdatedAt    time.Time `json:"updated_at"`
+
+	// Name Display name. Team names are not unique; use the team ID as the canonical identifier.
+	Name    string  `json:"name"`
+	OwnerId *string `json:"owner_id"`
+
+	// Slug Human-readable alias. Team slugs are not unique; use the team ID as the canonical identifier.
+	Slug      string    `json:"slug"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // TeamDeleteConflictDetails defines model for TeamDeleteConflictDetails.
@@ -3632,7 +3640,10 @@ type UpdateTeamMemberRequestRole string
 
 // UpdateTeamRequest defines model for UpdateTeamRequest.
 type UpdateTeamRequest struct {
+	// Name Display name. Team names are not unique.
 	Name *string `json:"name,omitempty"`
+
+	// Slug Human-readable alias. Team slugs are not unique.
 	Slug *string `json:"slug,omitempty"`
 }
 

--- a/pkg/gateway/http/handlers/team.go
+++ b/pkg/gateway/http/handlers/team.go
@@ -154,10 +154,6 @@ func (h *TeamHandler) CreateTeam(c *gin.Context) {
 	}
 
 	if err := h.repo.CreateTeam(c.Request.Context(), team); err != nil {
-		if errors.Is(err, identity.ErrTeamAlreadyExists) {
-			spec.JSONError(c, http.StatusConflict, spec.CodeConflict, "team with this slug already exists")
-			return
-		}
 		h.logger.Error("Failed to create team", zap.Error(err))
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to create team")
 		return
@@ -300,10 +296,6 @@ func (h *TeamHandler) UpdateTeam(c *gin.Context) {
 	}
 
 	if err := h.repo.UpdateTeam(c.Request.Context(), team); err != nil {
-		if errors.Is(err, identity.ErrTeamAlreadyExists) {
-			spec.JSONError(c, http.StatusConflict, spec.CodeConflict, "team with this slug already exists")
-			return
-		}
 		h.logger.Error("Failed to update team", zap.Error(err))
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to update team")
 		return

--- a/pkg/gateway/identity/repository.go
+++ b/pkg/gateway/identity/repository.go
@@ -11,10 +11,9 @@ var (
 	ErrUserAlreadyExists  = errors.New("user already exists")
 	ErrInvalidCredentials = errors.New("invalid credentials")
 
-	ErrTeamNotFound      = errors.New("team not found")
-	ErrTeamAlreadyExists = errors.New("team already exists")
-	ErrMemberNotFound    = errors.New("team member not found")
-	ErrAlreadyMember     = errors.New("user is already a team member")
+	ErrTeamNotFound   = errors.New("team not found")
+	ErrMemberNotFound = errors.New("team member not found")
+	ErrAlreadyMember  = errors.New("user is already a team member")
 
 	ErrIdentityNotFound      = errors.New("identity not found")
 	ErrIdentityAlreadyExists = errors.New("identity already exists")

--- a/pkg/gateway/identity/ssh_public_key_repository_test.go
+++ b/pkg/gateway/identity/ssh_public_key_repository_test.go
@@ -223,6 +223,7 @@ func newGatewayIdentityTestPool(t *testing.T) (*pgxpool.Pool, string) {
 
 	pool, err := dbpool.New(ctx, dbpool.Options{
 		DatabaseURL: dbURL,
+		MaxConns:    4,
 		Schema:      schema,
 	})
 	if err != nil {

--- a/pkg/gateway/identity/team_repository.go
+++ b/pkg/gateway/identity/team_repository.go
@@ -22,9 +22,6 @@ func (r *Repository) CreateTeam(ctx context.Context, team *Team) error {
 		RETURNING id, created_at, updated_at
 	`, team.Name, team.Slug, team.OwnerID, team.HomeRegionID).Scan(&team.ID, &team.CreatedAt, &team.UpdatedAt)
 	if err != nil {
-		if isDuplicateKeyError(err) {
-			return ErrTeamAlreadyExists
-		}
 		return fmt.Errorf("insert team: %w", err)
 	}
 	return nil
@@ -47,23 +44,6 @@ func (r *Repository) GetTeamByID(ctx context.Context, id string) (*Team, error) 
 	return &team, nil
 }
 
-// GetTeamBySlug retrieves a team by slug.
-func (r *Repository) GetTeamBySlug(ctx context.Context, slug string) (*Team, error) {
-	var team Team
-	err := r.pool.QueryRow(ctx, `
-		SELECT id, name, slug, owner_id, home_region_id, created_at, updated_at
-		FROM teams
-		WHERE slug = $1
-	`, slug).Scan(&team.ID, &team.Name, &team.Slug, &team.OwnerID, &team.HomeRegionID, &team.CreatedAt, &team.UpdatedAt)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrTeamNotFound
-		}
-		return nil, fmt.Errorf("query team: %w", err)
-	}
-	return &team, nil
-}
-
 // UpdateTeam updates a team.
 func (r *Repository) UpdateTeam(ctx context.Context, team *Team) error {
 	err := r.pool.QueryRow(ctx, `
@@ -75,9 +55,6 @@ func (r *Repository) UpdateTeam(ctx context.Context, team *Team) error {
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return ErrTeamNotFound
-		}
-		if isDuplicateKeyError(err) {
-			return ErrTeamAlreadyExists
 		}
 		return fmt.Errorf("update team: %w", err)
 	}

--- a/pkg/gateway/identity/team_repository_test.go
+++ b/pkg/gateway/identity/team_repository_test.go
@@ -2,11 +2,13 @@ package identity
 
 import (
 	"context"
-	"errors"
 	"testing"
+
+	gatewaymigrations "github.com/sandbox0-ai/sandbox0/pkg/gateway/migrations"
+	"github.com/sandbox0-ai/sandbox0/pkg/migrate"
 )
 
-func TestTeamRepositoryScopesSlugUniquenessToOwner(t *testing.T) {
+func TestTeamRepositoryAllowsDuplicateNamesAndSlugs(t *testing.T) {
 	pool, _ := newGatewayIdentityTestPool(t)
 	if pool == nil {
 		return
@@ -35,9 +37,61 @@ func TestTeamRepositoryScopesSlugUniquenessToOwner(t *testing.T) {
 		t.Fatalf("create team B with same slug for another owner: %v", err)
 	}
 
-	duplicate := &Team{Name: "Duplicate", Slug: "gcp-us-east-4", OwnerID: &ownerAID}
-	if err := repo.CreateTeam(ctx, duplicate); !errors.Is(err, ErrTeamAlreadyExists) {
-		t.Fatalf("duplicate owner slug error = %v, want %v", err, ErrTeamAlreadyExists)
+	teamC := &Team{Name: "GCP US East 4", Slug: "gcp-us-east-4", OwnerID: &ownerAID}
+	if err := repo.CreateTeam(ctx, teamC); err != nil {
+		t.Fatalf("create team C with same name and slug for same owner: %v", err)
+	}
+
+	teamIDs := map[string]struct{}{
+		teamA.ID: {},
+		teamB.ID: {},
+		teamC.ID: {},
+	}
+	if len(teamIDs) != 3 {
+		t.Fatalf("team IDs are not unique: A=%s B=%s C=%s", teamA.ID, teamB.ID, teamC.ID)
+	}
+}
+
+func TestGatewayMigration14RepairsProductionSlugConstraint(t *testing.T) {
+	pool, schema := newGatewayIdentityTestPool(t)
+	if pool == nil {
+		return
+	}
+
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, `
+		DELETE FROM goose_db_version WHERE version_id = 14;
+		INSERT INTO goose_db_version (version_id, is_applied)
+		SELECT version_id, true
+		FROM generate_series(9, 13) AS versions(version_id);
+		ALTER TABLE teams ADD CONSTRAINT teams_slug_key UNIQUE (slug);
+	`); err != nil {
+		t.Fatalf("prepare production migration state: %v", err)
+	}
+
+	if err := migrate.Up(
+		ctx,
+		pool,
+		".",
+		migrate.WithBaseFS(gatewaymigrations.FS),
+		migrate.WithSchema(schema),
+	); err != nil {
+		t.Fatalf("apply migration 14 from production version: %v", err)
+	}
+
+	var hasGlobalConstraint bool
+	if err := pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_constraint
+			WHERE conrelid = 'teams'::regclass
+			  AND conname = 'teams_slug_key'
+		)
+	`).Scan(&hasGlobalConstraint); err != nil {
+		t.Fatalf("query global slug constraint: %v", err)
+	}
+	if hasGlobalConstraint {
+		t.Fatal("global team slug constraint still exists after migration 14")
 	}
 }
 
@@ -108,6 +162,11 @@ func TestTeamRepositoryTransferTeamOwnerPromotesMember(t *testing.T) {
 	team := &Team{Name: "Transfer Team", Slug: "transfer-team", OwnerID: &ownerID}
 	if err := repo.CreateTeam(ctx, team); err != nil {
 		t.Fatalf("create team: %v", err)
+	}
+	nextOwnerID := nextOwner.ID
+	existingTeam := &Team{Name: "Existing Team", Slug: "transfer-team", OwnerID: &nextOwnerID}
+	if err := repo.CreateTeam(ctx, existingTeam); err != nil {
+		t.Fatalf("create next owner's team with same slug: %v", err)
 	}
 	for _, member := range []*TeamMember{
 		{TeamID: team.ID, UserID: owner.ID, Role: "admin"},

--- a/pkg/gateway/migrations/00014_allow_duplicate_team_slugs.sql
+++ b/pkg/gateway/migrations/00014_allow_duplicate_team_slugs.sql
@@ -1,0 +1,29 @@
+-- +goose Up
+-- Version 14 intentionally follows migration versions recorded by existing deployments.
+ALTER TABLE IF EXISTS teams
+    DROP CONSTRAINT IF EXISTS teams_slug_key;
+
+DROP INDEX IF EXISTS teams_slug_key;
+DROP INDEX IF EXISTS idx_teams_owner_slug;
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM teams
+        WHERE owner_id IS NOT NULL
+          AND slug IS NOT NULL
+        GROUP BY owner_id, slug
+        HAVING COUNT(*) > 1
+    ) THEN
+        RAISE EXCEPTION 'cannot restore owner-scoped unique team slugs while duplicate slugs exist';
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_teams_owner_slug
+    ON teams(owner_id, slug)
+    WHERE slug IS NOT NULL;


### PR DESCRIPTION
## Summary

- add forward migration 14 to remove both global and owner-scoped team slug uniqueness
- keep team IDs as the canonical unique identifier while allowing duplicate names and slugs
- remove the now-ambiguous global slug lookup and stale slug-conflict handling
- document the API contract and regenerate API types
- add PostgreSQL coverage for fresh schemas, ownership transfer, and the deployed version-13 migration state

## Root cause

The deployed global gateway database still has `teams_slug_key UNIQUE (slug)`. Its Goose ledger is already at version 13, so the later migration that reused version 6 to scope slug uniqueness was treated as already applied. A new version 14 migration is required to converge both deployed and fresh databases.

The migration only removes uniqueness constraints and indexes. It does not rewrite existing team rows.

## Impact

Team names and slugs may repeat, including for the same owner. Authentication, routing, and resource identity continue to use the UUID team ID.

## Validation

- `make proto manifests apispec`
- `go mod tidy`
- `helm lint infra-operator/chart`
- `GOFLAGS=-buildvcs=false golangci-lint run ./...`
- PR Quick Check unit-test command with race detection across all non-e2e packages
- full `pkg/gateway/identity` suite against PostgreSQL 15
- production-shape regression from Goose version 13 with `teams_slug_key UNIQUE (slug)` to migration 14
