### PR TITLE
Fix auto-resume initialization and claim churn

### DIFF
--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
@@ -542,6 +543,14 @@ func (s *Server) writeSandboxLifecycleTransitionError(c *gin.Context, action, sa
 		spec.JSONError(c, http.StatusTooManyRequests, "quota_exceeded", err.Error())
 	case errors.Is(err, service.ErrSandboxCheckpointRequiresCtld):
 		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox checkpoint pause requires ctld")
+	case errors.Is(err, service.ErrSandboxResumeBackoff):
+		retryAfter := service.SandboxResumeRetryAfter(err)
+		retryAfterSeconds := int((retryAfter + time.Second - 1) / time.Second)
+		if retryAfterSeconds < 1 {
+			retryAfterSeconds = 1
+		}
+		c.Header("Retry-After", strconv.Itoa(retryAfterSeconds))
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox resume is temporarily backing off")
 	case errors.Is(err, context.DeadlineExceeded):
 		spec.JSONError(c, http.StatusGatewayTimeout, spec.CodeUnavailable, fmt.Sprintf("timed out waiting for sandbox to %s", action))
 	case errors.Is(err, context.Canceled):

--- a/manager/pkg/service/migrations/00011_index_lifecycle_txns_by_sandbox.sql
+++ b/manager/pkg/service/migrations/00011_index_lifecycle_txns_by_sandbox.sql
@@ -1,0 +1,9 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sandbox_lifecycle_txns_sandbox_kind_epoch
+    ON manager.sandbox_lifecycle_txns(sandbox_id, kind, epoch DESC);
+
+-- +goose Down
+
+DROP INDEX CONCURRENTLY IF EXISTS manager.idx_sandbox_lifecycle_txns_sandbox_kind_epoch;

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -348,6 +349,24 @@ func (t memorySandboxStoreTx) GetActiveLifecycleTxn(_ context.Context, sandboxID
 	return nil, nil
 }
 
+func (t memorySandboxStoreTx) ListRecentLifecycleTxns(_ context.Context, sandboxID, kind string, limit int) ([]*SandboxLifecycleTxn, error) {
+	t.store.mu.Lock()
+	defer t.store.mu.Unlock()
+	txns := make([]*SandboxLifecycleTxn, 0, len(t.store.lifecycleTxns))
+	for _, txn := range t.store.lifecycleTxns {
+		if txn != nil && txn.SandboxID == sandboxID && txn.Kind == kind {
+			txns = append(txns, cloneSandboxLifecycleTxn(txn))
+		}
+	}
+	sort.Slice(txns, func(i, j int) bool {
+		return txns[i].Epoch > txns[j].Epoch
+	})
+	if limit > 0 && len(txns) > limit {
+		txns = txns[:limit]
+	}
+	return txns, nil
+}
+
 func (t memorySandboxStoreTx) BeginLifecycleTxn(_ context.Context, txn *SandboxLifecycleTxn) error {
 	t.store.mu.Lock()
 	defer t.store.mu.Unlock()
@@ -436,6 +455,8 @@ func (t memorySandboxStoreTx) AbortLifecycleTxn(_ context.Context, txnID, reason
 	if txn := t.store.lifecycleTxns[txnID]; txn != nil && sandboxLifecyclePhaseActive(txn.Phase) {
 		txn.Phase = SandboxLifecyclePhaseAborted
 		txn.Error = reason
+		txn.AbortedAt = time.Now().UTC()
+		txn.UpdatedAt = txn.AbortedAt
 	}
 	return nil
 }
@@ -925,6 +946,98 @@ func TestResumeSandboxSingleflightPreventsConcurrentSandboxLocks(t *testing.T) {
 	store.mu.Unlock()
 	if lockCalls != 1 {
 		t.Fatalf("sandbox lock calls after joined resumes = %d, want 1", lockCalls)
+	}
+}
+
+func TestResumePausedSandboxRuntimeBacksOffBeforeClaimingAnotherPod(t *testing.T) {
+	now := time.Date(2026, time.March, 7, 12, 0, 0, 0, time.UTC)
+	store := &memorySandboxStore{
+		records: map[string]*SandboxRecord{
+			"sandbox-a": {
+				ID:                "sandbox-a",
+				TeamID:            "team-a",
+				UserID:            "user-a",
+				TemplateID:        "default",
+				TemplateName:      "default",
+				TemplateNamespace: "tpl-default",
+				Status:            SandboxStatusPaused,
+				RuntimeGeneration: 3,
+				TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
+			},
+		},
+		lifecycleTxns: map[string]*SandboxLifecycleTxn{
+			"resume-failed": {
+				ID:             "resume-failed",
+				SandboxID:      "sandbox-a",
+				Kind:           SandboxLifecycleKindResume,
+				Phase:          SandboxLifecyclePhaseAborted,
+				Epoch:          4,
+				FromGeneration: 3,
+				ToGeneration:   4,
+				AbortedAt:      now.Add(-5 * time.Second),
+			},
+		},
+	}
+	client := fake.NewSimpleClientset()
+	svc := &SandboxService{
+		k8sClient:    client,
+		podLister:    runtimeIdentityPodLister(t),
+		sandboxStore: store,
+		config:       SandboxServiceConfig{ProcdPort: 49983},
+		clock:        fixedClock{now: now},
+		logger:       zap.NewNop(),
+	}
+
+	_, err := svc.ResumePausedSandboxRuntime(context.Background(), "sandbox-a")
+	if !errors.Is(err, ErrSandboxResumeBackoff) {
+		t.Fatalf("ResumePausedSandboxRuntime() error = %v, want ErrSandboxResumeBackoff", err)
+	}
+	if retryAfter := SandboxResumeRetryAfter(err); retryAfter != 10*time.Second {
+		t.Fatalf("SandboxResumeRetryAfter() = %s, want 10s", retryAfter)
+	}
+	for _, action := range client.Actions() {
+		if action.GetResource().Resource == "pods" &&
+			(action.GetVerb() == "patch" || action.GetVerb() == "create" || action.GetVerb() == "delete") {
+			t.Fatalf("unexpected pod mutation during resume backoff: %#v", action)
+		}
+	}
+}
+
+func TestSandboxResumeFailureRetryAfterUsesConsecutiveExponentialBackoff(t *testing.T) {
+	now := time.Date(2026, time.March, 7, 12, 0, 0, 0, time.UTC)
+	txns := []*SandboxLifecycleTxn{
+		{
+			Kind:           SandboxLifecycleKindResume,
+			Phase:          SandboxLifecyclePhaseAborted,
+			FromGeneration: 3,
+			AbortedAt:      now.Add(-10 * time.Second),
+		},
+		{
+			Kind:           SandboxLifecycleKindResume,
+			Phase:          SandboxLifecyclePhaseAborted,
+			FromGeneration: 3,
+			AbortedAt:      now.Add(-time.Minute),
+		},
+		{
+			Kind:           SandboxLifecycleKindResume,
+			Phase:          SandboxLifecyclePhaseAborted,
+			FromGeneration: 3,
+			AbortedAt:      now.Add(-2 * time.Minute),
+		},
+	}
+
+	retryAfter, failures := sandboxResumeFailureRetryAfter(txns, 3, now)
+	if failures != 3 {
+		t.Fatalf("failure count = %d, want 3", failures)
+	}
+	if retryAfter != 50*time.Second {
+		t.Fatalf("retry after = %s, want 50s", retryAfter)
+	}
+
+	txns[1].Phase = SandboxLifecyclePhaseCommitted
+	retryAfter, failures = sandboxResumeFailureRetryAfter(txns, 3, now)
+	if failures != 1 || retryAfter != 5*time.Second {
+		t.Fatalf("retry after committed boundary = %s with %d failures, want 5s with 1", retryAfter, failures)
 	}
 }
 

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -854,10 +854,18 @@ func declaredVolumeMountsByPath(template *v1alpha1.SandboxTemplate) map[string]v
 	return out
 }
 
-func declaredVolumeMountDirs(template *v1alpha1.SandboxTemplate) []string {
+func unboundVolumeMountDirs(template *v1alpha1.SandboxTemplate, mounts []ClaimMount) []string {
 	declared := declaredVolumeMountsByPath(template)
 	if len(declared) == 0 {
 		return nil
+	}
+	for i := range mounts {
+		boundPath := filepath.Clean(strings.TrimSpace(mounts[i].MountPoint))
+		for mountPath := range declared {
+			if mountPath == boundPath || strings.HasPrefix(mountPath, boundPath+string(filepath.Separator)) {
+				delete(declared, mountPath)
+			}
+		}
 	}
 	dirs := make([]string, 0, len(declared))
 	for mountPath := range declared {
@@ -1694,8 +1702,11 @@ func (s *SandboxService) initializeProcd(
 				s.config.PublicRootDomain,
 			),
 		}),
-		Webhook:   webhookConfig,
-		MountDirs: declaredVolumeMountDirs(template),
+		Webhook: webhookConfig,
+		// Bound portals are already mounted by ctld. Touching one here can block
+		// initialization on its FUSE backend; procd only needs to materialize
+		// optional mount paths that were not bound for this claim.
+		MountDirs: unboundVolumeMountDirs(template, req.Mounts),
 	}
 
 	var initErr error

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -2126,6 +2126,43 @@ func TestValidateClaimMountsForTemplateAllowsPartialDeclaredMountPoints(t *testi
 	}
 }
 
