### PR TITLE
Add prepaid team admission enforcement

### DIFF
--- a/.github/workflows/pr-quick-check.yml
+++ b/.github/workflows/pr-quick-check.yml
@@ -85,6 +85,15 @@ jobs:
           packages="$(go list -buildvcs=false ./... | grep -Ev '/tests/(e2e|integration)(/|$)')"
           GOTOOLCHAIN=go1.25.0+auto go test -buildvcs=false -race -count=1 $packages
 
+      - name: Enforce 100% billing admission statement coverage
+        shell: bash
+        run: |
+          profile="$(mktemp)"
+          trap 'rm -f -- "$profile"' EXIT
+          GOTOOLCHAIN=go1.25.0+auto go test -buildvcs=false -count=1 -coverprofile="$profile" ./pkg/gateway/admission
+          coverage="$(go tool cover -func="$profile" | awk '/^total:/ { print $3 }')"
+          test "$coverage" = "100.0%"
+
       - name: Show git diff on failure
         if: failure()
         shell: bash

--- a/cluster-gateway/pkg/http/admission.go
+++ b/cluster-gateway/pkg/http/admission.go
@@ -1,0 +1,25 @@
+package http
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/admission"
+)
+
+// enforceRuntimeStartAdmission covers runtime starts that don't necessarily
+// enter through a usage-starting API route, including SSH and public exposure
+// auto-resume.
+func (s *Server) enforceRuntimeStartAdmission(c *gin.Context, teamID string) bool {
+	requireState := s.cfg != nil && s.cfg.AdmissionRequireState
+	if s.admissionStore == nil && !requireState {
+		// A gateway without the shared control-plane database is a self-hosted
+		// configuration and has no hosted billing admission projection.
+		return true
+	}
+	return admission.EnforceUsageStart(
+		c,
+		s.admissionStore,
+		s.logger,
+		requireState,
+		teamID,
+	)
+}

--- a/cluster-gateway/pkg/http/admission_test.go
+++ b/cluster-gateway/pkg/http/admission_test.go
@@ -1,0 +1,178 @@
+package http
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/client"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/admission"
+	gatewayauthn "github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"go.uber.org/zap"
+)
+
+type runtimeAdmissionStore struct {
+	record admission.Record
+	found  bool
+	err    error
+}
+
+func (s *runtimeAdmissionStore) Get(context.Context, string) (admission.Record, bool, error) {
+	return s.record, s.found, s.err
+}
+
+func (s *runtimeAdmissionStore) Put(
+	context.Context,
+	string,
+	admission.Update,
+) (admission.PutResult, error) {
+	return admission.PutResult{}, nil
+}
+
+func TestEnforceRuntimeStartAdmission(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("self hosted without projection", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(recorder)
+		ctx.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+		server := &Server{cfg: &config.ClusterGatewayConfig{}}
+		if !server.enforceRuntimeStartAdmission(ctx, "team") {
+			t.Fatalf("self-hosted admission was rejected: %s", recorder.Body.String())
+		}
+	})
+
+	t.Run("hosted missing projection", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(recorder)
+		ctx.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+		cfg := &config.ClusterGatewayConfig{}
+		cfg.AdmissionRequireState = true
+		server := &Server{
+			cfg:            cfg,
+			admissionStore: &runtimeAdmissionStore{},
+			logger:         zap.NewNop(),
+		}
+		if server.enforceRuntimeStartAdmission(ctx, "team") ||
+			recorder.Code != http.StatusServiceUnavailable {
+			t.Fatalf("missing admission status = %d body=%s", recorder.Code, recorder.Body.String())
+		}
+	})
+}
+
+func TestContextAutoResumeHonorsAdmission(t *testing.T) {
+	pausedSandbox := &mgr.Sandbox{
+		ID:         "sb-demo",
+		TeamID:     "team-a",
+		UserID:     "user-a",
+		Status:     mgr.SandboxStatusPaused,
+		Paused:     true,
+		AutoResume: true,
+	}
+	var resumed atomic.Bool
+	manager := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/sandboxes/sb-demo":
+			_ = spec.WriteSuccess(w, http.StatusOK, pausedSandbox)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/sandboxes/sb-demo/resume":
+			resumed.Store(true)
+			_ = spec.WriteSuccess(w, http.StatusOK, map[string]any{"sandbox_id": "sb-demo"})
+		default:
+			t.Fatalf("unexpected manager request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer manager.Close()
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	generator := internalauth.NewGenerator(internalauth.GeneratorConfig{
+		Caller:     "cluster-gateway",
+		PrivateKey: privateKey,
+		TTL:        time.Minute,
+	})
+	server := &Server{
+		cfg: &config.ClusterGatewayConfig{},
+		admissionStore: &runtimeAdmissionStore{
+			found: true,
+			record: admission.Record{
+				State:   admission.StateRestricted,
+				Version: 9,
+				Reason:  "insufficient_credits",
+			},
+		},
+		managerClient: client.NewManagerClient(manager.URL, generator, zap.NewNop(), time.Second),
+		logger:        zap.NewNop(),
+	}
+
+	address, recorder := mustGetProcdURL(t, server, "team-a", "user-a", "sb-demo")
+	if address != nil ||
+		recorder.Code != http.StatusForbidden ||
+		resumed.Load() {
+		t.Fatalf(
+			"context admission address=%v status=%d resumed=%v body=%s",
+			address,
+			recorder.Code,
+			resumed.Load(),
+			recorder.Body.String(),
+		)
+	}
+}
+
+func TestInternalResumeHonorsAdmission(t *testing.T) {
+	managerCalled := false
+	manager := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		managerCalled = true
+	}))
+	defer manager.Close()
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	generator := internalauth.NewGenerator(internalauth.GeneratorConfig{
+		Caller:     "cluster-gateway",
+		PrivateKey: privateKey,
+		TTL:        time.Minute,
+	})
+	server := &Server{
+		cfg: &config.ClusterGatewayConfig{},
+		admissionStore: &runtimeAdmissionStore{
+			found:  true,
+			record: admission.Record{State: admission.StateRestricted, Version: 3},
+		},
+		managerClient: client.NewManagerClient(manager.URL, generator, zap.NewNop(), time.Second),
+		logger:        zap.NewNop(),
+	}
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Params = gin.Params{{Key: "id", Value: "sb-demo"}}
+	request := httptest.NewRequest(http.MethodPost, "/internal/v1/sandboxes/sb-demo/resume", nil)
+	authContext := &gatewayauthn.AuthContext{TeamID: "team-a", UserID: "user-a"}
+	ctx.Set("auth_context", authContext)
+	ctx.Request = request.WithContext(gatewayauthn.WithAuthContext(request.Context(), authContext))
+
+	server.resumeInternalSandbox(ctx)
+
+	if recorder.Code != http.StatusForbidden || managerCalled {
+		t.Fatalf(
+			"internal resume status=%d manager_called=%v body=%s",
+			recorder.Code,
+			managerCalled,
+			recorder.Body.String(),
+		)
+	}
+	if !strings.Contains(recorder.Body.String(), spec.CodeAdmissionRestricted) {
+		t.Fatalf("internal resume error = %s", recorder.Body.String())
+	}
+}

