### PR TITLE
Fix resume failure reporting and template pool status

### DIFF
--- a/cluster-gateway/pkg/client/manager.go
+++ b/cluster-gateway/pkg/client/manager.go
@@ -3,7 +3,6 @@ package client
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -24,6 +23,9 @@ var (
 
 	// ErrManagerUnavailable indicates the manager service is unreachable or returned an unexpected error.
 	ErrManagerUnavailable = errors.New("manager service unavailable")
+
+	// ErrSandboxResumeFailed indicates manager returned a completed, unsuccessful resume response.
+	ErrSandboxResumeFailed = errors.New("sandbox resume failed")
 )
 
 // ManagerClient provides methods to call manager APIs
@@ -209,12 +211,7 @@ func (c *ManagerClient) ResumeSandbox(ctx context.Context, sandboxID, userID, te
 	}
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		var payload map[string]any
-		_ = json.Unmarshal(body, &payload)
-		if msg, ok := payload["message"].(string); ok && msg != "" {
-			return fmt.Errorf("%w: %s", ErrManagerUnavailable, msg)
-		}
-		return fmt.Errorf("%w: unexpected status code %d", ErrManagerUnavailable, resp.StatusCode)
+		return sandboxResumeStatusError(resp.StatusCode, body)
 	}
 	return nil
 }
@@ -236,4 +233,11 @@ func managerUnavailableStatusError(statusCode int, body []byte) error {
 		return fmt.Errorf("%w: %s", ErrManagerUnavailable, message)
 	}
 	return fmt.Errorf("%w: unexpected status code %d: %s", ErrManagerUnavailable, statusCode, string(body))
+}
+
+func sandboxResumeStatusError(statusCode int, body []byte) error {
+	if message, ok := spec.DecodeErrorMessage(body); ok {
+		return fmt.Errorf("%w: %s", ErrSandboxResumeFailed, message)
+	}
+	return fmt.Errorf("%w: unexpected status code %d: %s", ErrSandboxResumeFailed, statusCode, string(body))
 }

--- a/cluster-gateway/pkg/client/manager_test.go
+++ b/cluster-gateway/pkg/client/manager_test.go
@@ -61,3 +61,56 @@ func TestResumeSandboxUsesRequestContextInsteadOfClientTimeout(t *testing.T) {
 		t.Fatalf("ResumeSandbox() error = %v, want nil", err)
 	}
 }
+
+func TestResumeSandboxMarksManagerErrorResponseAsDefinitiveFailure(t *testing.T) {
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	tokenGen := internalauth.NewGenerator(internalauth.GeneratorConfig{
+		Caller:     "cluster-gateway",
+		PrivateKey: privateKey,
+		TTL:        time.Minute,
+	})
+	manager := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusGatewayTimeout)
+		_, _ = w.Write([]byte(`{"success":false,"error":{"code":"unavailable","message":"runtime initialization timed out"}}`))
+	}))
+	defer manager.Close()
+
+	client := NewManagerClient(manager.URL, tokenGen, zap.NewNop(), time.Second)
+	err = client.ResumeSandbox(context.Background(), "sandbox-1", "user-1", "team-1")
+	if !errors.Is(err, ErrSandboxResumeFailed) {
+		t.Fatalf("ResumeSandbox() error = %v, want ErrSandboxResumeFailed", err)
+	}
+	if strings.Contains(err.Error(), "unexpected status code") {
+		t.Fatalf("ResumeSandbox() error = %q, want decoded manager message", err.Error())
+	}
+	if !strings.Contains(err.Error(), "runtime initialization timed out") {
+		t.Fatalf("ResumeSandbox() error = %q, want manager message", err.Error())
+	}
+}
+
+func TestResumeSandboxDoesNotMarkTransportUncertaintyAsDefinitiveFailure(t *testing.T) {
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	tokenGen := internalauth.NewGenerator(internalauth.GeneratorConfig{
+		Caller:     "cluster-gateway",
+		PrivateKey: privateKey,
+		TTL:        time.Minute,
+	})
+	client := NewManagerClient("http://127.0.0.1:1", tokenGen, zap.NewNop(), time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = client.ResumeSandbox(ctx, "sandbox-1", "user-1", "team-1")
+	if err == nil {
+		t.Fatal("ResumeSandbox() error = nil, want canceled request error")
+	}
+	if errors.Is(err, ErrSandboxResumeFailed) {
+		t.Fatalf("ResumeSandbox() error = %v, do not want ErrSandboxResumeFailed", err)
+	}
+}

--- a/cluster-gateway/pkg/http/handlers_context.go
+++ b/cluster-gateway/pkg/http/handlers_context.go
@@ -238,7 +238,11 @@ func (s *Server) getProcdURL(c *gin.Context, sandboxID string) (*url.URL, error)
 				zap.String("sandbox_id", sandboxID),
 				zap.Error(err),
 			)