+func TestUnboundVolumeMountDirsExcludesBoundPortals(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		Spec: v1alpha1.SandboxTemplateSpec{
+			VolumeMounts: []v1alpha1.VolumeMountSpec{
+				{Name: "workspace", MountPath: "/workspace"},
+				{Name: "cache", MountPath: "/workspace/cache"},
+				{Name: "scratch", MountPath: "/scratch"},
+				{Name: "data", MountPath: "/data"},
+			},
+		},
+	}
+
+	got := unboundVolumeMountDirs(template, []ClaimMount{
+		{SandboxVolumeID: "vol-workspace", MountPoint: "/workspace/project/.."},
+		{SandboxVolumeID: "vol-data", MountPoint: "/data"},
+	})
+	if joined := strings.Join(got, ","); joined != "/scratch" {
+		t.Fatalf("unboundVolumeMountDirs() = %q, want /scratch", joined)
+	}
+}
+
+func TestUnboundVolumeMountDirsKeepsOmittedOptionalMounts(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		Spec: v1alpha1.SandboxTemplateSpec{
+			VolumeMounts: []v1alpha1.VolumeMountSpec{
+				{Name: "workspace", MountPath: "/workspace"},
+				{Name: "data", MountPath: "/data"},
+			},
+		},
+	}
+
+	got := unboundVolumeMountDirs(template, nil)
+	if joined := strings.Join(got, ","); joined != "/data,/workspace" {
+		t.Fatalf("unboundVolumeMountDirs() = %q, want /data,/workspace", joined)
+	}
+}
+
 func TestValidateClaimMountsForTemplateAllowsDeclaredMountPoint(t *testing.T) {
 	req := &ClaimRequest{
 		Mounts: []ClaimMount{{SandboxVolumeID: "vol-1", MountPoint: "/workspace/project/../data"}},

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -19,6 +19,39 @@ import (
 
 const sandboxLifecycleWaitInterval = 100 * time.Millisecond
 
+const (
+	sandboxResumeFailureHistoryLimit   = 8
+	sandboxResumeFailureInitialBackoff = 15 * time.Second
+	sandboxResumeFailureMaxBackoff     = 2 * time.Minute
+)
+
+// ErrSandboxResumeBackoff indicates that a recent failed resume is temporarily
+// suppressing another runtime claim for the same sandbox.
+var ErrSandboxResumeBackoff = errors.New("sandbox resume is backing off")
+
+type sandboxResumeBackoffError struct {
+	retryAfter time.Duration
+	failures   int
+}
+
+func (e *sandboxResumeBackoffError) Error() string {
+	return fmt.Sprintf("%s after %d consecutive failures; retry after %s",
+		ErrSandboxResumeBackoff.Error(), e.failures, e.retryAfter.Round(time.Second))
+}
+
+func (e *sandboxResumeBackoffError) Unwrap() error {
+	return ErrSandboxResumeBackoff
+}
+
+// SandboxResumeRetryAfter returns the remaining claim backoff carried by err.
+func SandboxResumeRetryAfter(err error) time.Duration {
+	var backoffErr *sandboxResumeBackoffError
+	if !errors.As(err, &backoffErr) {
+		return 0
+	}
+	return backoffErr.retryAfter
+}
+
 // ResumePausedSandboxRuntime creates a new runtime for a paused durable sandbox
 // and restores the latest writable rootfs checkpoint. A terminal runtime first
 // completes crash recovery through the durable pause transaction.
@@ -126,6 +159,21 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 			}
 			if locked.Status != SandboxStatusPaused {
 				return k8serrors.NewConflict(corev1.Resource("sandbox"), sandboxID, fmt.Errorf("sandbox runtime for status %q is not available", locked.Status))
+			}
+			recentResumes, err := tx.ListRecentLifecycleTxns(
+				lockCtx,
+				sandboxID,
+				SandboxLifecycleKindResume,
+				sandboxResumeFailureHistoryLimit,
+			)
+			if err != nil {
+				return err
+			}
+			if retryAfter, failures := sandboxResumeFailureRetryAfter(recentResumes, locked.RuntimeGeneration, s.now()); retryAfter > 0 {
+				return &sandboxResumeBackoffError{
+					retryAfter: retryAfter,
+					failures:   failures,
+				}
 			}
 
 			resumeTemplate, err := s.templateForSandboxRecord(locked)
@@ -249,6 +297,46 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 	}
 	s.enqueueHotClaimReservation(restoredPod)
 	return s.GetSandbox(ctx, sandboxID)
+}
+
+func sandboxResumeFailureRetryAfter(txns []*SandboxLifecycleTxn, runtimeGeneration int64, now time.Time) (time.Duration, int) {
+	failures := 0
+	var latestFailureAt time.Time
+	for _, txn := range txns {
+		if txn == nil ||
+			txn.Kind != SandboxLifecycleKindResume ||
+			txn.Phase != SandboxLifecyclePhaseAborted ||
+			txn.FromGeneration != runtimeGeneration {
+			break
+		}
+		failureAt := txn.AbortedAt
+		if failureAt.IsZero() {
+			failureAt = txn.UpdatedAt
+		}
+		if failureAt.IsZero() {
+			break
+		}
+		if failures == 0 {
+			latestFailureAt = failureAt
+		}
+		failures++
+	}
+	if failures == 0 {
+		return 0, 0
+	}
+
+	backoff := sandboxResumeFailureInitialBackoff
+	for i := 1; i < failures && backoff < sandboxResumeFailureMaxBackoff; i++ {
+		backoff *= 2
+		if backoff > sandboxResumeFailureMaxBackoff {
+			backoff = sandboxResumeFailureMaxBackoff
+		}
+	}
+	retryAfter := latestFailureAt.Add(backoff).Sub(now)
+	if retryAfter <= 0 {
+		return 0, failures
+	}
+	return retryAfter, failures
 }
 
 func (s *SandboxService) recordResumeLifecycleRuntime(ctx context.Context, sandboxID string, txn *SandboxLifecycleTxn, pod *corev1.Pod) error {

--- a/manager/pkg/service/sandbox_store.go
+++ b/manager/pkg/service/sandbox_store.go
@@ -178,6 +178,7 @@ type SandboxStoreTx interface {
 	MarkRuntimePaused(ctx context.Context, sandboxID string, generation int64, pausedAt time.Time) error
 	SaveRootFSState(ctx context.Context, state *SandboxRootFSState) error
 	GetActiveLifecycleTxn(ctx context.Context, sandboxID string) (*SandboxLifecycleTxn, error)
+	ListRecentLifecycleTxns(ctx context.Context, sandboxID, kind string, limit int) ([]*SandboxLifecycleTxn, error)
 	BeginLifecycleTxn(ctx context.Context, txn *SandboxLifecycleTxn) error
 	SetLifecycleTxnRuntime(ctx context.Context, txnID, namespace, podName string) error
 	UpdateLifecycleTxnPhase(ctx context.Context, txnID, phase string) error
@@ -674,6 +675,35 @@ func (t sandboxStoreTx) SaveRootFSState(ctx context.Context, state *SandboxRootF
 
 func (t sandboxStoreTx) GetActiveLifecycleTxn(ctx context.Context, sandboxID string) (*SandboxLifecycleTxn, error) {
 	return getActiveLifecycleTxn(ctx, t.tx, sandboxID)
+}
+
+func (t sandboxStoreTx) ListRecentLifecycleTxns(ctx context.Context, sandboxID, kind string, limit int) ([]*SandboxLifecycleTxn, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	rows, err := t.tx.Query(ctx, lifecycleTxnSelectSQL()+`
+		WHERE sandbox_id = $1
+			AND kind = $2
+		ORDER BY epoch DESC
+		LIMIT $3
+	`, strings.TrimSpace(sandboxID), strings.TrimSpace(kind), limit)
+	if err != nil {
+		return nil, fmt.Errorf("list recent lifecycle txns: %w", err)
+	}
+	defer rows.Close()
+
+	txns := make([]*SandboxLifecycleTxn, 0, limit)
+	for rows.Next() {
+		txn, err := scanLifecycleTxnRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		txns = append(txns, txn)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate recent lifecycle txns: %w", err)
+	}
+	return txns, nil
 }
 
 func (t sandboxStoreTx) BeginLifecycleTxn(ctx context.Context, txn *SandboxLifecycleTxn) error {

--- a/tests/integration/internal/tests/manager/api_test.go
+++ b/tests/integration/internal/tests/manager/api_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -1218,6 +1219,22 @@ func (t memorySandboxStoreTxForManagerIntegration) GetActiveLifecycleTxn(_ conte
 		}
 	}
 	return nil, nil
+}
+
+func (t memorySandboxStoreTxForManagerIntegration) ListRecentLifecycleTxns(_ context.Context, sandboxID, kind string, limit int) ([]*service.SandboxLifecycleTxn, error) {
+	txns := make([]*service.SandboxLifecycleTxn, 0, len(t.store.lifecycleTxns))
+	for _, txn := range t.store.lifecycleTxns {
+		if txn != nil && txn.SandboxID == sandboxID && txn.Kind == kind {
+			txns = append(txns, cloneSandboxLifecycleTxnForManagerIntegration(txn))
+		}
+	}
+	sort.Slice(txns, func(i, j int) bool {
+		return txns[i].Epoch > txns[j].Epoch
+	})
+	if limit > 0 && len(txns) > limit {
+		txns = txns[:limit]
+	}
+	return txns, nil
 }
 
 func (t memorySandboxStoreTxForManagerIntegration) BeginLifecycleTxn(_ context.Context, txn *service.SandboxLifecycleTxn) error {


### PR DESCRIPTION
## Summary

- avoid touching ctld-bound FUSE mount paths, including descendants, during procd initialization
- retain directory materialization for declared optional mounts that were not bound
- persistently back off repeated failed resumes for the same runtime generation before claiming another pod
- return Retry-After from manager while a resume is backing off
- add an online-safe lifecycle transaction lookup index

## Incident evidence

Production manager logs showed repeated hot claims succeeding through rootfs restore and workspace portal bind, followed by the procd initialize request timing out after 6 seconds across multiple pods and nodes. Each completed failure deleted the claimed pod, while the next serial request immediately claimed another one. Existing singleflight only coalesced concurrent requests and did not protect the idle pool from that serial loop.

## Validation

- go test ./manager/pkg/service ./manager/pkg/http ./manager/procd/pkg/http/handlers
- go vet ./manager/pkg/service ./manager/pkg/http ./manager/procd/pkg/http/handlers

The remote test environment was intentionally not touched because it is in use.