--- a/cluster-gateway/pkg/http/handlers_context.go
+++ b/cluster-gateway/pkg/http/handlers_context.go
@@ -233,6 +233,9 @@ func (s *Server) getProcdURL(c *gin.Context, sandboxID string) (*url.URL, error)
 		return nil, errors.New("sandbox auto_resume is disabled")
 	}
 	if sandboxNeedsRuntime(sandbox) {
+		if !s.enforceRuntimeStartAdmission(c, authCtx.TeamID) {
+			return nil, errors.New("sandbox resume is restricted by admission policy")
+		}
 		if err := s.managerClient.ResumeSandbox(c.Request.Context(), sandboxID, authCtx.UserID, authCtx.TeamID); err != nil {
 			s.logger.Warn("Resume sandbox failed",
 				zap.String("sandbox_id", sandboxID),

--- a/cluster-gateway/pkg/http/handlers_exposure.go
+++ b/cluster-gateway/pkg/http/handlers_exposure.go
@@ -101,6 +101,9 @@ func (s *Server) handlePublicExposureNoRoute(c *gin.Context) {
 			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox is not running and resume is disabled")
 			return
 		}
+		if !s.enforceRuntimeStartAdmission(c, sandbox.TeamID) {
+			return
+		}
 		if err := s.managerClient.ResumeSandbox(c.Request.Context(), sandboxID, "", sandbox.TeamID); err != nil {
 			s.logger.Warn("Auto resume failed", zap.String("sandbox_id", sandboxID), zap.Error(err))
 			if errors.Is(err, client.ErrSandboxResumeFailed) {

--- a/cluster-gateway/pkg/http/handlers_internal_sandboxes.go
+++ b/cluster-gateway/pkg/http/handlers_internal_sandboxes.go
@@ -85,6 +85,9 @@ func (s *Server) resumeInternalSandbox(c *gin.Context) {
 		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "sandbox_id is required")
 		return
 	}
+	if !s.enforceRuntimeStartAdmission(c, authCtx.TeamID) {
+		return
+	}
 
 	if err := s.managerClient.ResumeSandbox(c.Request.Context(), sandboxID, authCtx.UserID, authCtx.TeamID); err != nil {
 		s.logger.Warn("Internal sandbox resume failed",

--- a/cluster-gateway/pkg/http/sandbox_service_policy_test.go
+++ b/cluster-gateway/pkg/http/sandbox_service_policy_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/client"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	mgr "github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/admission"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/ratelimit"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
@@ -529,6 +530,51 @@ func TestSandboxFunctionServiceExecutesAfterPausedAutoResume(t *testing.T) {
 	}
 }
 
+func TestSandboxFunctionServiceAutoResumeHonorsAdmission(t *testing.T) {
+	procd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("restricted exposure reached procd")
+	}))
+	defer procd.Close()
+
+	port := serverPort(t, procd.URL)
+	activeSandbox := newFunctionServiceSandbox(procd.URL, port)
+	activeSandbox.Status = mgr.SandboxStatusRunning
+	activeSandbox.Services[0].Ingress.Routes[0].Resume = true
+	managerURL, resumed := newPausedFunctionManager(t, activeSandbox)
+	gateway := newSandboxServiceExposureTestServerWithAdmission(
+		t,
+		managerURL,
+		&runtimeAdmissionStore{
+			found:  true,
+			record: admission.Record{State: admission.StateRestricted, Version: 4},
+		},
+	)
+	gatewayServer := httptest.NewServer(gateway)
+	defer gatewayServer.Close()
+
+	request := newGatewayRequest(
+		t,
+		http.MethodPost,
+		gatewayServer.URL,
+		fmt.Sprintf("sb-demo--p%d.aws-us-east-1.sandbox0.app", port),
+		"/events/resume",
+	)
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("gateway request: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusForbidden || resumed.Load() {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf(
+			"exposure admission status=%d resumed=%v body=%s",
+			response.StatusCode,
+			resumed.Load(),
+			string(body),
+		)
+	}
+}
+
 func TestSandboxFunctionServiceProxiesWebSocketAfterPausedAutoResume(t *testing.T) {
 	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
 	procd := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -963,6 +1009,14 @@ func newSandboxServiceExposureTestServer(t *testing.T, sandbox *mgr.Sandbox) htt
 }
 
 func newSandboxServiceExposureTestServerWithManagerURL(t *testing.T, managerURL string) http.Handler {
+	return newSandboxServiceExposureTestServerWithAdmission(t, managerURL, nil)
+}
+
+func newSandboxServiceExposureTestServerWithAdmission(
+	t *testing.T,
+	managerURL string,
+	store admission.Store,
+) http.Handler {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
@@ -989,6 +1043,7 @@ func newSandboxServiceExposureTestServerWithManagerURL(t *testing.T, managerURL 
 		managerClient:         client.NewManagerClient(managerURL, gen, zap.NewNop(), time.Second),
 		internalAuthGen:       gen,
 		sandboxServiceLimiter: ratelimit.NewMemoryLimiter(ratelimit.MemoryConfig{}),
+		admissionStore:        store,
 	}
 	router := gin.New()
 	router.NoRoute(s.handlePublicExposureNoRoute)

--- a/cluster-gateway/pkg/http/server.go
+++ b/cluster-gateway/pkg/http/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/client"
 	"github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/middleware"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/admission"
 	gatewayapikey "github.com/sandbox0-ai/sandbox0/pkg/gateway/apikey"
 	gatewaybuiltin "github.com/sandbox0-ai/sandbox0/pkg/gateway/auth/builtin"
 	gatewayoidc "github.com/sandbox0-ai/sandbox0/pkg/gateway/auth/oidc"
@@ -43,6 +44,7 @@ type ServerOption func(*serverOptions)
 type serverOptions struct {
 	sandboxObservabilityRepo sandboxobservability.Repository
 	meteringReader           gatewayhandlers.MeteringReader
+	admissionStore           admission.Store
 }
 
 func WithSandboxObservabilityRepository(repo sandboxobservability.Repository) ServerOption {
@@ -54,6 +56,12 @@ func WithSandboxObservabilityRepository(repo sandboxobservability.Repository) Se
 func WithMeteringReader(reader gatewayhandlers.MeteringReader) ServerOption {
 	return func(opts *serverOptions) {
 		opts.meteringReader = reader
+	}
+}
+
+func WithAdmissionStore(store admission.Store) ServerOption {
+	return func(opts *serverOptions) {
+		opts.admissionStore = store
 	}
 }
 
@@ -79,6 +87,7 @@ type Server struct {
 	requestLogger                            *middleware.RequestLogger
 	logger                                   *zap.Logger
 	meteringHandler                          *gatewayhandlers.MeteringHandler
+	admissionStore                           admission.Store
 	observabilityHandler                     *gatewayhandlers.SandboxObservabilityHandler
 	auditSigningKey                          ed25519.PrivateKey
 	auditDelivery                            *auditDelivery
@@ -297,6 +306,10 @@ func NewServer(
 	}
 
 	meteringHandler := gatewayhandlers.NewMeteringHandler(options.meteringReader, cfg.RegionID, logger)
+	admissionStore := options.admissionStore
+	if admissionStore == nil && pool != nil {
+		admissionStore = admission.NewRepository(pool)
+	}
 	observabilityOptions := []gatewayhandlers.SandboxObservabilityHandlerOption(nil)
 	if cfg.SandboxObservability.AuditEnabled {
 		observabilityOptions = append(observabilityOptions, gatewayhandlers.WithAuditIntegrityPolicy(gatewayhandlers.AuditIntegrityPolicy{
@@ -358,6 +371,7 @@ func NewServer(
 		requestLogger:                            requestLogger,
 		logger:                                   logger,
 		meteringHandler:                          meteringHandler,
+		admissionStore:                           admissionStore,
 		observabilityHandler:                     observabilityHandler,
 		auditSigningKey:                          auditSigningPrivateKey,
 		auditDelivery:                            delivery,
@@ -491,6 +505,7 @@ func (s *Server) setupRoutes() {
 			// Apply internal auth to all v1 routes (requests come from regional-gateway)
 			v1.Use(s.authMiddleware.Authenticate())
 		}
+		v1.Use(admission.NewUsageMiddleware(s.admissionStore, s.logger, s.cfg.AdmissionRequireState))
 
 		// === Sandbox Management (→ Manager) ===
 		sandboxes := v1.Group("/sandboxes")
@@ -622,6 +637,7 @@ func (s *Server) setupRoutes() {
 	// Metering export is region-scoped and must remain available when
 	// cluster-gateway serves as the single-cluster public API entrypoint.
 	s.setupMeteringRoutes()
+	s.setupAdmissionRoutes()
 
 	// Host-based public exposure fallback (for non-/api paths)
 	s.router.NoRoute(s.handlePublicExposureNoRoute)
@@ -734,7 +750,7 @@ func (s *Server) setupMeteringRoutes() {
 		internal.Use(s.publicAuth.RequireSystemAdmin())
 	case authModeBoth:
 		internal.Use(s.compositeAuth.Authenticate())
-		internal.Use(requireMeteringAccess())
+		internal.Use(requireInternalOrSystemAdmin())
 	default:
 		internal.Use(s.authMiddleware.Authenticate())
 	}
@@ -745,7 +761,7 @@ func (s *Server) setupMeteringRoutes() {
 	}
 }
 
-func requireMeteringAccess() gin.HandlerFunc {
+func requireInternalOrSystemAdmin() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		authCtx := gatewaymiddleware.GetAuthContext(c)
 		if authCtx == nil {
@@ -762,6 +778,22 @@ func requireMeteringAccess() gin.HandlerFunc {
 			"error": "system admin access required",
 		})
 	}
+}
+
+func (s *Server) setupAdmissionRoutes() {
+	handler := admission.NewHandler(s.admissionStore, s.logger)
+	internal := s.router.Group("/internal/v1")
+	switch normalizeAuthMode(s.cfg.AuthMode) {
+	case authModePublic:
+		internal.Use(s.publicAuth.Authenticate())
+		internal.Use(s.publicAuth.RequireSystemAdmin())
+	case authModeBoth:
+		internal.Use(s.compositeAuth.Authenticate())
+		internal.Use(requireInternalOrSystemAdmin())
+	default:
+		internal.Use(s.authMiddleware.Authenticate())
+	}
+	internal.PUT("/teams/:team_id/admission-state", handler.Put)
 }
 
 // Start starts the HTTP server

--- a/cluster-gateway/pkg/http/server_metering_routes_test.go
+++ b/cluster-gateway/pkg/http/server_metering_routes_test.go
@@ -56,6 +56,9 @@ func TestSetupRoutesMountsMeteringEndpointsInPublicMode(t *testing.T) {
 	if !hasRoute(server.router, "GET", "/internal/v1/metering/windows") {
 		t.Fatal("expected metering windows route to be mounted")
 	}
+	if !hasRoute(server.router, http.MethodPut, "/internal/v1/teams/:team_id/admission-state") {
+		t.Fatal("expected team admission state route to be mounted")
+	}
 }
 
 func TestSetupRoutesSkipsControlPlaneEndpointsInPublicMode(t *testing.T) {
@@ -121,6 +124,9 @@ func TestSetupRoutesMountsControlPlaneEndpointsInInternalMode(t *testing.T) {
 	}
 	if !hasRoute(server.router, "DELETE", "/internal/v1/teams/:team_id/quotas/:dimension") {
 		t.Fatal("expected internal mode to mount internal quota delete route")
+	}
+	if !hasRoute(server.router, http.MethodPut, "/internal/v1/teams/:team_id/admission-state") {
+		t.Fatal("expected internal mode to mount team admission state route")
 	}
 }
 

--- a/infra-operator/api/config/gateway.go
+++ b/infra-operator/api/config/gateway.go
@@ -68,6 +68,12 @@ type GatewayConfig struct {
 	// +kubebuilder:default=true
 	RateLimitFailOpen bool `yaml:"rate_limit_fail_open" json:"-"`
 
+	// AdmissionRequireState rejects usage-starting requests until a team
+	// admission record has been projected into the region database.
+	// +optional
+	// +kubebuilder:default=false
+	AdmissionRequireState bool `yaml:"admission_require_state" json:"admissionRequireState"`
+
 	// Identity and Teams
 	// +optional
 	// +kubebuilder:default="Personal Team"

--- a/infra-operator/api/v1alpha1/service_api_config_types.go
+++ b/infra-operator/api/v1alpha1/service_api_config_types.go
@@ -55,6 +55,14 @@ type GatewayConfig struct {
 	RateLimitRedisTimeout    metav1.Duration `json:"-"`
 	RateLimitFailOpen        bool            `json:"-"`
 
+	// AdmissionRequireState rejects usage-starting requests until a team
+	// admission record has been projected into the region database. Hosted
+	// prepaid deployments should enable it; self-hosted deployments default to
+	// allowing teams without an external billing projection.
+	// +optional
+	// +kubebuilder:default=false
+	AdmissionRequireState bool `json:"admissionRequireState,omitempty"`
+
 	// Identity and Teams
 	// +optional
 	// +kubebuilder:default="Personal Team"

--- a/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
+++ b/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
@@ -3038,6 +3038,14 @@ spec:
                         default: {}
                         description: Config contains cluster-gateway specific configuration
                         properties:
+                          admissionRequireState:
+                            default: false
+                            description: |-
+                              AdmissionRequireState rejects usage-starting requests until a team
+                              admission record has been projected into the region database. Hosted
+                              prepaid deployments should enable it; self-hosted deployments default to
+                              allowing teams without an external billing projection.
+                            type: boolean
                           allowedCallers:
                             default:
                             - regional-gateway
@@ -3343,6 +3351,14 @@ spec:
                         default: {}
                         description: Config contains global-gateway specific configuration
                         properties:
+                          admissionRequireState:
+                            default: false
+                            description: |-
+                              AdmissionRequireState rejects usage-starting requests until a team
+                              admission record has been projected into the region database. Hosted
+                              prepaid deployments should enable it; self-hosted deployments default to
+                              allowing teams without an external billing projection.
+                            type: boolean
                           baseUrl:
                             default: http://localhost:8080
                             description: BaseURL sets the external base URL used by
@@ -3964,6 +3980,14 @@ spec:
                         default: {}
                         description: Config contains regional-gateway specific configuration
                         properties:
+                          admissionRequireState:
+                            default: false
+                            description: |-
+                              AdmissionRequireState rejects usage-starting requests until a team
+                              admission record has been projected into the region database. Hosted
+                              prepaid deployments should enable it; self-hosted deployments default to
+                              allowing teams without an external billing projection.
+                            type: boolean
                           authMode:
                             default: self_hosted
                             enum:

--- a/infra-operator/internal/runtimeconfig/gateway.go
+++ b/infra-operator/internal/runtimeconfig/gateway.go
@@ -135,6 +135,7 @@ func applyGatewayConfig(dst *apiconfig.GatewayConfig, src infrav1alpha1.GatewayC
 	dst.RateLimitRedisKeyPrefix = src.RateLimitRedisKeyPrefix
 	dst.RateLimitRedisTimeout = src.RateLimitRedisTimeout
 	dst.RateLimitFailOpen = src.RateLimitFailOpen
+	dst.AdmissionRequireState = src.AdmissionRequireState
 	dst.DefaultTeamName = src.DefaultTeamName
 	dst.BuiltInAuth = apiconfig.BuiltInAuthConfig{
 		Enabled:                   src.BuiltInAuth.Enabled,

--- a/infra-operator/internal/runtimeconfig/gateway_test.go
+++ b/infra-operator/internal/runtimeconfig/gateway_test.go
@@ -12,12 +12,13 @@ import (
 func TestApplyGatewayConfigCopiesJWTKeyFields(t *testing.T) {
 	src := infrav1alpha1.GlobalGatewayConfig{
 		GatewayConfig: infrav1alpha1.GatewayConfig{
-			JWTIssuer:         "https://api.sandbox0.ai",
-			JWTPrivateKeyPEM:  "private-pem",
-			JWTPublicKeyPEM:   "public-pem",
-			JWTPrivateKeyFile: "/runtime/secrets/jwt_private_key.pem",
-			JWTPublicKeyFile:  "/runtime/secrets/jwt_public_key.pem",
-			JWTAccessTokenTTL: metav1.Duration{Duration: 15 * time.Minute},
+			JWTIssuer:             "https://api.sandbox0.ai",
+			JWTPrivateKeyPEM:      "private-pem",
+			JWTPublicKeyPEM:       "public-pem",
+			JWTPrivateKeyFile:     "/runtime/secrets/jwt_private_key.pem",
+			JWTPublicKeyFile:      "/runtime/secrets/jwt_public_key.pem",
+			JWTAccessTokenTTL:     metav1.Duration{Duration: 15 * time.Minute},
+			AdmissionRequireState: true,
 		},
 	}
 
@@ -36,6 +37,9 @@ func TestApplyGatewayConfigCopiesJWTKeyFields(t *testing.T) {
 	}
 	if cfg.JWTPublicKeyFile != src.JWTPublicKeyFile {
 		t.Fatalf("expected public key file to be copied")
+	}
+	if !cfg.AdmissionRequireState {
+		t.Fatal("expected admission require state to be copied")
 	}
 }
 

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -236,7 +236,7 @@ func TestClaimRequestDoesNotAcceptRuntimeMetadataFromJSON(t *testing.T) {
 	if err := json.Unmarshal([]byte(`{
 		"template":"template-a",
 		"metadata":{
-			"owner_kind":"managed-agent"
+			"owner_kind":"automation"
 		}
 	}`), &req); err != nil {
 		t.Fatalf("Unmarshal() error = %v", err)
@@ -280,7 +280,7 @@ func TestClaimIdlePodAppliesRuntimeOwnerMetadata(t *testing.T) {
 		TeamID: "team-a",
 		UserID: "user-a",
 		Metadata: &ClaimMetadata{
-			OwnerKind: "managed-agent",
+			OwnerKind: "automation",
 		},
 	})
 	if err != nil {
@@ -1005,13 +1005,13 @@ func TestCreateNewPodDefersNetworkApplyUntilPodHasNetworkIdentity(t *testing.T) 
 func TestClaimSandboxDeletesColdPodAfterNetworkApplyFailure(t *testing.T) {
 	withClaimTestPublicKey(t)
 
-	templateNamespace, err := naming.TemplateNamespaceForBuiltin("managed-agent-claude")
+	templateNamespace, err := naming.TemplateNamespaceForBuiltin("automation-claude")
 	if err != nil {
 		t.Fatalf("template namespace: %v", err)
 	}
 	template := &v1alpha1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "managed-agent-claude",
+			Name:      "automation-claude",
 			Namespace: templateNamespace,
 		},
 		Spec: v1alpha1.SandboxTemplateSpec{
@@ -1033,7 +1033,7 @@ func TestClaimSandboxDeletesColdPodAfterNetworkApplyFailure(t *testing.T) {
 		logger:               zap.NewNop(),
 	}
 
-	_, err = svc.ClaimSandbox(context.Background(), &ClaimRequest{Template: "managed-agent-claude", TeamID: "team-a", UserID: "user-a"})
+	_, err = svc.ClaimSandbox(context.Background(), &ClaimRequest{Template: "automation-claude", TeamID: "team-a", UserID: "user-a"})
 	if err == nil {
 		t.Fatal("ClaimSandbox() error = nil, want network apply failure")
 	}
@@ -1149,7 +1149,7 @@ func TestCreateNewPodAppliesRuntimeOwnerMetadata(t *testing.T) {
 		TeamID: "team-a",
 		UserID: "user-a",
 		Metadata: &ClaimMetadata{
-			OwnerKind: "managed-agent",
+			OwnerKind: "automation",
 		},
 	})
 	if err != nil {
@@ -1574,13 +1574,13 @@ func TestInitializeClaimRootFSFromSnapshotRejectsInternalTemplateBuildSnapshot(t
 
 func TestClaimSandboxCleansColdPodWhenClaimReadinessFails(t *testing.T) {
 	withClaimTestPublicKey(t)
-	templateNamespace, err := naming.TemplateNamespaceForBuiltin("managed-agent-claude")
+	templateNamespace, err := naming.TemplateNamespaceForBuiltin("automation-claude")
 	if err != nil {
 		t.Fatalf("template namespace: %v", err)
 	}
 	template := &v1alpha1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "managed-agent-claude",
+			Name:      "automation-claude",
 			Namespace: templateNamespace,
 		},
 		Spec: v1alpha1.SandboxTemplateSpec{
@@ -1606,7 +1606,7 @@ func TestClaimSandboxCleansColdPodWhenClaimReadinessFails(t *testing.T) {
 		logger: zap.NewNop(),
 	}
 
-	_, err = svc.ClaimSandbox(ctx, &ClaimRequest{Template: "managed-agent-claude", TeamID: "team-a", UserID: "user-a"})
+	_, err = svc.ClaimSandbox(ctx, &ClaimRequest{Template: "automation-claude", TeamID: "team-a", UserID: "user-a"})
 	if err == nil {
 		t.Fatal("ClaimSandbox() error = nil, want claim readiness failure")
 	}
@@ -1624,14 +1624,14 @@ func TestObserveClaimPhaseRecordsMetric(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	svc := &SandboxService{metrics: obsmetrics.NewManager(registry)}
 
-	svc.observeClaimPhase("managed-agents", "cold", "wait_for_pod_claim_ready", time.Now().Add(-20*time.Millisecond), nil)
+	svc.observeClaimPhase("automation", "cold", "wait_for_pod_claim_ready", time.Now().Add(-20*time.Millisecond), nil)
 
 	families, err := registry.Gather()
 	if err != nil {
 		t.Fatalf("gather metrics: %v", err)
 	}
 	metric := findMetric(families, "manager_sandbox_claim_phase_duration_seconds", map[string]string{
-		"template": "managed-agents",
+		"template": "automation",
 		"type":     "cold",
 		"phase":    "wait_for_pod_claim_ready",
 		"status":   "success",
@@ -1651,14 +1651,14 @@ func TestObservePodNetworkIdentityStageRecordsMetric(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	svc := &SandboxService{metrics: obsmetrics.NewManager(registry)}
 
-	svc.observePodNetworkIdentityStage("managed-agents", "pod_ip_assigned", "timeout", "pod IP is not assigned", time.Now().Add(-20*time.Millisecond))
+	svc.observePodNetworkIdentityStage("automation", "pod_ip_assigned", "timeout", "pod IP is not assigned", time.Now().Add(-20*time.Millisecond))
 
 	families, err := registry.Gather()
 	if err != nil {
 		t.Fatalf("gather metrics: %v", err)
 	}
 	metric := findMetric(families, "manager_pod_network_identity_stage_duration_seconds", map[string]string{
-		"template": "managed-agents",
+		"template": "automation",
 		"stage":    "pod_ip_assigned",
 		"status":   "timeout",
 		"reason":   "ip_unassigned",
@@ -1677,12 +1677,12 @@ func TestObservePodNetworkIdentityStageRecordsMetric(t *testing.T) {
 func TestPodLifecycleStageTrackerRecordsCompletedStagesOnce(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	svc := &SandboxService{metrics: obsmetrics.NewManager(registry)}
-	tracker := newPodLifecycleStageTracker(svc, "managed-agents")
+	tracker := newPodLifecycleStageTracker(svc, "automation")
 	createdAt := time.Now().UTC().Add(-time.Minute)
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "cold-pod",
-			Namespace:         "tpl-managed-agents",
+			Namespace:         "tpl-automation",
 			CreationTimestamp: metav1.NewTime(createdAt),
 		},
 		Status: corev1.PodStatus{
@@ -1741,7 +1741,7 @@ func TestPodLifecycleStageTrackerRecordsCompletedStagesOnce(t *testing.T) {
 	}
 	for stage, wantSeconds := range want {
 		metric := findMetric(families, "manager_pod_lifecycle_stage_duration_seconds", map[string]string{
-			"template": "managed-agents",
+			"template": "automation",
 			"stage":    stage,
 		})
 		if metric == nil || metric.GetHistogram() == nil {
@@ -1760,14 +1760,14 @@ func TestObserveIdleClaimRecordsMetric(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	svc := &SandboxService{metrics: obsmetrics.NewManager(registry)}
 
-	svc.observeIdleClaim("managed-agents", "success")
+	svc.observeIdleClaim("automation", "success")
 
 	families, err := registry.Gather()
 	if err != nil {
 		t.Fatalf("gather metrics: %v", err)
 	}
 	metric := findMetric(families, "manager_sandbox_idle_claims_total", map[string]string{
-		"template": "managed-agents",
+		"template": "automation",
 		"result":   "success",
 	})
 	if metric == nil || metric.GetCounter() == nil {
@@ -2529,11 +2529,11 @@ func assertClaimOwnerMetadata(t *testing.T, pod *corev1.Pod) {
 	if pod == nil {
 		t.Fatal("pod is nil")
 	}
-	if got := pod.Labels[controller.LabelOwnerKind]; got != "managed-agent" {
-		t.Fatalf("owner kind label = %q, want managed-agent", got)
+	if got := pod.Labels[controller.LabelOwnerKind]; got != "automation" {
+		t.Fatalf("owner kind label = %q, want automation", got)
 	}
-	if got := pod.Annotations[controller.AnnotationOwnerKind]; got != "managed-agent" {
-		t.Fatalf("owner kind annotation = %q, want managed-agent", got)
+	if got := pod.Annotations[controller.AnnotationOwnerKind]; got != "automation" {
+		t.Fatalf("owner kind annotation = %q, want automation", got)
 	}
 }
 

--- a/manager/pkg/service/sandbox_service_ttl_test.go
+++ b/manager/pkg/service/sandbox_service_ttl_test.go
@@ -215,8 +215,8 @@ func TestPersistUpdatedSandboxPodStoresRuntimeMetadata(t *testing.T) {
 	pod := testSandboxPod()
 	pod.Labels[controller.LabelTemplateID] = "default"
 	pod.Labels[controller.LabelTemplateLogicalID] = "default"
-	pod.Labels[controller.LabelOwnerKind] = "managed-agent"
-	pod.Annotations[controller.AnnotationOwnerKind] = "managed-agent"
+	pod.Labels[controller.LabelOwnerKind] = "automation"
+	pod.Annotations[controller.AnnotationOwnerKind] = "automation"
 	pod.Annotations[controller.AnnotationConfig] = `{"ttl":300}`
 	pod.Annotations[controller.AnnotationWebhookStateVolumeID] = "webhook-volume-1"
 
@@ -234,7 +234,7 @@ func TestPersistUpdatedSandboxPodStoresRuntimeMetadata(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, record)
 	assert.Equal(t, "webhook-volume-1", record.WebhookStateVolumeID)
-	assert.Equal(t, "managed-agent", record.OwnerKind)
+	assert.Equal(t, "automation", record.OwnerKind)
 }
 
 func TestRefreshSandboxPersistsExpirationRecord(t *testing.T) {

--- a/pkg/gateway/admission/http.go
+++ b/pkg/gateway/admission/http.go
@@ -1,0 +1,205 @@
+package admission
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/middleware"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"go.uber.org/zap"
+)
+
+type Handler struct {
+	store  Store
+	logger *zap.Logger
+}
+
+func NewHandler(store Store, logger *zap.Logger) *Handler {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &Handler{store: store, logger: logger}
+}
+
+func (h *Handler) Put(c *gin.Context) {
+	teamID := strings.TrimSpace(c.Param("team_id"))
+	if _, err := uuid.Parse(teamID); err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "team_id must be a UUID")
+		return
+	}
+
+	var update Update
+	decoder := json.NewDecoder(c.Request.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&update); err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "invalid admission update")
+		return
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "invalid admission update")
+		return
+	}
+
+	normalized, err := update.Validate()
+	if err != nil {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
+		return
+	}
+	if h == nil || h.store == nil {
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "admission state store is unavailable")
+		return
+	}
+
+	result, err := h.store.Put(c.Request.Context(), teamID, normalized)
+	if errors.Is(err, ErrVersionConflict) {
+		spec.JSONError(c, http.StatusConflict, spec.CodeConflict, err.Error())
+		return
+	}
+	if err != nil {
+		h.logger.Error("Failed to update team admission state",
+			zap.String("team_id", teamID),
+			zap.Error(err),
+		)
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to update team admission state")
+		return
+	}
+	spec.JSONSuccess(c, http.StatusOK, result)
+}
+
+func NewUsageMiddleware(reader Reader, logger *zap.Logger, requireState bool) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !StartsUsage(c.Request.Method, c.FullPath()) &&
+			!StartsUsage(c.Request.Method, c.Request.URL.Path) {
+			c.Next()
+			return
+		}
+		if reader == nil && !requireState {
+			// Self-hosted gateways have no external billing projection. Their
+			// explicit default is to keep admission disabled.
+			c.Next()
+			return
+		}
+
+		authCtx := middleware.GetAuthContext(c)
+		teamID := ""
+		if authCtx != nil {
+			teamID = authCtx.TeamID
+		}
+		if !EnforceUsageStart(c, reader, logger, requireState, teamID) {
+			return
+		}
+		c.Next()
+	}
+}
+
+// EnforceUsageStart applies one team's admission state at the point where an
+// operation can start billable work. It is shared by route middleware and
+// runtime auto-resume paths. This is deliberately soft prepaid: it rejects new
+// spend and resume paths but never terminates an already-running sandbox.
+func EnforceUsageStart(
+	c *gin.Context,
+	reader Reader,
+	logger *zap.Logger,
+	requireState bool,
+	teamID string,
+) bool {
+	teamID = strings.TrimSpace(teamID)
+	if teamID == "" {
+		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "team context is required")
+		c.Abort()
+		return false
+	}
+	if reader == nil {
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "admission state is unavailable")
+		c.Abort()
+		return false
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	record, found, err := reader.Get(c.Request.Context(), teamID)
+	if err != nil {
+		logger.Error("Failed to read team admission state",
+			zap.String("team_id", teamID),
+			zap.Error(err),
+		)
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "admission state is unavailable")
+		c.Abort()
+		return false
+	}
+	if !found && requireState {
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "admission state is not initialized")
+		c.Abort()
+		return false
+	}
+	if found && record.State == StateRestricted {
+		spec.JSONError(c, http.StatusForbidden, spec.CodeAdmissionRestricted, "team is not allowed to start additional usage", gin.H{
+			"reason":  record.Reason,
+			"version": record.Version,
+		})
+		c.Abort()
+		return false
+	}
+	return true
+}
+
+func StartsUsage(method, routePattern string) bool {
+	routePattern = strings.TrimSuffix(routePattern, "/")
+	switch method {
+	case http.MethodPut:
+		return hasSinglePathSegment(routePattern, "/api/v1/sandboxes/") ||
+			hasSinglePathSegment(routePattern, "/api/v1/templates/")
+	case http.MethodPost:
+		switch routePattern {
+		case "/api/v1/sandboxes",
+			"/api/v1/templates",
+			"/api/v1/templates/from-sandbox",
+			"/api/v1/sandboxvolumes":
+			return true
+		}
+		if hasResourceAction(routePattern, "/api/v1/sandboxes/", "resume", "fork", "snapshots") {
+			return true
+		}
+		return hasResourceAction(routePattern, "/api/v1/sandboxvolumes/", "fork", "snapshots")
+	}
+	return false
+}
+
+func hasSinglePathSegment(value, prefix string) bool {
+	remainder, found := strings.CutPrefix(value, prefix)
+	return found && remainder != "" && !strings.Contains(remainder, "/")
+}
+
+func hasResourceAction(value, prefix string, actions ...string) bool {
+	remainder, found := strings.CutPrefix(value, prefix)
+	if !found {
+		return false
+	}
+	parts := strings.Split(remainder, "/")
+	if len(parts) != 2 || parts[0] == "" {
+		return false
+	}
+	for _, action := range actions {
+		if parts[1] == action {
+			return true
+		}
+	}
+	return false
+}
+
+func ensureJSONEOF(decoder *json.Decoder) error {
+	var extra any
+	err := decoder.Decode(&extra)
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	if err == nil {
+		return errors.New("multiple JSON values")
+	}
+	return err
+}

--- a/pkg/gateway/admission/http_test.go
+++ b/pkg/gateway/admission/http_test.go
@@ -1,0 +1,317 @@
+package admission
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"go.uber.org/zap"
+)
+
+const testTeamID = "11111111-1111-4111-8111-111111111111"
+
+type fakeStore struct {
+	record    Record
+	found     bool
+	getErr    error
+	putResult PutResult
+	putErr    error
+	putTeamID string
+	putUpdate Update
+}
+
+func (s *fakeStore) Get(context.Context, string) (Record, bool, error) {
+	return s.record, s.found, s.getErr
+}
+
+func (s *fakeStore) Put(_ context.Context, teamID string, update Update) (PutResult, error) {
+	s.putTeamID = teamID
+	s.putUpdate = update
+	return s.putResult, s.putErr
+}
+
+func TestHandlerPutValidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		teamID string
+		body   string
+	}{
+		{name: "invalid team id", teamID: "bad", body: `{}`},
+		{name: "malformed body", teamID: testTeamID, body: `{`},
+		{name: "unknown field", teamID: testTeamID, body: `{"version":1,"state":"allowed","source":"test","unknown":true}`},
+		{name: "multiple values", teamID: testTeamID, body: `{"version":1,"state":"allowed","source":"test"} {}`},
+		{name: "invalid trailing value", teamID: testTeamID, body: `{"version":1,"state":"allowed","source":"test"} x`},
+		{name: "invalid update", teamID: testTeamID, body: `{"version":-1,"state":"allowed","source":"test"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := servePut(t, NewHandler(&fakeStore{}, nil), tt.teamID, tt.body)
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusBadRequest, recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandlerPutResults(t *testing.T) {
+	body := `{"version":4,"state":"restricted","source":" control ","reason":" reason "}`
+
+	t.Run("store unavailable", func(t *testing.T) {
+		recorder := servePut(t, NewHandler(nil, zap.NewNop()), testTeamID, body)
+		if recorder.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+		}
+	})
+
+	t.Run("version conflict", func(t *testing.T) {
+		store := &fakeStore{putErr: ErrVersionConflict}
+		recorder := servePut(t, NewHandler(store, zap.NewNop()), testTeamID, body)
+		if recorder.Code != http.StatusConflict {
+			t.Fatalf("status = %d, want %d", recorder.Code, http.StatusConflict)
+		}
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		store := &fakeStore{putErr: errors.New("failure")}
+		recorder := servePut(t, NewHandler(store, zap.NewNop()), testTeamID, body)
+		if recorder.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want %d", recorder.Code, http.StatusInternalServerError)
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		want := PutResult{
+			Record:  Record{TeamID: testTeamID, Version: 4, State: StateRestricted},
+			Applied: true,
+		}
+		store := &fakeStore{putResult: want}
+		recorder := servePut(t, NewHandler(store, zap.NewNop()), testTeamID, body)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+		}
+		if store.putTeamID != testTeamID || store.putUpdate.Source != "control" || store.putUpdate.Reason != "reason" {
+			t.Fatalf("Put() team = %q, update = %#v", store.putTeamID, store.putUpdate)
+		}
+		var response spec.Response
+		if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil || !response.Success {
+			t.Fatalf("response = %#v, error = %v", response, err)
+		}
+	})
+}
+
+func TestNilHandlerReturnsUnavailable(t *testing.T) {
+	var handler *Handler
+	recorder := servePut(t, handler, testTeamID, `{"version":1,"state":"allowed","source":"test"}`)
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func servePut(t *testing.T, handler *Handler, teamID, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.PUT("/internal/v1/teams/:team_id/admission-state", handler.Put)
+	request := httptest.NewRequest(
+		http.MethodPut,
+		"/internal/v1/teams/"+teamID+"/admission-state",
+		bytes.NewBufferString(body),
+	)
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+	return recorder
+}
+
+func TestUsageMiddleware(t *testing.T) {
+	t.Run("non usage route", func(t *testing.T) {
+		recorder := serveUsage(t, http.MethodGet, "/api/v1/sandboxes", "/api/v1/sandboxes", nil, nil)
+		if recorder.Code != http.StatusNoContent {
+			t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNoContent)
+		}
+	})
+
+	t.Run("missing auth context", func(t *testing.T) {
+		recorder := serveUsage(t, http.MethodPost, "/api/v1/sandboxes", "/api/v1/sandboxes", nil, &fakeStore{})
+		if recorder.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("missing team context", func(t *testing.T) {
+		authCtx := &authn.AuthContext{}
+		recorder := serveUsage(t, http.MethodPost, "/api/v1/sandboxes", "/api/v1/sandboxes", authCtx, &fakeStore{})
+		if recorder.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("self hosted reader unavailable", func(t *testing.T) {
+		authCtx := &authn.AuthContext{TeamID: testTeamID}
+		recorder := serveUsage(t, http.MethodPost, "/api/v1/sandboxes", "/api/v1/sandboxes", authCtx, nil)
+		if recorder.Code != http.StatusNoContent {
+			t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNoContent)
+		}
+	})
+
+	t.Run("required reader unavailable", func(t *testing.T) {
+		authCtx := &authn.AuthContext{TeamID: testTeamID}
+		recorder := serveUsageWithRequirement(
+			t,
+			http.MethodPost,
+			"/api/v1/sandboxes",
+			"/api/v1/sandboxes",
+			authCtx,
+			nil,
+			true,
+		)
+		if recorder.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+		}
+	})
+
+	t.Run("read error", func(t *testing.T) {
+		authCtx := &authn.AuthContext{TeamID: testTeamID}
+		store := &fakeStore{getErr: errors.New("failure")}
+		recorder := serveUsage(t, http.MethodPost, "/api/v1/sandboxes", "/api/v1/sandboxes", authCtx, store)
+		if recorder.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+		}
+	})
+
+	t.Run("default allowed", func(t *testing.T) {
+		authCtx := &authn.AuthContext{TeamID: testTeamID}
+		recorder := serveUsage(t, http.MethodPost, "/api/v1/sandboxes", "/api/v1/sandboxes", authCtx, &fakeStore{})
+		if recorder.Code != http.StatusNoContent {
+			t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNoContent)
+		}
+	})
+
+	t.Run("required state missing", func(t *testing.T) {
+		authCtx := &authn.AuthContext{TeamID: testTeamID}
+		recorder := serveUsageWithRequirement(
+			t,
+			http.MethodPost,
+			"/api/v1/sandboxes",
+			"/api/v1/sandboxes",
+			authCtx,
+			&fakeStore{},
+			true,
+		)
+		if recorder.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+		}
+	})
+
+	t.Run("explicitly allowed", func(t *testing.T) {
+		authCtx := &authn.AuthContext{TeamID: testTeamID}
+		store := &fakeStore{found: true, record: Record{State: StateAllowed}}
+		recorder := serveUsage(t, http.MethodPost, "/api/v1/sandboxes", "/api/v1/sandboxes", authCtx, store)
+		if recorder.Code != http.StatusNoContent {
+			t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNoContent)
+		}
+	})
+
+	t.Run("restricted through wildcard route", func(t *testing.T) {
+		gin.SetMode(gin.TestMode)
+		router := gin.New()
+		router.Use(func(c *gin.Context) {
+			c.Set("auth_context", &authn.AuthContext{TeamID: testTeamID})
+			c.Next()
+		})
+		store := &fakeStore{
+			found:  true,
+			record: Record{Version: 9, State: StateRestricted, Reason: "policy"},
+		}
+		router.Use(NewUsageMiddleware(store, nil, false))
+		router.POST("/api/v1/templates/*path", func(c *gin.Context) {
+			c.Status(http.StatusNoContent)
+		})
+		request := httptest.NewRequest(http.MethodPost, "/api/v1/templates/from-sandbox", nil)
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, request)
+		if recorder.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusForbidden, recorder.Body.String())
+		}
+		if !strings.Contains(recorder.Body.String(), spec.CodeAdmissionRestricted) ||
+			!strings.Contains(recorder.Body.String(), `"version":9`) {
+			t.Fatalf("response = %s", recorder.Body.String())
+		}
+	})
+}
+
+func serveUsage(
+	t *testing.T,
+	method string,
+	route string,
+	requestPath string,
+	authCtx *authn.AuthContext,
+	reader Reader,
+) *httptest.ResponseRecorder {
+	return serveUsageWithRequirement(t, method, route, requestPath, authCtx, reader, false)
+}
+
+func serveUsageWithRequirement(
+	t *testing.T,
+	method string,
+	route string,
+	requestPath string,
+	authCtx *authn.AuthContext,
+	reader Reader,
+	requireState bool,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		if authCtx != nil {
+			c.Set("auth_context", authCtx)
+		}
+		c.Next()
+	})
+	router.Use(NewUsageMiddleware(reader, zap.NewNop(), requireState))
+	router.Handle(method, route, func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+	request := httptest.NewRequest(method, requestPath, nil)
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+	return recorder
+}
+
+func TestStartsUsage(t *testing.T) {
+	tests := []struct {
+		method string
+		path   string
+		want   bool
+	}{
+		{method: http.MethodPut, path: "/api/v1/sandboxes/sb-1", want: true},
+		{method: http.MethodPut, path: "/api/v1/sandboxes/sb-1/network", want: false},
+		{method: http.MethodPut, path: "/api/v1/templates/template-1", want: true},
+		{method: http.MethodPut, path: "/api/v1/templates/template-1/status", want: false},
+		{method: http.MethodPost, path: "/api/v1/sandboxes", want: true},
+		{method: http.MethodPost, path: "/api/v1/templates/", want: true},
+		{method: http.MethodPost, path: "/api/v1/templates/from-sandbox", want: true},
+		{method: http.MethodPost, path: "/api/v1/sandboxvolumes", want: true},
+		{method: http.MethodPost, path: "/api/v1/sandboxes/sb-1/resume", want: true},
+		{method: http.MethodPost, path: "/api/v1/sandboxes/sb-1/fork", want: true},
+		{method: http.MethodPost, path: "/api/v1/sandboxes/sb-1/snapshots", want: true},
+		{method: http.MethodPost, path: "/api/v1/sandboxvolumes/vol-1/fork", want: true},
+		{method: http.MethodPost, path: "/api/v1/sandboxvolumes/vol-1/snapshots", want: true},
+		{method: http.MethodPost, path: "/api/v1/sandboxes//resume", want: false},
+		{method: http.MethodPost, path: "/api/v1/sandboxes/sb-1/pause", want: false},
+		{method: http.MethodDelete, path: "/api/v1/sandboxes/sb-1", want: false},
+	}
+	for _, tt := range tests {
+		if got := StartsUsage(tt.method, tt.path); got != tt.want {
+			t.Errorf("StartsUsage(%q, %q) = %v, want %v", tt.method, tt.path, got, tt.want)
+		}
+	}
+}

--- a/pkg/gateway/admission/repository.go
+++ b/pkg/gateway/admission/repository.go
@@ -1,0 +1,119 @@
+package admission
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type Reader interface {
+	Get(context.Context, string) (Record, bool, error)
+}
+
+type Store interface {
+	Reader
+	Put(context.Context, string, Update) (PutResult, error)
+}
+
+type Repository struct {
+	db rowQuerier
+}
+
+type rowQuerier interface {
+	QueryRow(context.Context, string, ...any) pgx.Row
+}
+
+func NewRepository(pool *pgxpool.Pool) *Repository {
+	if pool == nil {
+		return &Repository{}
+	}
+	return &Repository{db: pool}
+}
+
+func (r *Repository) Get(ctx context.Context, teamID string) (Record, bool, error) {
+	if r == nil || r.db == nil {
+		return Record{}, false, errors.New("admission repository is unavailable")
+	}
+
+	record, err := scanRecord(r.db.QueryRow(ctx, `
+		SELECT team_id::text, version, state, source, reason, updated_at
+		FROM team_admission_states
+		WHERE team_id = $1
+	`, teamID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Record{}, false, nil
+	}
+	if err != nil {
+		return Record{}, false, fmt.Errorf("get team admission state: %w", err)
+	}
+	return record, true, nil
+}
+
+func (r *Repository) Put(ctx context.Context, teamID string, update Update) (PutResult, error) {
+	if r == nil || r.db == nil {
+		return PutResult{}, errors.New("admission repository is unavailable")
+	}
+
+	normalized, err := update.Validate()
+	if err != nil {
+		return PutResult{}, err
+	}
+
+	record, err := scanRecord(r.db.QueryRow(ctx, `
+		INSERT INTO team_admission_states (
+			team_id,
+			version,
+			state,
+			source,
+			reason
+		)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (team_id) DO UPDATE
+		SET
+			version = EXCLUDED.version,
+			state = EXCLUDED.state,
+			source = EXCLUDED.source,
+			reason = EXCLUDED.reason,
+			updated_at = NOW()
+		WHERE team_admission_states.version < EXCLUDED.version
+		RETURNING team_id::text, version, state, source, reason, updated_at
+	`, teamID, normalized.Version, normalized.State, normalized.Source, normalized.Reason))
+	if err == nil {
+		return PutResult{Record: record, Applied: true}, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return PutResult{}, fmt.Errorf("put team admission state: %w", err)
+	}
+
+	current, found, err := r.Get(ctx, teamID)
+	if err != nil {
+		return PutResult{}, err
+	}
+	if !found {
+		return PutResult{}, errors.New("team admission state disappeared after a version race")
+	}
+	if current.Version == normalized.Version && !current.Matches(normalized) {
+		return PutResult{}, fmt.Errorf(
+			"%w: version %d already has different content",
+			ErrVersionConflict,
+			normalized.Version,
+		)
+	}
+	return PutResult{Record: current, Applied: false}, nil
+}
+
+func scanRecord(row pgx.Row) (Record, error) {
+	var record Record
+	err := row.Scan(
+		&record.TeamID,
+		&record.Version,
+		&record.State,
+		&record.Source,
+		&record.Reason,
+		&record.UpdatedAt,
+	)
+	return record, err
+}

--- a/pkg/gateway/admission/repository_integration_test.go
+++ b/pkg/gateway/admission/repository_integration_test.go
@@ -1,0 +1,194 @@
+package admission
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sandbox0-ai/sandbox0/pkg/dbpool"
+	gatewaymigrations "github.com/sandbox0-ai/sandbox0/pkg/gateway/migrations"
+	"github.com/sandbox0-ai/sandbox0/pkg/migrate"
+)
+
+func TestRepositoryPostgresIntegration(t *testing.T) {
+	databaseURL := os.Getenv("INTEGRATION_DATABASE_URL")
+	if databaseURL == "" {
+		databaseURL = os.Getenv("TEST_DATABASE_URL")
+	}
+	if databaseURL == "" {
+		t.Skip("missing INTEGRATION_DATABASE_URL or TEST_DATABASE_URL")
+	}
+
+	ctx := context.Background()
+	schema := "gateway_admission_test_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	adminPool, err := pgxpool.New(ctx, databaseURL)
+	if err != nil {
+		t.Fatalf("connect admin pool: %v", err)
+	}
+	t.Cleanup(adminPool.Close)
+	if _, err := adminPool.Exec(ctx, "CREATE SCHEMA "+schema); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = adminPool.Exec(ctx, "DROP SCHEMA IF EXISTS "+schema+" CASCADE")
+	})
+
+	pool, err := dbpool.New(ctx, dbpool.Options{
+		DatabaseURL: databaseURL,
+		MaxConns:    20,
+		Schema:      schema,
+	})
+	if err != nil {
+		t.Fatalf("connect schema pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	migrationOptions := []migrate.Option{
+		migrate.WithBaseFS(gatewaymigrations.FS),
+		migrate.WithSchema(schema),
+	}
+	if err := migrate.Up(ctx, pool, ".", migrationOptions...); err != nil {
+		t.Fatalf("migrate up: %v", err)
+	}
+	if err := migrate.Down(ctx, pool, ".", migrationOptions...); err != nil {
+		t.Fatalf("migrate down: %v", err)
+	}
+	var admissionTable *string
+	if err := adminPool.QueryRow(ctx, "SELECT to_regclass($1)::text", schema+".team_admission_states").Scan(&admissionTable); err != nil {
+		t.Fatalf("look up rolled back table: %v", err)
+	}
+	if admissionTable != nil {
+		t.Fatalf("team_admission_states still exists after down migration: %s", *admissionTable)
+	}
+	if err := migrate.Up(ctx, pool, ".", migrationOptions...); err != nil {
+		t.Fatalf("migrate back up: %v", err)
+	}
+
+	repository := NewRepository(pool)
+	teamID := createAdmissionTestTeam(t, ctx, pool, "monotonic")
+	if _, found, err := repository.Get(ctx, teamID); err != nil || found {
+		t.Fatalf("default Get() found = %v, error = %v", found, err)
+	}
+
+	const versions = 24
+	var waitGroup sync.WaitGroup
+	errs := make(chan error, versions)
+	for version := int64(1); version <= versions; version++ {
+		waitGroup.Add(1)
+		go func(version int64) {
+			defer waitGroup.Done()
+			_, err := repository.Put(ctx, teamID, Update{
+				Version: version,
+				State:   StateRestricted,
+				Source:  "integration",
+				Reason:  fmt.Sprintf("version-%d", version),
+			})
+			errs <- err
+		}(version)
+	}
+	waitGroup.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent Put() error = %v", err)
+		}
+	}
+	record, found, err := repository.Get(ctx, teamID)
+	if err != nil || !found {
+		t.Fatalf("final Get() found = %v, error = %v", found, err)
+	}
+	if record.Version != versions || record.Reason != fmt.Sprintf("version-%d", versions) {
+		t.Fatalf("final admission = %#v", record)
+	}
+
+	conflictTeamID := createAdmissionTestTeam(t, ctx, pool, "conflict")
+	conflictUpdates := []Update{
+		{Version: 1, State: StateAllowed, Source: "integration", Reason: "a"},
+		{Version: 1, State: StateRestricted, Source: "integration", Reason: "b"},
+	}
+	results := make(chan error, len(conflictUpdates))
+	for _, update := range conflictUpdates {
+		waitGroup.Add(1)
+		go func(update Update) {
+			defer waitGroup.Done()
+			_, err := repository.Put(ctx, conflictTeamID, update)
+			results <- err
+		}(update)
+	}
+	waitGroup.Wait()
+	close(results)
+	successes := 0
+	conflicts := 0
+	for err := range results {
+		switch {
+		case err == nil:
+			successes++
+		case errors.Is(err, ErrVersionConflict):
+			conflicts++
+		default:
+			t.Fatalf("conflicting Put() error = %v", err)
+		}
+	}
+	if successes != 1 || conflicts != 1 {
+		t.Fatalf("conflicting results: successes = %d, conflicts = %d", successes, conflicts)
+	}
+
+	replayTeamID := createAdmissionTestTeam(t, ctx, pool, "replay")
+	replay := Update{Version: 1, State: StateRestricted, Source: "integration", Reason: "same"}
+	replayApplied := make(chan bool, 2)
+	replayErrors := make(chan error, 2)
+	for range 2 {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			result, err := repository.Put(ctx, replayTeamID, replay)
+			replayApplied <- result.Applied
+			replayErrors <- err
+		}()
+	}
+	waitGroup.Wait()
+	close(replayApplied)
+	close(replayErrors)
+	appliedCount := 0
+	for applied := range replayApplied {
+		if applied {
+			appliedCount++
+		}
+	}
+	for err := range replayErrors {
+		if err != nil {
+			t.Fatalf("replayed Put() error = %v", err)
+		}
+	}
+	if appliedCount != 1 {
+		t.Fatalf("replayed Put() applied count = %d, want 1", appliedCount)
+	}
+
+	if _, err := pool.Exec(ctx, "DELETE FROM teams WHERE id = $1", replayTeamID); err != nil {
+		t.Fatalf("delete team: %v", err)
+	}
+	if _, found, err := repository.Get(ctx, replayTeamID); err != nil || found {
+		t.Fatalf("Get() after team delete found = %v, error = %v", found, err)
+	}
+}
+
+func createAdmissionTestTeam(t *testing.T, ctx context.Context, pool *pgxpool.Pool, suffix string) string {
+	t.Helper()
+	teamID := uuid.NewString()
+	if _, err := pool.Exec(
+		ctx,
+		"INSERT INTO teams (id, name, slug) VALUES ($1, $2, $3)",
+		teamID,
+		"Admission "+suffix,
+		"admission-"+suffix+"-"+uuid.NewString(),
+	); err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+	return teamID
+}

--- a/pkg/gateway/admission/repository_test.go
+++ b/pkg/gateway/admission/repository_test.go
@@ -1,0 +1,192 @@
+package admission
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type fakeQuerier struct {
+	rows  []pgx.Row
+	calls int
+}
+
+func (q *fakeQuerier) QueryRow(context.Context, string, ...any) pgx.Row {
+	row := q.rows[q.calls]
+	q.calls++
+	return row
+}
+
+type fakeRow struct {
+	values []any
+	err    error
+}
+
+func (r fakeRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	for index, value := range r.values {
+		switch target := dest[index].(type) {
+		case *string:
+			*target = value.(string)
+		case *int64:
+			*target = value.(int64)
+		case *State:
+			*target = value.(State)
+		case *time.Time:
+			*target = value.(time.Time)
+		}
+	}
+	return nil
+}
+
+func admissionRow(version int64, state State, source, reason string) pgx.Row {
+	return fakeRow{values: []any{
+		"11111111-1111-4111-8111-111111111111",
+		version,
+		state,
+		source,
+		reason,
+		time.Unix(10, 0).UTC(),
+	}}
+}
+
+func TestRepositoryGet(t *testing.T) {
+	if repository := NewRepository(&pgxpool.Pool{}); repository.db == nil {
+		t.Fatal("NewRepository(pool) did not retain the pool")
+	}
+	var nilRepository *Repository
+	if _, _, err := nilRepository.Get(context.Background(), "team"); err == nil {
+		t.Fatal("nil Repository.Get() error = nil")
+	}
+	if _, _, err := NewRepository(nil).Get(context.Background(), "team"); err == nil {
+		t.Fatal("NewRepository(nil).Get() error = nil")
+	}
+
+	t.Run("not found", func(t *testing.T) {
+		repository := &Repository{db: &fakeQuerier{rows: []pgx.Row{fakeRow{err: pgx.ErrNoRows}}}}
+		_, found, err := repository.Get(context.Background(), "team")
+		if err != nil || found {
+			t.Fatalf("Get() found = %v, error = %v", found, err)
+		}
+	})
+
+	t.Run("database error", func(t *testing.T) {
+		wantErr := errors.New("database failure")
+		repository := &Repository{db: &fakeQuerier{rows: []pgx.Row{fakeRow{err: wantErr}}}}
+		_, _, err := repository.Get(context.Background(), "team")
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("Get() error = %v, want %v", err, wantErr)
+		}
+	})
+
+	t.Run("record", func(t *testing.T) {
+		repository := &Repository{db: &fakeQuerier{rows: []pgx.Row{
+			admissionRow(3, StateRestricted, "source", "reason"),
+		}}}
+		record, found, err := repository.Get(context.Background(), "team")
+		if err != nil || !found {
+			t.Fatalf("Get() found = %v, error = %v", found, err)
+		}
+		if record.Version != 3 || record.State != StateRestricted || record.Source != "source" || record.Reason != "reason" {
+			t.Fatalf("Get() = %#v", record)
+		}
+	})
+}
+
+func TestRepositoryPut(t *testing.T) {
+	ctx := context.Background()
+	valid := Update{Version: 2, State: StateAllowed, Source: "source", Reason: "reason"}
+
+	var nilRepository *Repository
+	if _, err := nilRepository.Put(ctx, "team", valid); err == nil {
+		t.Fatal("nil Repository.Put() error = nil")
+	}
+	if _, err := NewRepository(nil).Put(ctx, "team", valid); err == nil {
+		t.Fatal("NewRepository(nil).Put() error = nil")
+	}
+
+	repository := &Repository{db: &fakeQuerier{}}
+	if _, err := repository.Put(ctx, "team", Update{}); !errors.Is(err, ErrInvalidUpdate) {
+		t.Fatalf("Put(invalid) error = %v", err)
+	}
+
+	t.Run("applied", func(t *testing.T) {
+		repository := &Repository{db: &fakeQuerier{rows: []pgx.Row{
+			admissionRow(2, StateAllowed, "source", "reason"),
+		}}}
+		result, err := repository.Put(ctx, "team", valid)
+		if err != nil || !result.Applied || result.Record.Version != 2 {
+			t.Fatalf("Put() result = %#v, error = %v", result, err)
+		}
+	})
+
+	t.Run("insert error", func(t *testing.T) {
+		wantErr := errors.New("insert failure")
+		repository := &Repository{db: &fakeQuerier{rows: []pgx.Row{fakeRow{err: wantErr}}}}
+		_, err := repository.Put(ctx, "team", valid)
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("Put() error = %v, want %v", err, wantErr)
+		}
+	})
+
+	t.Run("read after race error", func(t *testing.T) {
+		wantErr := errors.New("read failure")
+		repository := &Repository{db: &fakeQuerier{rows: []pgx.Row{
+			fakeRow{err: pgx.ErrNoRows},
+			fakeRow{err: wantErr},
+		}}}
+		_, err := repository.Put(ctx, "team", valid)
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("Put() error = %v, want %v", err, wantErr)
+		}
+	})
+
+	t.Run("row disappears after race", func(t *testing.T) {
+		repository := &Repository{db: &fakeQuerier{rows: []pgx.Row{
+			fakeRow{err: pgx.ErrNoRows},
+			fakeRow{err: pgx.ErrNoRows},
+		}}}
+		if _, err := repository.Put(ctx, "team", valid); err == nil {
+			t.Fatal("Put() error = nil")
+		}
+	})
+
+	t.Run("same version conflict", func(t *testing.T) {
+		repository := &Repository{db: &fakeQuerier{rows: []pgx.Row{
+			fakeRow{err: pgx.ErrNoRows},
+			admissionRow(2, StateRestricted, "source", "reason"),
+		}}}
+		_, err := repository.Put(ctx, "team", valid)
+		if !errors.Is(err, ErrVersionConflict) {
+			t.Fatalf("Put() error = %v, want ErrVersionConflict", err)
+		}
+	})
+
+	t.Run("idempotent replay", func(t *testing.T) {
+		repository := &Repository{db: &fakeQuerier{rows: []pgx.Row{
+			fakeRow{err: pgx.ErrNoRows},
+			admissionRow(2, StateAllowed, "source", "reason"),
+		}}}
+		result, err := repository.Put(ctx, "team", valid)
+		if err != nil || result.Applied {
+			t.Fatalf("Put() result = %#v, error = %v", result, err)
+		}
+	})
+
+	t.Run("stale version", func(t *testing.T) {
+		repository := &Repository{db: &fakeQuerier{rows: []pgx.Row{
+			fakeRow{err: pgx.ErrNoRows},
+			admissionRow(3, StateRestricted, "newer", "newer"),
+		}}}
+		result, err := repository.Put(ctx, "team", valid)
+		if err != nil || result.Applied || result.Record.Version != 3 {
+			t.Fatalf("Put() result = %#v, error = %v", result, err)
+		}
+	})
+}

--- a/pkg/gateway/admission/types.go
+++ b/pkg/gateway/admission/types.go
@@ -1,0 +1,74 @@
+package admission
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type State string
+
+const (
+	StateAllowed    State = "allowed"
+	StateRestricted State = "restricted"
+)
+
+const (
+	maxSourceLength = 128
+	maxReasonLength = 512
+)
+
+var (
+	ErrInvalidUpdate   = errors.New("invalid admission update")
+	ErrVersionConflict = errors.New("admission version conflict")
+)
+
+type Record struct {
+	TeamID    string    `json:"team_id"`
+	Version   int64     `json:"version"`
+	State     State     `json:"state"`
+	Source    string    `json:"source"`
+	Reason    string    `json:"reason"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type Update struct {
+	Version int64  `json:"version"`
+	State   State  `json:"state"`
+	Source  string `json:"source"`
+	Reason  string `json:"reason"`
+}
+
+type PutResult struct {
+	Record  Record `json:"admission"`
+	Applied bool   `json:"applied"`
+}
+
+func (u Update) Validate() (Update, error) {
+	u.Source = strings.TrimSpace(u.Source)
+	u.Reason = strings.TrimSpace(u.Reason)
+	if u.Version < 0 {
+		return Update{}, fmt.Errorf("%w: version must not be negative", ErrInvalidUpdate)
+	}
+	if u.State != StateAllowed && u.State != StateRestricted {
+		return Update{}, fmt.Errorf("%w: state must be %q or %q", ErrInvalidUpdate, StateAllowed, StateRestricted)
+	}
+	if u.Source == "" {
+		return Update{}, fmt.Errorf("%w: source is required", ErrInvalidUpdate)
+	}
+	if len(u.Source) > maxSourceLength {
+		return Update{}, fmt.Errorf("%w: source must not exceed %d bytes", ErrInvalidUpdate, maxSourceLength)
+	}
+	if len(u.Reason) > maxReasonLength {
+		return Update{}, fmt.Errorf("%w: reason must not exceed %d bytes", ErrInvalidUpdate, maxReasonLength)
+	}
+	return u, nil
+}
+
+func (r Record) Matches(update Update) bool {
+	return r.Version == update.Version &&
+		r.State == update.State &&
+		r.Source == update.Source &&
+		r.Reason == update.Reason
+}

--- a/pkg/gateway/admission/types_test.go
+++ b/pkg/gateway/admission/types_test.go
@@ -1,0 +1,64 @@
+package admission
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestUpdateValidate(t *testing.T) {
+	valid := Update{
+		Version: 7,
+		State:   StateRestricted,
+		Source:  "  control-plane  ",
+		Reason:  "  policy  ",
+	}
+	normalized, err := valid.Validate()
+	if err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if normalized.Source != "control-plane" || normalized.Reason != "policy" {
+		t.Fatalf("Validate() = %#v", normalized)
+	}
+
+	tests := []struct {
+		name   string
+		update Update
+	}{
+		{name: "negative version", update: Update{Version: -1, State: StateAllowed, Source: "source"}},
+		{name: "invalid state", update: Update{Version: 1, State: "blocked", Source: "source"}},
+		{name: "missing source", update: Update{Version: 1, State: StateAllowed}},
+		{name: "source too long", update: Update{Version: 1, State: StateAllowed, Source: strings.Repeat("s", maxSourceLength+1)}},
+		{name: "reason too long", update: Update{Version: 1, State: StateAllowed, Source: "source", Reason: strings.Repeat("r", maxReasonLength+1)}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.update.Validate()
+			if !errors.Is(err, ErrInvalidUpdate) {
+				t.Fatalf("Validate() error = %v, want ErrInvalidUpdate", err)
+			}
+		})
+	}
+}
+
+func TestRecordMatches(t *testing.T) {
+	record := Record{
+		Version: 2,
+		State:   StateAllowed,
+		Source:  "source",
+		Reason:  "reason",
+	}
+	update := Update{
+		Version: 2,
+		State:   StateAllowed,
+		Source:  "source",
+		Reason:  "reason",
+	}
+	if !record.Matches(update) {
+		t.Fatal("Matches() = false, want true")
+	}
+	update.Reason = "different"
+	if record.Matches(update) {
+		t.Fatal("Matches() = true, want false")
+	}
+}

--- a/pkg/gateway/migrations/00015_add_team_admission_state.sql
+++ b/pkg/gateway/migrations/00015_add_team_admission_state.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+CREATE TABLE team_admission_states (
+    team_id UUID PRIMARY KEY REFERENCES teams(id) ON DELETE CASCADE,
+    version BIGINT NOT NULL CHECK (version >= 0),
+    state TEXT NOT NULL CHECK (state IN ('allowed', 'restricted')),
+    source TEXT NOT NULL CHECK (source <> ''),
+    reason TEXT NOT NULL DEFAULT '',
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS team_admission_states;

--- a/pkg/gateway/spec/response.go
+++ b/pkg/gateway/spec/response.go
@@ -37,6 +37,7 @@ const (
 	CodeConflict            = "conflict"
 	CodeTemplateNotReady    = "template_not_ready"
 	CodeSandboxResumeFailed = "sandbox_resume_failed"
+	CodeAdmissionRestricted = "admission_restricted"
 	CodeUnavailable         = "unavailable"
 	CodeInternal            = "internal_error"
 	CodeNotLicensed         = "feature_not_licensed"

--- a/pkg/gateway/teamresources/inventory_test.go
+++ b/pkg/gateway/teamresources/inventory_test.go
@@ -90,6 +90,9 @@ func TestDiscoveryHelpers(t *testing.T) {
 	if !isIgnoredDiscoveredTable("shared_gateway", "team_members") {
 		t.Fatal("team_members should be ignored because team deletion cascades membership")
 	}
+	if !isIgnoredDiscoveredTable("shared_gateway", "team_admission_states") {
+		t.Fatal("team_admission_states should be ignored because team deletion cascades admission state")
+	}
 	if isIgnoredDiscoveredTable("manager", "sandboxes") {
 		t.Fatal("sandboxes should not be ignored")
 	}

--- a/pkg/gateway/teamresources/repository.go
+++ b/pkg/gateway/teamresources/repository.go
@@ -511,7 +511,7 @@ func compactSchemas(schemas []string) []string {
 
 func isIgnoredDiscoveredTable(_ string, table string) bool {
 	switch table {
-	case "team_members":
+	case "team_members", "team_admission_states":
 		return true
 	default:
 		return false

--- a/pkg/metering/types.go
+++ b/pkg/metering/types.go
@@ -7,8 +7,7 @@ import (
 )
 
 const (
-	ProductSandbox      = "sandbox"
-	ProductManagedAgent = "managed_agent"
+	ProductSandbox = "sandbox"
 
 	ProducerStorage = "storage-proxy.storage"
 
@@ -33,21 +32,18 @@ const (
 	WindowTypeSandboxObjectStoreGetRequests = "sandbox.object_store_get_requests"
 	WindowTypeSandboxObjectStorePutRequests = "sandbox.object_store_put_requests"
 
-	WindowTypeManagedAgentSessionRunningMilliseconds = "managed_agent.session_running_milliseconds"
-
 	WindowUnitMilliseconds    = "milliseconds"
 	WindowUnitBytes           = "bytes"
 	WindowUnitByteHours       = "byte_hours"
 	WindowUnitCount           = "count"
 	WindowUnitMiBMilliseconds = "mib_milliseconds"
 
-	SubjectTypeSandbox             = "sandbox"
-	SubjectTypeVolume              = "volume"
-	SubjectTypeSnapshot            = "snapshot"
-	SubjectTypeRootFS              = "rootfs"
-	SubjectTypeObjectStoreBucket   = "object_store_bucket"
-	SubjectTypeTemplate            = "template"
-	SubjectTypeManagedAgentSession = "managed_agent_session"
+	SubjectTypeSandbox           = "sandbox"
+	SubjectTypeVolume            = "volume"
+	SubjectTypeSnapshot          = "snapshot"
+	SubjectTypeRootFS            = "rootfs"
+	SubjectTypeObjectStoreBucket = "object_store_bucket"
+	SubjectTypeTemplate          = "template"
 )
 
 type Event struct {

--- a/regional-gateway/pkg/http/server.go
+++ b/regional-gateway/pkg/http/server.go
@@ -14,6 +14,7 @@ import (
 	internalmiddleware "github.com/sandbox0-ai/sandbox0/cluster-gateway/pkg/middleware"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	registryprovider "github.com/sandbox0-ai/sandbox0/manager/pkg/registry"
+	"github.com/sandbox0-ai/sandbox0/pkg/gateway/admission"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/apikey"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/auth/builtin"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/auth/oidc"
@@ -38,11 +39,18 @@ type ServerOption func(*serverOptions)
 
 type serverOptions struct {
 	meteringReader gatewayhandlers.MeteringReader
+	admissionStore admission.Store
 }
 
 func WithMeteringReader(reader gatewayhandlers.MeteringReader) ServerOption {
 	return func(opts *serverOptions) {
 		opts.meteringReader = reader
+	}
+}
+
+func WithAdmissionStore(store admission.Store) ServerOption {
+	return func(opts *serverOptions) {
+		opts.admissionStore = store
 	}
 }
 
@@ -62,6 +70,7 @@ type Server struct {
 	logger               *zap.Logger
 	internalAuthGen      *internalauth.Generator
 	meteringHandler      *gatewayhandlers.MeteringHandler
+	admissionStore       admission.Store
 	obsProvider          *observability.Provider
 	httpClient           *http.Client
 
@@ -212,6 +221,10 @@ func NewServer(
 		return nil, fmt.Errorf("create team quota rate limiter: %w", err)
 	}
 	requestLogger := middleware.NewRequestLogger(logger)
+	admissionStore := options.admissionStore
+	if admissionStore == nil && pool != nil {
+		admissionStore = admission.NewRepository(pool)
+	}
 
 	// Initialize built-in auth provider
 	var builtinProvider *builtin.Provider
@@ -257,6 +270,7 @@ func NewServer(
 		logger:                logger,
 		internalAuthGen:       internalAuthGen,
 		meteringHandler:       gatewayhandlers.NewMeteringHandler(options.meteringReader, cfg.RegionID, logger),
+		admissionStore:        admissionStore,
 		obsProvider:           obsProvider,
 		httpClient:            httpClient,
 		clusterGatewayProxies: make(map[string]*proxy.Router),
@@ -305,6 +319,7 @@ func (s *Server) setupRoutes() {
 
 	s.setupPublicRoutes()
 	s.setupMeteringRoutes()
+	s.setupAdmissionRoutes()
 	s.setupInternalSSHRoutes()
 
 	// ===== API Proxy Routes =====
@@ -315,6 +330,7 @@ func (s *Server) setupRoutes() {
 		api.Use(s.authMiddleware.Authenticate())
 		api.Use(attachAuditCorrelation())
 		api.Use(s.rateLimiter.RateLimit())
+		api.Use(admission.NewUsageMiddleware(s.admissionStore, s.logger, s.cfg.AdmissionRequireState))
 
 		usage := api.Group("/v1/usage")
 		usage.Use(s.requireTeamContextForTeamScopedAPI())
@@ -371,6 +387,14 @@ func (s *Server) setupRoutes() {
 	// Unmatched API routes fall back to the default cluster-gateway. Everything
 	// else goes through the public exposure fallback.
 	s.router.NoRoute(s.handleNoRoute)
+}
+
+func (s *Server) setupAdmissionRoutes() {
+	handler := admission.NewHandler(s.admissionStore, s.logger)
+	internal := s.router.Group("/internal/v1")
+	internal.Use(s.authMiddleware.Authenticate())
+	internal.Use(s.authMiddleware.RequireSystemAdmin())
+	internal.PUT("/teams/:team_id/admission-state", handler.Put)
 }
 
 func (s *Server) setupInternalSSHRoutes() {

--- a/regional-gateway/pkg/http/server_metering_routes_test.go
+++ b/regional-gateway/pkg/http/server_metering_routes_test.go
@@ -35,6 +35,17 @@ func TestSetupMeteringRoutesMountsRegionScopedEndpoints(t *testing.T) {
 	}
 }
 
+func TestSetupAdmissionRoutesMountsRegionScopedEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	server := testMeteringRouteServer()
+	server.setupAdmissionRoutes()
+
+	if !hasRoute(server.router, http.MethodPut, "/internal/v1/teams/:team_id/admission-state") {
+		t.Fatal("expected team admission state route to be mounted")
+	}
+}
+
 func TestSetupRoutesExposesTeamScopedUsageAPI(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	logger := zap.NewNop()


### PR DESCRIPTION
## Summary

- add a versioned team admission projection in each region database
- enforce admission on usage-starting HTTP routes and runtime resume paths
- keep self-hosted deployments permissive by default while allowing hosted gateways to require seeded state
- add the generated operator CRD field and remove the retired managed-agent metering vocabulary
- ignore the cascading team admission projection during team-resource deletion inventory

## Why

Prepaid billing needs a region-local admission decision so new billable work can be stopped without coupling request latency to the global billing control plane. Versioned, idempotent updates let the billing worker project state safely into each region.

## Impact

Hosted deployments can opt into fail-closed behavior with admissionRequireState. The default remains false, so deploying this change does not block existing teams before the billing projection has been seeded. Soft prepaid blocks creates and every resume path but never terminates an already-running sandbox.

## Validation

- race tests pass for team resources, admission, cluster-gateway HTTP, and regional-gateway HTTP
- admission package statement coverage is 100.0%
- remote Aliyun environment:
  - allowed create returns 201
  - restricted create and resume return 403 admission_restricted
  - an already-running sandbox remains running after restriction
  - missing required projection returns 503 unavailable
  - restoring allowed state succeeds
  - deleting a team with cascading admission state succeeds
- operator manifests generated and checked
- git diff check passes