-			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is waking up")
+			if errors.Is(err, client.ErrSandboxResumeFailed) {
+				spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeSandboxResumeFailed, "sandbox resume failed")
+			} else {
+				spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is waking up")
+			}
 			return nil, err
 		}
 		if needsRuntimeRefetch {

--- a/cluster-gateway/pkg/http/handlers_context_test.go
+++ b/cluster-gateway/pkg/http/handlers_context_test.go
@@ -236,8 +236,88 @@ func TestGetProcdURLPausedSandboxReturnsWakingUp(t *testing.T) {
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
 	}
+	assertGatewayError(t, rec, spec.CodeUnavailable, "sandbox is waking up")
 	if resumeCalls != 1 {
 		t.Fatalf("resumeCalls = %d, want 1", resumeCalls)
+	}
+}
+
+func TestGetProcdURLReportsDefinitiveResumeFailure(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	validator := internalauth.NewValidator(internalauth.ValidatorConfig{
+		Target:             "manager",
+		PublicKey:          publicKey,
+		AllowedCallers:     []string{"cluster-gateway"},
+		ClockSkewTolerance: 5 * time.Second,
+	})
+	tokenGen := internalauth.NewGenerator(internalauth.GeneratorConfig{
+		Caller:     "cluster-gateway",
+		PrivateKey: privateKey,
+		TTL:        time.Minute,
+	})
+
+	var resumeCalls int
+	manager := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := validator.Validate(r.Header.Get(internalauth.DefaultTokenHeader)); err != nil {
+			t.Fatalf("validate token: %v", err)
+		}
+		switch {
+		case r.Method == http.MethodGet:
+			_ = spec.WriteSuccess(w, http.StatusOK, mgr.Sandbox{
+				ID:         "sb-1",
+				TeamID:     "team-a",
+				UserID:     "user-a",
+				Status:     mgr.SandboxStatusPaused,
+				Paused:     true,
+				AutoResume: true,
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sandboxes/sb-1/resume":
+			resumeCalls++
+			_ = spec.WriteError(w, http.StatusGatewayTimeout, spec.CodeUnavailable, "runtime initialization timed out")
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer manager.Close()
+
+	server := &Server{
+		managerClient: client.NewManagerClient(manager.URL, tokenGen, zap.NewNop(), time.Second),
+		logger:        zap.NewNop(),
+	}
+
+	addr, rec := mustGetProcdURL(t, server, "team-a", "user-a", "sb-1")
+	if addr != nil {
+		t.Fatalf("addr = %v, want nil", addr)
+	}
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+	assertGatewayError(t, rec, spec.CodeSandboxResumeFailed, "sandbox resume failed")
+	if resumeCalls != 1 {
+		t.Fatalf("resumeCalls = %d, want 1", resumeCalls)
+	}
+}
+
+func assertGatewayError(t *testing.T, rec *httptest.ResponseRecorder, code string, message string) {
+	t.Helper()
+
+	var response spec.Response
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode gateway response: %v", err)
+	}
+	if response.Error == nil {
+		t.Fatal("gateway response error is nil")
+	}
+	if response.Error.Code != code {
+		t.Fatalf("error code = %q, want %q", response.Error.Code, code)
+	}
+	if response.Error.Message != message {
+		t.Fatalf("error message = %q, want %q", response.Error.Message, message)
 	}
 }
 

--- a/cluster-gateway/pkg/http/handlers_exposure.go
+++ b/cluster-gateway/pkg/http/handlers_exposure.go
@@ -103,7 +103,11 @@ func (s *Server) handlePublicExposureNoRoute(c *gin.Context) {
 		}
 		if err := s.managerClient.ResumeSandbox(c.Request.Context(), sandboxID, "", sandbox.TeamID); err != nil {
 			s.logger.Warn("Auto resume failed", zap.String("sandbox_id", sandboxID), zap.Error(err))
-			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is waking up")
+			if errors.Is(err, client.ErrSandboxResumeFailed) {
+				spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeSandboxResumeFailed, "sandbox resume failed")
+			} else {
+				spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is waking up")
+			}
 			return
 		}
 		s.invalidateSandboxInternalCache(c.Request.Context(), sandboxID)

--- a/cluster-gateway/pkg/http/handlers_internal_sandboxes.go
+++ b/cluster-gateway/pkg/http/handlers_internal_sandboxes.go
@@ -97,7 +97,11 @@ func (s *Server) resumeInternalSandbox(c *gin.Context) {
 			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "sandbox not found")
 			return
 		}
