### PR TITLE
Fix long-running context request timeouts

### DIFF
--- a/cluster-gateway/pkg/http/handlers_context.go
+++ b/cluster-gateway/pkg/http/handlers_context.go
@@ -60,7 +60,7 @@ func (s *Server) createContext(c *gin.Context) {
 	upReq.Header = c.Request.Header.Clone()
 	requestModifier(upReq)
 
-	resp, err := s.outboundHTTPClient().Do(upReq)
+	resp, err := proxy.ClientForRequest(s.outboundHTTPClient(), upReq).Do(upReq)
 	if err != nil {
 		if proxy.IsTimeoutError(err) {
 			spec.JSONError(c, http.StatusGatewayTimeout, spec.CodeUnavailable, "sandbox process request timed out")

--- a/cluster-gateway/pkg/http/handlers_context_test.go
+++ b/cluster-gateway/pkg/http/handlers_context_test.go
@@ -7,18 +7,83 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/client"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
 	gatewayauthn "github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"github.com/sandbox0-ai/sandbox0/pkg/proxy"
 	"go.uber.org/zap"
 )
+
+func TestCreateContextHonorsDisabledUpstreamTimeout(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	procd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/contexts" {
+			t.Fatalf("unexpected procd request %s %s", r.Method, r.URL.Path)
+		}
+		time.Sleep(50 * time.Millisecond)
+		_ = spec.WriteSuccess(w, http.StatusCreated, map[string]any{"id": "ctx-1"})
+	}))
+	defer procd.Close()
+
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	tokenGen := internalauth.NewGenerator(internalauth.GeneratorConfig{
+		Caller:     "cluster-gateway",
+		PrivateKey: privateKey,
+		TTL:        time.Minute,
+	})
+	manager := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = spec.WriteSuccess(w, http.StatusOK, mgr.Sandbox{
+			ID:           "sb-1",
+			TeamID:       "team-a",
+			UserID:       "user-a",
+			InternalAddr: procd.URL,
+			Status:       mgr.SandboxStatusRunning,
+		})
+	}))
+	defer manager.Close()
+
+	cfg := &config.ClusterGatewayConfig{}
+	cfg.ProxyTimeout.Duration = 10 * time.Millisecond
+	server := &Server{
+		cfg:             cfg,
+		managerClient:   client.NewManagerClient(manager.URL, tokenGen, zap.NewNop(), time.Second),
+		internalAuthGen: tokenGen,
+		logger:          zap.NewNop(),
+		httpClient:      &http.Client{Timeout: cfg.ProxyTimeout.Duration},
+	}
+
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Params = gin.Params{{Key: "id", Value: "sb-1"}}
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/sandboxes/sb-1/contexts",
+		strings.NewReader(`{"type":"cmd","cmd":{"command":["sh","-lc","true"]},"wait_until_done":true}`),
+	)
+	req = proxy.WithUpstreamTimeoutDisabledRequest(req)
+	authCtx := &gatewayauthn.AuthContext{TeamID: "team-a", UserID: "user-a"}
+	ctx.Set("auth_context", authCtx)
+	ctx.Request = req.WithContext(gatewayauthn.WithAuthContext(req.Context(), authCtx))
+
+	server.createContext(ctx)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+}
 
 func TestGetProcdURLFetchesManagerForEachRequest(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/docs/sandbox/contexts/page.mdx
+++ b/docs/sandbox/contexts/page.mdx
@@ -415,12 +415,43 @@ Create a new context in a sandbox.
 | `pty_size` | object | Terminal size `{rows, cols}` |
 | `ttl_sec` | integer | Context time-to-live in seconds |
 | `idle_timeout_sec` | integer | Idle timeout in seconds |
-| `wait_until_done` | boolean | Wait for completion (default: false) |
+| `wait_until_done` | boolean | Wait for completion on the create request (default: false) |
 
 For Cmd contexts created with `wait_until_done: true`, the response includes
 `output_raw`, `stdout`, `stderr`, `exit_code`, and `state` after the process
 exits. `stdout` and `stderr` are populated for non-PTY Cmd contexts when
 available; PTY and REPL contexts may only expose `output_raw`.
+
+### Long-running commands
+
+Do not keep the create request open for a command that may run for a long time.
+Create the Cmd context with `wait_until_done: false` and a bounded `ttl_sec`,
+attach to its [WebSocket stream](#websocket-streaming), and then fetch the
+context after the terminal `done` event to read the final `stdout`, `stderr`,
+`exit_code`, and `state`.
+
+```bash
+# 1. Start the command and save data.id from the response.
+curl -X POST "$SANDBOX0_BASE_URL/api/v1/sandboxes/$SANDBOX_ID/contexts" \
+    -H "Authorization: Bearer $SANDBOX0_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{
+        "type": "cmd",
+        "cmd": {"command": ["sh", "-lc", "run-my-long-job"]},
+        "wait_until_done": false,
+        "ttl_sec": 3600
+    }'
+
+# 2. Follow /contexts/{context_id}/ws until its terminal done event.
+# 3. Read the final result.
+curl "$SANDBOX0_BASE_URL/api/v1/sandboxes/$SANDBOX_ID/contexts/$CONTEXT_ID" \
+    -H "Authorization: Bearer $SANDBOX0_TOKEN"
+```
+
+The Context WebSocket is live rather than replayable. If the caller must
+disconnect and later resume output from a cursor, retain process identity across
+retries, or recover execution after sandbox runtime replacement, use a
+[Supervised Session](/docs/sandbox/session-supervisor) instead.
 
 ### REPL Configuration
 

--- a/manager/procd/pkg/http/handlers/context.go
+++ b/manager/procd/pkg/http/handlers/context.go
@@ -24,16 +24,18 @@ import (
 
 // ContextHandler handles context-related HTTP requests.
 type ContextHandler struct {
-	manager  *ctxpkg.Manager
-	logger   *zap.Logger
-	upgrader websocket.Upgrader
+	manager     *ctxpkg.Manager
+	logger      *zap.Logger
+	execTimeout time.Duration
+	upgrader    websocket.Upgrader
 }
 
 // NewContextHandler creates a new context handler.
 func NewContextHandler(manager *ctxpkg.Manager, logger *zap.Logger) *ContextHandler {
 	return &ContextHandler{
-		manager: manager,
-		logger:  logger,
+		manager:     manager,
+		logger:      logger,
+		execTimeout: execTimeout,
 		upgrader: websocket.Upgrader{
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,
@@ -372,7 +374,7 @@ func (h *ContextHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.WaitUntilDone {
-		output, execErr, aborted := h.execInputSync(ctx, input, r.Context())
+		output, execErr, aborted := h.execInputSyncWithTimeout(ctx, input, r.Context(), 0)
 		if aborted {
 			return
 		}
@@ -607,6 +609,18 @@ func applySplitOutputToExecResponse(response *ContextExecResponse, ctx *ctxpkg.C
 }
 
 func (h *ContextHandler) execInputSync(ctx *ctxpkg.Context, input string, requestCtx context.Context) (string, *execError, bool) {
+	return h.execInputSyncWithTimeout(ctx, input, requestCtx, h.execTimeout)
+}
+
+// execInputSyncWithTimeout waits for a prompt or process completion. A
+// non-positive timeout lets the request context and context cleanup policy own
+// the lifetime, which is required by wait_until_done context creation.
+func (h *ContextHandler) execInputSyncWithTimeout(
+	ctx *ctxpkg.Context,
+	input string,
+	requestCtx context.Context,
+	executionTimeout time.Duration,
+) (string, *execError, bool) {
 	if ctx == nil || ctx.MainProcess == nil {
 		return "", &execError{
 			status:  http.StatusConflict,
@@ -662,8 +676,13 @@ func (h *ContextHandler) execInputSync(ctx *ctxpkg.Context, input string, reques
 		}, false
 	}
 
-	timeout := time.NewTimer(execTimeout)
-	defer timeout.Stop()
+	var timeout *time.Timer
+	var timeoutCh <-chan time.Time
+	if executionTimeout > 0 {
+		timeout = time.NewTimer(executionTimeout)
+		timeoutCh = timeout.C
+		defer timeout.Stop()
+	}
 
 	var output bytes.Buffer
 	var promptTimer *time.Timer
@@ -672,7 +691,7 @@ func (h *ContextHandler) execInputSync(ctx *ctxpkg.Context, input string, reques
 		select {
 		case <-requestCtx.Done():
 			return "", nil, true
-		case <-timeout.C:
+		case <-timeoutCh:
 			return "", &execError{
 				status:  http.StatusRequestTimeout,
 				code:    "exec_timeout",

--- a/manager/procd/pkg/http/handlers/context_test.go
+++ b/manager/procd/pkg/http/handlers/context_test.go
@@ -287,6 +287,37 @@ func TestCreateContextWaitUntilDoneIncludesCMDSplitOutput(t *testing.T) {
 	}
 }
 
+func TestCreateContextWaitUntilDoneCanExceedExecTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell command fixture requires POSIX")
+	}
+	handler := NewContextHandler(ctxpkg.NewManager(), zap.NewNop())
+	handler.execTimeout = 10 * time.Millisecond
+	req := httptest.NewRequest(http.MethodPost, "/contexts", strings.NewReader(`{
+		"type": "cmd",
+		"cmd": {"command": ["/bin/sh", "-c", "sleep 0.05; printf done"]},
+		"wait_until_done": true,
+		"ttl_sec": 1
+	}`))
+	rec := httptest.NewRecorder()
+
+	handler.Create(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var resp struct {
+		Success bool            `json:"success"`
+		Data    ContextResponse `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if !resp.Success || resp.Data.Stdout == nil || *resp.Data.Stdout != "done" {
+		t.Fatalf("response = %+v, want successful output after exec timeout", resp)
+	}
+}
+
 func TestExecReturnsCMDTerminalStatus(t *testing.T) {
 	outputCh := make(chan process.ProcessOutput, 1)
 	var proc *fakeProcess
@@ -426,6 +457,21 @@ func TestExecInputSync_OutputBeforePromptReturnsOutput(t *testing.T) {
 	}
 	if output != "_S0_> hello world" {
 		t.Errorf("output = %q, want %q", output, "_S0_> hello world")
+	}
+}
+
+func TestExecInputSyncRetainsInteractionTimeout(t *testing.T) {
+	proc := &fakeProcess{outputCh: make(chan process.ProcessOutput)}
+	handler, ctx := newHandlerWithContext(proc, process.ProcessTypeREPL)
+	handler.execTimeout = 10 * time.Millisecond
+
+	_, execErr, aborted := handler.execInputSync(ctx, "print('hello world')\n", context.Background())
+
+	if aborted {
+		t.Fatal("execInputSync() aborted, want timeout error")
+	}
+	if execErr == nil || execErr.code != "exec_timeout" {
+		t.Fatalf("execInputSync() error = %#v, want exec_timeout", execErr)
 	}
 }
 

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -6664,6 +6664,12 @@ components:
           $ref: "#/components/schemas/CreateCMDContextRequest"
         wait_until_done:
           type: boolean
+          description: >-
+            Wait for the context process to finish before returning. For
+            long-running commands, prefer an asynchronous context with a
+            bounded ttl_sec and follow it through the context WebSocket and GET
+            APIs. Use a supervised session when reconnectable, replayable, or
+            restartable execution is required.
         cwd:
           type: string
         env_vars:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -1038,7 +1038,9 @@ type CreateContextRequest struct {
 	Repl           *CreateREPLContextRequest `json:"repl,omitempty"`
 	TtlSec         *int32                    `json:"ttl_sec,omitempty"`
 	Type           *ProcessType              `json:"type,omitempty"`
-	WaitUntilDone  *bool                     `json:"wait_until_done,omitempty"`
+
+	// WaitUntilDone Wait for the context process to finish before returning. For long-running commands, prefer an asynchronous context with a bounded ttl_sec and follow it through the context WebSocket and GET APIs. Use a supervised session when reconnectable, replayable, or restartable execution is required.
+	WaitUntilDone *bool `json:"wait_until_done,omitempty"`
 }
 
 // CreateExecutionSessionAttemptRequest defines model for CreateExecutionSessionAttemptRequest.

--- a/pkg/proxy/request_timeout.go
+++ b/pkg/proxy/request_timeout.go
@@ -113,6 +113,21 @@ func ApplyRequestTimeout(req *http.Request, defaultTimeout time.Duration) (*http
 	return req.WithContext(ctx), cancel
 }
 
+// ClientForRequest returns an HTTP client that honors the request's upstream
+// timeout policy. http.Client.Timeout is a separate deadline from the request
+// context, so it must also be disabled for whitelisted requests.
+func ClientForRequest(client *http.Client, req *http.Request) *http.Client {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	if req == nil || client.Timeout <= 0 || !UpstreamTimeoutDisabled(req.Context()) {
+		return client
+	}
+	withoutTimeout := *client
+	withoutTimeout.Timeout = 0
+	return &withoutTimeout
+}
+
 // IsTimeoutError reports whether err was caused by an upstream timeout.
 func IsTimeoutError(err error) bool {
 	if err == nil {

--- a/pkg/proxy/request_timeout_test.go
+++ b/pkg/proxy/request_timeout_test.go
@@ -1,0 +1,45 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestClientForRequestDisablesClientTimeoutForWhitelistedRequest(t *testing.T) {
+	client := &http.Client{Timeout: time.Second}
+	req, err := http.NewRequestWithContext(
+		WithUpstreamTimeoutDisabled(context.Background()),
+		http.MethodGet,
+		"http://example.com",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext() error = %v", err)
+	}
+
+	got := ClientForRequest(client, req)
+
+	if got == client {
+		t.Fatal("ClientForRequest() returned the original timed client")
+	}
+	if got.Timeout != 0 {
+		t.Fatalf("ClientForRequest() timeout = %s, want 0", got.Timeout)
+	}
+	if client.Timeout != time.Second {
+		t.Fatalf("original client timeout = %s, want 1s", client.Timeout)
+	}
+}
+
+func TestClientForRequestPreservesDefaultTimeout(t *testing.T) {
+	client := &http.Client{Timeout: time.Second}
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+
+	if got := ClientForRequest(client, req); got != client {
+		t.Fatal("ClientForRequest() replaced the client for a normal request")
+	}
+}


### PR DESCRIPTION
## What changed

- make direct Context creation calls honor the gateway's disabled-upstream-timeout marker, including the separate `http.Client.Timeout`
- let `wait_until_done` Context creation run until process completion, request cancellation, or the Context cleanup policy, while retaining the 30-second interaction timeout for `/exec`
- document the recommended long-running command flow: asynchronous Context, bounded `ttl_sec`, WebSocket terminal event, final GET, and Supervised Sessions when replay or recovery is required
- add gateway and procd regression coverage and regenerate the OpenAPI types

## Root cause

The sandbox route middleware disabled the request-context timeout, but cluster-gateway's shared HTTP client still imposed its own 10-second deadline on the direct create-Context request. After that layer, procd independently imposed a hardcoded 30-second execution timeout on `wait_until_done`.

## Validation

- `make proto manifests apispec`
- `go mod tidy` with no `go.mod` or `go.sum` diff
- `GOFLAGS=-buildvcs=false golangci-lint run ./...`
- `GOTOOLCHAIN=go1.25.0+auto go test -buildvcs=false -race -count=1` for all non-e2e/integration packages
