### PR TITLE
fix(ctld): make host data root configurable

### DIFF
--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -422,7 +422,18 @@ spec:
             containerdHostDataRoot: /var/lib/containerd/sandbox0
 ```
 
-`ctld` also keeps a disposable node-local rootfs object cache under its host data directory. This cache accelerates pause/resume when the restoring ctld already has the needed rootfs layer objects. The default cap is `20Gi` per ctld node. Set `rootfsObjectCacheMaxBytes: "0"` to disable it, or tune the GC fields to fit your node disk:
+Separately, `ctld` stores volume portal WAL, HA state, and its node-local rootfs cache under `/var/lib/sandbox0/ctld` by default. Put this directory on durable node storage, not a capacity-constrained system disk. On nodes with a dedicated data disk, set `hostDataRoot` to a directory on that disk:
+
+```yaml
+spec:
+    services:
+        ctld:
+            hostDataRoot: /var/lib/containerd/sandbox0/ctld
+```
+
+Changing `hostDataRoot` does not migrate existing data. Cordon the node, stop both ctld HA slots, copy the complete old directory, and then update the setting. The volume portal WAL and HA state are not disposable.
+
+The rootfs object cache inside that directory is disposable and accelerates pause/resume when the restoring ctld already has the needed rootfs layer objects. The default cap is `20Gi` per ctld node. Set `rootfsObjectCacheMaxBytes: "0"` to disable it, or tune the GC fields to fit your node disk:
 
 ```yaml
 spec:

--- a/docs/self-hosted/install/page.mdx
+++ b/docs/self-hosted/install/page.mdx
@@ -339,6 +339,17 @@ spec:
             containerdHostDataRoot: /var/lib/containerd/sandbox0
 ```
 
+`ctld` keeps volume portal WAL, HA state, and its rootfs cache under `/var/lib/sandbox0/ctld` by default. On nodes with a dedicated data disk, place that directory on the data disk too:
+
+```yaml
+spec:
+    services:
+        ctld:
+            hostDataRoot: /var/lib/containerd/sandbox0/ctld
+```
+
+If ctld has already run on the node, stop both HA slots and migrate the complete existing directory before changing `hostDataRoot`. Only the rootfs cache is disposable; the volume portal WAL and HA state are not.
+
 For large writable rootfs checkpoints, ctld uses a disposable node-local object cache capped at `20Gi` per node by default. Tune the cap and free-space floor for your node disk:
 
 ```yaml