-		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox resume failed")
+		if errors.Is(err, client.ErrSandboxResumeFailed) {
+			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeSandboxResumeFailed, "sandbox resume failed")
+			return
+		}
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "manager service unavailable")
 		return
 	}
 	s.invalidateSandboxInternalCache(c.Request.Context(), sandboxID)

--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -195,6 +195,11 @@ Common auto-resume entrypoints:
 
 For a paused sandbox, auto-resume creates a new runtime pod for the same sandbox identity and restores the saved rootfs checkpoint before the sandbox is used. Public service URLs remain stable until the sandbox is explicitly deleted or `hard_ttl` expires.
 
+Supported runtime access distinguishes an accepted resume from a failed attempt:
+
+- `503 unavailable` with `sandbox is waking up` means the accepted lifecycle transition has not committed yet; poll sandbox details before retrying the runtime request
+- `503 sandbox_resume_failed` with `sandbox resume failed` means that resume attempt ended unsuccessfully; clients may perform a bounded retry, but should not treat the failed attempt as still in progress
+
 Running PIDs, memory, sockets, and client attachments do not survive pause. A [supervised session](/docs/sandbox/session-supervisor) keeps its logical identity and retained journal, then follows its `runtime_recovery` policy in the new runtime generation.
 
 See [Sandbox Services](/docs/sandbox/services), [Sandbox Functions](/docs/sandbox/functions), and [SSH](/docs/sandbox/ssh) for the user-facing flows.

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -233,6 +233,7 @@ func main() {
 	// Create operator
 	operator := controller.NewOperator(
 		k8sClient,
+		crdClient,
 		podInformer.Informer(),
 		replicaSetInformer,
 		secretInformer,

--- a/manager/pkg/controller/operator.go
+++ b/manager/pkg/controller/operator.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	clientset "github.com/sandbox0-ai/sandbox0/manager/pkg/generated/clientset/versioned"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/namespacepolicy"
 	obsmetrics "github.com/sandbox0-ai/sandbox0/pkg/observability/metrics"
 	"go.uber.org/zap"
@@ -21,6 +22,7 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 )
 
@@ -31,6 +33,7 @@ const (
 // Operator is the main controller for SandboxTemplate CRD
 type Operator struct {
 	k8sClient      kubernetes.Interface
+	crdClient      clientset.Interface
 	podLister      corelisters.PodLister
 	podsSynced     cache.InformerSynced
 	poolManager    *PoolManager
@@ -95,6 +98,7 @@ func (t *TemplateListerImpl) Get(namespace, name string) (*v1alpha1.SandboxTempl
 // NewOperator creates a new Operator
 func NewOperator(
 	k8sClient kubernetes.Interface,
+	crdClient clientset.Interface,
 	podInformer cache.SharedIndexInformer,
 	replicaSetInformer cache.SharedIndexInformer,
 	secretInformer cache.SharedIndexInformer,
@@ -116,6 +120,7 @@ func NewOperator(
 
 	op := &Operator{
 		k8sClient:        k8sClient,
+		crdClient:        crdClient,
 		podLister:        podLister,
 		podsSynced:       podInformer.HasSynced,
 		poolManager:      poolManager,
@@ -338,25 +343,95 @@ func (op *Operator) updateTemplateStatus(ctx context.Context, template *v1alpha1
 		}
 	}
 
-	// Update status if changed
-	if template.Status.IdleCount != idleCount || template.Status.ActiveCount != activeCount {
-		template.Status.IdleCount = idleCount
-		template.Status.ActiveCount = activeCount
-		template.Status.LastUpdateTime = metav1.Now()
+	if err := op.persistTemplateStatus(ctx, template.Namespace, template.Name, idleCount, activeCount); err != nil {
+		return err
+	}
 
-		// Update conditions
-		template.Status.Conditions = op.computeConditions(template, idleCount, activeCount)
+	return nil
+}
 
-		// Note: In a real implementation, we should use a status subresource update
-		// For now, we'll just log the status
+// persistTemplateStatus writes pool observations without mutating informer
+// objects or overwriting status owned by another controller.
+func (op *Operator) persistTemplateStatus(
+	ctx context.Context,
+	namespace string,
+	name string,
+	idleCount int32,
+	activeCount int32,
+) error {
+	if op.crdClient == nil {
+		return fmt.Errorf("sandbox template client is not configured")
+	}
+
+	templates := op.crdClient.Sandbox0V1alpha1().SandboxTemplates(namespace)
+	updated := false
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := templates.Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		conditions := op.computeConditions(current, idleCount, activeCount)
+		preserveConditionTransitionTimes(current.Status.Conditions, conditions)
+		if current.Status.IdleCount == idleCount &&
+			current.Status.ActiveCount == activeCount &&
+			templateConditionsEqual(current.Status.Conditions, conditions) {
+			return nil
+		}
+
+		next := current.DeepCopy()
+		next.Status.IdleCount = idleCount
+		next.Status.ActiveCount = activeCount
+		next.Status.Conditions = conditions
+		next.Status.LastUpdateTime = metav1.Now()
+		if _, err := templates.Update(ctx, next, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+		updated = true
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if updated {
 		op.logger.Info("Template status updated",
-			zap.String("template", template.Name),
+			zap.String("template", name),
 			zap.Int32("idle", idleCount),
 			zap.Int32("active", activeCount),
 		)
 	}
-
 	return nil
+}
+
+func preserveConditionTransitionTimes(
+	current []v1alpha1.SandboxTemplateCondition,
+	next []v1alpha1.SandboxTemplateCondition,
+) {
+	for i := range next {
+		for _, condition := range current {
+			if condition.Type == next[i].Type &&
+				condition.Status == next[i].Status &&
+				!condition.LastTransitionTime.IsZero() {
+				next[i].LastTransitionTime = condition.LastTransitionTime
+				break
+			}
+		}
+	}
+}
+
+func templateConditionsEqual(
+	left []v1alpha1.SandboxTemplateCondition,
+	right []v1alpha1.SandboxTemplateCondition,
+) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // computeConditions computes the conditions for a template

--- a/manager/pkg/controller/operator_test.go
+++ b/manager/pkg/controller/operator_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	crdfake "github.com/sandbox0-ai/sandbox0/manager/pkg/generated/clientset/versioned/fake"
 	"github.com/sandbox0-ai/sandbox0/pkg/sandboxprobe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,6 +20,7 @@ import (
 )
 
 func TestOperatorUpdateTemplateStatusUsesReadyIdlePods(t *testing.T) {
+	transitionTime := metav1.NewTime(time.Unix(1_700_000_000, 0))
 	template := &v1alpha1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "template-a",
@@ -30,7 +32,31 @@ func TestOperatorUpdateTemplateStatusUsesReadyIdlePods(t *testing.T) {
 				MaxIdle: 5,
 			},
 		},
+		Status: v1alpha1.SandboxTemplateStatus{
+			Creation: &v1alpha1.TemplateCreationStatus{
+				State: v1alpha1.TemplateCreationStateReady,
+				Stage: v1alpha1.TemplateCreationStageReconciling,
+			},
+			Conditions: []v1alpha1.SandboxTemplateCondition{
+				{
+					Type:               v1alpha1.SandboxTemplateReady,
+					Status:             v1alpha1.ConditionFalse,
+					LastTransitionTime: transitionTime,
+					Reason:             "InsufficientIdlePods",
+					Message:            "Idle pod count (0) is less than minIdle (2)",
+				},
+				{
+					Type:               v1alpha1.SandboxTemplatePoolHealthy,
+					Status:             v1alpha1.ConditionTrue,
+					LastTransitionTime: transitionTime,
+					Reason:             "PoolHealthy",
+					Message:            "Pool is healthy",
+				},
+			},
+		},
 	}
+	informerTemplate := template.DeepCopy()
+	crdClient := crdfake.NewSimpleClientset(template.DeepCopy())
 
 	podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
 		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
@@ -52,6 +78,7 @@ func TestOperatorUpdateTemplateStatusUsesReadyIdlePods(t *testing.T) {
 	probeRunner := &recordingSandboxProbeRunner{}
 	op := &Operator{
 		podLister:      corelisters.NewPodLister(podIndexer),
+		crdClient:      crdClient,
 		logger:         zap.NewNop(),
 		statsPublisher: publisher,
 		probeRunner:    probeRunner,
@@ -61,13 +88,43 @@ func TestOperatorUpdateTemplateStatusUsesReadyIdlePods(t *testing.T) {
 	err := op.updateTemplateStatus(context.Background(), template)
 	require.NoError(t, err)
 
-	assert.Equal(t, int32(1), template.Status.IdleCount)
-	assert.Equal(t, int32(2), template.Status.ActiveCount)
-	require.Len(t, template.Status.Conditions, 2)
-	assert.Equal(t, v1alpha1.ConditionFalse, template.Status.Conditions[0].Status)
-	assert.Equal(t, "InsufficientIdlePods", template.Status.Conditions[0].Reason)
-	assert.Equal(t, v1alpha1.ConditionTrue, template.Status.Conditions[1].Status)
-	assert.Equal(t, "PoolHealthy", template.Status.Conditions[1].Reason)
+	assert.Equal(t, informerTemplate, template, "the informer object must not be mutated")
+
+	persisted, err := crdClient.Sandbox0V1alpha1().SandboxTemplates("default").Get(
+		context.Background(),
+		"template-a",
+		metav1.GetOptions{},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), persisted.Status.IdleCount)
+	assert.Equal(t, int32(2), persisted.Status.ActiveCount)
+	assert.Equal(t, template.Status.Creation, persisted.Status.Creation)
+	require.Len(t, persisted.Status.Conditions, 2)
+	assert.Equal(t, v1alpha1.ConditionFalse, persisted.Status.Conditions[0].Status)
+	assert.Equal(t, "InsufficientIdlePods", persisted.Status.Conditions[0].Reason)
+	assert.Equal(t, transitionTime, persisted.Status.Conditions[0].LastTransitionTime)
+	assert.Equal(t, v1alpha1.ConditionTrue, persisted.Status.Conditions[1].Status)
+	assert.Equal(t, "PoolHealthy", persisted.Status.Conditions[1].Reason)
+	assert.Equal(t, transitionTime, persisted.Status.Conditions[1].LastTransitionTime)
+	assert.False(t, persisted.Status.LastUpdateTime.IsZero())
+
+	updateActions := 0
+	for _, action := range crdClient.Actions() {
+		if action.GetVerb() == "update" {
+			updateActions++
+		}
+	}
+	require.Equal(t, 1, updateActions)
+
+	err = op.updateTemplateStatus(context.Background(), template)
+	require.NoError(t, err)
+	updateActions = 0
+	for _, action := range crdClient.Actions() {
+		if action.GetVerb() == "update" {
+			updateActions++
+		}
+	}
+	assert.Equal(t, 1, updateActions, "unchanged status must not be written again")
 
 	assert.Equal(t, 1, publisher.calls)
 	assert.Equal(t, int32(1), publisher.idleCount)

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -4907,7 +4907,9 @@ components:
           description: |
             Controls whether supported inbound API or public exposure requests may automatically
             make an inactive sandbox available. This setting does not control platform-initiated
-            runtime fault recovery.
+            runtime fault recovery. A supported access request returns `503 unavailable` with
+            `sandbox is waking up` when an accepted resume has not committed yet. It returns
+            `503 sandbox_resume_failed` when that resume attempt has ended unsuccessfully.
         services:
           type: array
           items:
@@ -5289,7 +5291,9 @@ components:
           description: |
             Controls whether supported inbound API or public exposure requests may automatically
             make an inactive sandbox available. This setting does not control platform-initiated
-            runtime fault recovery.
+            runtime fault recovery. A supported access request returns `503 unavailable` with
+            `sandbox is waking up` when an accepted resume has not committed yet. It returns
+            `503 sandbox_resume_failed` when that resume attempt has ended unsuccessfully.
         services:
           type: array
           items:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -2258,7 +2258,9 @@ type SandboxAuditResource struct {
 type SandboxConfig struct {
 	// AutoResume Controls whether supported inbound API or public exposure requests may automatically
 	// make an inactive sandbox available. This setting does not control platform-initiated
-	// runtime fault recovery.
+	// runtime fault recovery. A supported access request returns `503 unavailable` with
+	// `sandbox is waking up` when an accepted resume has not committed yet. It returns
+	// `503 sandbox_resume_failed` when that resume attempt has ended unsuccessfully.
 	AutoResume *bool              `json:"auto_resume,omitempty"`
 	EnvVars    *map[string]string `json:"env_vars,omitempty"`
 
@@ -2638,7 +2640,9 @@ type SandboxTemplateStatus struct {
 type SandboxUpdateConfig struct {
 	// AutoResume Controls whether supported inbound API or public exposure requests may automatically
 	// make an inactive sandbox available. This setting does not control platform-initiated
-	// runtime fault recovery.
+	// runtime fault recovery. A supported access request returns `503 unavailable` with
+	// `sandbox is waking up` when an accepted resume has not committed yet. It returns
+	// `503 sandbox_resume_failed` when that resume attempt has ended unsuccessfully.
 	AutoResume *bool `json:"auto_resume,omitempty"`
 
 	// EnvVars Sandbox-level environment variables used as defaults for new procd-managed

--- a/pkg/gateway/spec/response.go
+++ b/pkg/gateway/spec/response.go
@@ -30,15 +30,16 @@ type rawResponse struct {
 }
 
 const (
-	CodeBadRequest       = "bad_request"
-	CodeUnauthorized     = "unauthorized"
-	CodeForbidden        = "forbidden"
-	CodeNotFound         = "not_found"
-	CodeConflict         = "conflict"
-	CodeTemplateNotReady = "template_not_ready"
-	CodeUnavailable      = "unavailable"
-	CodeInternal         = "internal_error"
-	CodeNotLicensed      = "feature_not_licensed"
+	CodeBadRequest          = "bad_request"
+	CodeUnauthorized        = "unauthorized"
+	CodeForbidden           = "forbidden"
+	CodeNotFound            = "not_found"
+	CodeConflict            = "conflict"
+	CodeTemplateNotReady    = "template_not_ready"
+	CodeSandboxResumeFailed = "sandbox_resume_failed"
+	CodeUnavailable         = "unavailable"
+	CodeInternal            = "internal_error"
+	CodeNotLicensed         = "feature_not_licensed"
 )
 
 // successresp builds a success envelope.

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -98,6 +98,12 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 			var err error
 			session, cleanup, err = e2eutils.NewAPISession(env, false)
 			Expect(err).NotTo(HaveOccurred())
+			// Keep the API tunnel alive for spec-level deferred cleanups.
+			DeferCleanup(func() {
+				if cleanup != nil {
+					cleanup()
+				}
+			})
 
 			password, err := framework.GetSecretValue(env.TestCtx.Context, env.Config.Kubeconfig, env.Infra.Namespace, "admin-password", "password")
 			Expect(err).NotTo(HaveOccurred())
@@ -123,9 +129,6 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 			}
 			if sshFixtureCleanup != nil {
 				sshFixtureCleanup()
-			}
-			if cleanup != nil {
-				cleanup()
 			}
 		})
 


### PR DESCRIPTION
## Summary

- return `503 sandbox_resume_failed` only after manager has returned a completed non-success resume response; keep transport uncertainty and accepted-but-uncommitted resumes on the existing `unavailable` / `sandbox is waking up` path
- persist ready idle/active pool counts and conditions to `SandboxTemplate` with conflict retries, without mutating informer objects or overwriting creation status
- update the OpenAPI source, generated types, and pause/resume documentation

## Safety boundary

This intentionally does not add manager-side automatic failover to another idle Pod. Retry policy remains client-owned and bounded so a failed request cannot consume the pool without a fixed limit.

## Context

A hot claim can complete quickly but still fail during procd initialization. Cluster Gateway previously masked that completed failure as a wake-up still in progress, while the template controller only mutated its informer object and left live `idleCount` / `activeCount` at zero.

## Validation

- `make proto manifests apispec`
- `GOTOOLCHAIN=go1.25.0+auto go test -buildvcs=false -race -count=1 ./cluster-gateway/... ./manager/...`
- `GOTOOLCHAIN=go1.25.0+auto go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0 run ./...` (0 issues)
- `go mod tidy` (no diff)