--- a/infra-operator/api/v1alpha1/sandbox0infra_types.go
+++ b/infra-operator/api/v1alpha1/sandbox0infra_types.go
@@ -1371,6 +1371,14 @@ type ManagerServiceConfig struct {
 
 // CtldServiceConfig defines configuration for the ctld daemonset.
 type CtldServiceConfig struct {
+	// HostDataRoot is the node path mounted at /var/lib/sandbox0/ctld.
+	// It stores volume portal WAL, HA state, and the node-local rootfs cache.
+	// Migrate the existing directory while ctld is stopped before changing it.
+	// +optional
+	// +kubebuilder:default=/var/lib/sandbox0/ctld
+	// +kubebuilder:validation:Pattern=`^/.*`
+	HostDataRoot string `json:"hostDataRoot,omitempty"`
+
 	// ContainerdHostDataRoot is the containerd data root path on the host.
 	// Set this when nodes use a non-default containerd root such as a dedicated
 	// sandbox worker data disk.

--- a/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
+++ b/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
@@ -3312,6 +3312,14 @@ spec:
                           sandbox worker data disk.
                         pattern: ^/.*
                         type: string
+                      hostDataRoot:
+                        default: /var/lib/sandbox0/ctld
+                        description: |-
+                          HostDataRoot is the node path mounted at /var/lib/sandbox0/ctld.
+                          It stores volume portal WAL, HA state, and the node-local rootfs cache.
+                          Migrate the existing directory while ctld is stopped before changing it.
+                        pattern: ^/.*
+                        type: string
                       rootfsObjectCacheMaxAge:
                         description: |-
                           RootFSObjectCacheMaxAge evicts cache entries older than this age. Zero

--- a/infra-operator/internal/controller/services/ctld/ctld.go
+++ b/infra-operator/internal/controller/services/ctld/ctld.go
@@ -37,8 +37,10 @@ type Reconciler struct {
 
 const (
 	containerdDataMountPath        = "/host-var-lib/containerd"
+	ctldDataMountPath              = "/var/lib/sandbox0/ctld"
 	defaultContainerdHostDataRoot  = "/var/lib/containerd"
 	defaultContainerdHostStateRoot = "/run/containerd"
+	defaultCtldHostDataRoot        = ctldDataMountPath
 	ctldProbeTimeoutSeconds        = 15
 	ctldProbeFailureThreshold      = 12
 	ctldTerminationGraceSeconds    = int64(45)
@@ -109,6 +111,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 
 	nodeSelector, tolerations := common.ResolveSandboxNodePlacement(infra)
 	containerdHostDataRoot := ctldContainerdHostDataRoot(infra)
+	ctldDataHostRoot := ctldHostDataRoot(infra)
 	args := ctldArgs(infra, containerdHostDataRoot)
 	terminationGraceSeconds := ctldTerminationGraceSeconds
 	bidirectional := corev1.MountPropagationBidirectional
@@ -117,7 +120,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		{Name: "config", MountPath: "/config/config.yaml", SubPath: "config.yaml", ReadOnly: true},
 		{Name: "csi-plugin", MountPath: "/csi"},
 		{Name: "kubelet", MountPath: "/var/lib/kubelet", MountPropagation: &bidirectional},
-		{Name: "ctld-data", MountPath: "/var/lib/sandbox0/ctld"},
+		{Name: "ctld-data", MountPath: ctldDataMountPath},
 		{Name: "containerd-sock", MountPath: "/host-run/containerd"},
 		{Name: "containerd-data", MountPath: containerdDataMountPath, ReadOnly: true},
 		{Name: netdsvc.RunVolumeName, MountPath: netdsvc.RunMountDirectory},
@@ -150,7 +153,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 			Name: "ctld-data",
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/var/lib/sandbox0/ctld",
+					Path: ctldDataHostRoot,
 					Type: &hostPathDirectoryOrCreate,
 				},
 			},
@@ -702,7 +705,7 @@ func ctldArgs(infra *infrav1alpha1.Sandbox0Infra, containerdHostDataRoot string)
 		"-containerd-host-root=" + defaultContainerdHostStateRoot,
 		"-containerd-data-root=" + containerdDataMountPath,
 		"-containerd-host-data-root=" + containerdHostDataRoot,
-		"-volume-portal-root=/var/lib/sandbox0/ctld",
+		"-volume-portal-root=" + ctldDataMountPath,
 		"-kubelet-pods-root=/var/lib/kubelet/pods",
 		"-csi-socket=/csi/csi.sock",
 	}
@@ -732,6 +735,16 @@ func ctldContainerdHostDataRoot(infra *infrav1alpha1.Sandbox0Infra) string {
 		return root
 	}
 	return defaultContainerdHostDataRoot
+}
+
+func ctldHostDataRoot(infra *infrav1alpha1.Sandbox0Infra) string {
+	if infra == nil || infra.Spec.Services == nil || infra.Spec.Services.Ctld == nil {
+		return defaultCtldHostDataRoot
+	}
+	if root := strings.TrimSpace(infra.Spec.Services.Ctld.HostDataRoot); root != "" {
+		return root
+	}
+	return defaultCtldHostDataRoot
 }
 
 func (r *Reconciler) ensureCSIDriver(ctx context.Context, labels map[string]string) error {

--- a/infra-operator/internal/controller/services/ctld/ctld_test.go
+++ b/infra-operator/internal/controller/services/ctld/ctld_test.go
@@ -618,19 +618,24 @@ func TestReconcileUsesDefaultContainerdHostDataRoot(t *testing.T) {
 	args := ds.Spec.Template.Spec.Containers[0].Args
 	assertContainsArg(t, args, "-containerd-host-data-root=/var/lib/containerd")
 	assertHostPathVolume(t, ds.Spec.Template.Spec.Volumes, "containerd-data", "/var/lib/containerd")
+	assertHostPathVolume(t, ds.Spec.Template.Spec.Volumes, "ctld-data", "/var/lib/sandbox0/ctld")
 }
 
 func TestReconcileUsesConfiguredContainerdHostDataRoot(t *testing.T) {
 	infra := newCtldTestInfra()
 	infra.Spec.Services.Ctld = &infrav1alpha1.CtldServiceConfig{
 		ContainerdHostDataRoot: "/var/lib/sandbox0-worker/containerd",
+		HostDataRoot:           "/var/lib/sandbox0-worker/ctld",
 	}
 
 	ds := reconcileCtldDaemonSet(t, infra)
 	args := ds.Spec.Template.Spec.Containers[0].Args
 	assertContainsArg(t, args, "-containerd-data-root=/host-var-lib/containerd")
 	assertContainsArg(t, args, "-containerd-host-data-root=/var/lib/sandbox0-worker/containerd")
+	assertContainsArg(t, args, "-volume-portal-root=/var/lib/sandbox0/ctld")
 	assertHostPathVolume(t, ds.Spec.Template.Spec.Volumes, "containerd-data", "/var/lib/sandbox0-worker/containerd")
+	assertHostPathVolume(t, ds.Spec.Template.Spec.Volumes, "ctld-data", "/var/lib/sandbox0-worker/ctld")
+	assertContainerVolumeMount(t, ds.Spec.Template.Spec.Containers[0].VolumeMounts, "ctld-data", "/var/lib/sandbox0/ctld")
 }
 
 func TestReconcilePassesRootFSObjectCacheConfig(t *testing.T) {


### PR DESCRIPTION
## What changed

- add `spec.services.ctld.hostDataRoot` for the host directory mounted at `/var/lib/sandbox0/ctld`
- preserve `/var/lib/sandbox0/ctld` as the default for upgrade compatibility
- keep the container path and `-volume-portal-root` stable while allowing the host path to live on a dedicated data disk
- document that volume portal WAL and HA state must be migrated while both ctld slots are stopped

## Root cause

The ctld hostPath was hard-coded to `/var/lib/sandbox0/ctld`. On nodes whose dedicated data disk is mounted elsewhere, portal WAL, HA state, and the rootfs cache remained on the smaller system disk. A full system disk can leave local portal state behind a committed database head and prevent normal recovery.

This change makes placement explicit without silently relocating existing installations during an operator upgrade.

## Validation

- `make manifests`
- `GOTOOLCHAIN=go1.25.0+auto go test ./infra-operator/...`
- `helm lint infra-operator/chart`
- generated-artifact diff limited to the expected Sandbox0Infra CRD field
