### PR TITLE
Harden manager rollouts and sandbox cleanup

### DIFF
--- a/infra-operator/api/config/manager.go
+++ b/infra-operator/api/config/manager.go
@@ -12,6 +12,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// ManagerLeaderElectionNameEnv identifies the Lease name shared by manager replicas.
+const ManagerLeaderElectionNameEnv = "MANAGER_LEADER_ELECTION_NAME"
+
 // ManagerConfig holds the configuration for the manager.
 type ManagerConfig struct {
 	// HTTP Server
@@ -510,8 +513,8 @@ func LoadManagerConfig() *ManagerConfig {
 
 	cfg, err := loadManagerConfig(path)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to load config from %s: %v, using empty config\n", path, err)
-		cfg = &ManagerConfig{}
+		fmt.Fprintf(os.Stderr, "Failed to load config from %s: %v, using default config\n", path, err)
+		cfg = defaultManagerConfig()
 	}
 	if cfg.EgressAuthDefaultResolveTTL.Duration == 0 {
 		cfg.EgressAuthDefaultResolveTTL = metav1.Duration{Duration: 5 * time.Minute}
@@ -593,7 +596,7 @@ func applyRootFSMaintenanceDefaults(cfg *ManagerConfig) {
 }
 
 func loadManagerConfig(path string) (*ManagerConfig, error) {
-	cfg := &ManagerConfig{}
+	cfg := defaultManagerConfig()
 	if path == "" {
 		return cfg, nil
 	}
@@ -611,4 +614,8 @@ func loadManagerConfig(path string) (*ManagerConfig, error) {
 	}
 
 	return cfg, nil
+}
+
+func defaultManagerConfig() *ManagerConfig {
+	return &ManagerConfig{LeaderElection: true}
 }

--- a/infra-operator/api/config/manager_test.go
+++ b/infra-operator/api/config/manager_test.go
@@ -65,3 +65,28 @@ sandbox_max_memory: 16Gi
 		t.Fatalf("sandbox max memory = %q, want 16Gi", cfg.SandboxMaxMemory)
 	}
 }
+
+func TestLoadManagerConfigDefaultsLeaderElectionOn(t *testing.T) {
+	cfg, err := loadManagerConfig("")
+	if err != nil {
+		t.Fatalf("loadManagerConfig: %v", err)
+	}
+	if !cfg.LeaderElection {
+		t.Fatal("leader election default = false, want true")
+	}
+}
+
+func TestLoadManagerConfigAllowsLeaderElectionOff(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "manager.yaml")
+	if err := os.WriteFile(path, []byte("leader_election: false\n"), 0o600); err != nil {
+		t.Fatalf("write manager config: %v", err)
+	}
+
+	cfg, err := loadManagerConfig(path)
+	if err != nil {
+		t.Fatalf("loadManagerConfig: %v", err)
+	}
+	if cfg.LeaderElection {
+		t.Fatal("leader election = true, want explicit false")
+	}
+}

--- a/infra-operator/internal/controller/services/manager/manager.go
+++ b/infra-operator/internal/controller/services/manager/manager.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -229,6 +230,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, 
 	envVars := []corev1.EnvVar{
 		{Name: "SERVICE", Value: "manager"},
 		{Name: "CONFIG_PATH", Value: "/config/config.yaml"},
+		{Name: apiconfig.ManagerLeaderElectionNameEnv, Value: deploymentName},
 	}
 	if storageConfig != nil {
 		storageHTTPPort := int32(storageConfig.HTTPPort)
@@ -237,6 +239,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, 
 		)
 		envVars = append(envVars, corev1.EnvVar{Name: "STORAGE_RUNTIME_CONFIG_PATH", Value: storageRuntimeConfigPath})
 	}
+	maxSurge := intstr.FromInt32(0)
+	maxUnavailable := intstr.FromInt32(1)
 
 	// Create deployment
 	if err := r.Resources.ReconcileDeploymentWithScope(ctx, scope, deploymentName, labels, replicas, common.ServiceDefinition{
@@ -254,6 +258,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, 
 		VolumeMounts:   volumeMounts,
 		Volumes:        volumes,
 		PodAnnotations: podAnnotations,
+		// A no-surge rollout also protects the first upgrade from a manager
+		// version that does not participate in leader election. Once all
+		// replicas are leader-aware, the Lease remains the single-writer guard.
+		DeploymentStrategy: &appsv1.DeploymentStrategy{
+			Type: appsv1.RollingUpdateDeploymentStrategyType,
+			RollingUpdate: &appsv1.RollingUpdateDeployment{
+				MaxSurge:       &maxSurge,
+				MaxUnavailable: &maxUnavailable,
+			},
+		},
 		LivenessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{

--- a/infra-operator/internal/controller/services/manager/manager_test.go
+++ b/infra-operator/internal/controller/services/manager/manager_test.go
@@ -439,6 +439,28 @@ func TestReconcileStorageRuntimeUsesManagerBudgetAndService(t *testing.T) {
 	if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas != 1 {
 		t.Fatalf("manager replicas = %v, want 1", deployment.Spec.Replicas)
 	}
+	leaderElectionName := ""
+	for _, env := range deployment.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == "MANAGER_LEADER_ELECTION_NAME" {
+			leaderElectionName = env.Value
+			break
+		}
+	}
+	if leaderElectionName != "demo-manager" {
+		t.Fatalf("manager leader election name = %q, want demo-manager", leaderElectionName)
+	}
+	if deployment.Spec.Strategy.Type != appsv1.RollingUpdateDeploymentStrategyType ||
+		deployment.Spec.Strategy.RollingUpdate == nil ||
+		deployment.Spec.Strategy.RollingUpdate.MaxSurge == nil ||
+		deployment.Spec.Strategy.RollingUpdate.MaxUnavailable == nil {
+		t.Fatalf("manager deployment strategy = %#v, want no-surge rolling update", deployment.Spec.Strategy)
+	}
+	if got := deployment.Spec.Strategy.RollingUpdate.MaxSurge.IntValue(); got != 0 {
+		t.Fatalf("manager maxSurge = %d, want 0", got)
+	}
+	if got := deployment.Spec.Strategy.RollingUpdate.MaxUnavailable.IntValue(); got != 1 {
+		t.Fatalf("manager maxUnavailable = %d, want 1", got)
+	}
 	resources := deployment.Spec.Template.Spec.Containers[0].Resources
 	if got := resources.Requests.Cpu().String(); got != "75m" {
 		t.Fatalf("manager CPU request = %q, want 75m", got)

--- a/manager/cmd/manager/leader_election.go
+++ b/manager/cmd/manager/leader_election.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+const (
+	defaultManagerLeaderElectionName = "sandbox0-manager"
+	serviceAccountNamespacePath      = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+	managerLeaderLeaseDuration = 15 * time.Second
+	managerLeaderRenewDeadline = 10 * time.Second
+	managerLeaderRetryPeriod   = 2 * time.Second
+)
+
+func runManagerLeaderElection(
+	ctx context.Context,
+	k8sClient kubernetes.Interface,
+	logger *zap.Logger,
+	startControllers func(context.Context),
+	onLeadershipLost func(),
+) error {
+	if k8sClient == nil {
+		return fmt.Errorf("kubernetes client is required for manager leader election")
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	identity, err := managerLeaderElectionIdentity()
+	if err != nil {
+		return err
+	}
+	namespace := managerLeaderElectionNamespace()
+	name := managerLeaderElectionName()
+	lostLeadership := false
+	elector, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+		Lock: &resourcelock.LeaseLock{
+			LeaseMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Client: k8sClient.CoordinationV1(),
+			LockConfig: resourcelock.ResourceLockConfig{
+				Identity: identity,
+			},
+		},
+		LeaseDuration: managerLeaderLeaseDuration,
+		RenewDeadline: managerLeaderRenewDeadline,
+		RetryPeriod:   managerLeaderRetryPeriod,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(leaderCtx context.Context) {
+				logger.Info("Manager controller leadership acquired",
+					zap.String("identity", identity),
+					zap.String("lease", namespace+"/"+name),
+				)
+				startControllers(leaderCtx)
+			},
+			OnStoppedLeading: func() {
+				if ctx.Err() != nil {
+					return
+				}
+				lostLeadership = true
+				logger.Error("Manager controller leadership lost",
+					zap.String("identity", identity),
+					zap.String("lease", namespace+"/"+name),
+				)
+				if onLeadershipLost != nil {
+					onLeadershipLost()
+				}
+			},
+			OnNewLeader: func(currentIdentity string) {
+				if currentIdentity == identity {
+					return
+				}
+				logger.Info("Manager controller leadership held by another replica",
+					zap.String("identity", currentIdentity),
+					zap.String("lease", namespace+"/"+name),
+				)
+			},
+		},
+		// Do not release the Lease before the leader-scoped controller
+		// goroutines have fully stopped. The short expiry gap is preferable to
+		// overlapping reconcilers during a rolling Deployment handoff.
+		ReleaseOnCancel: false,
+		Name:            name,
+	})
+	if err != nil {
+		return fmt.Errorf("configure manager leader election: %w", err)
+	}
+
+	logger.Info("Waiting for manager controller leadership",
+		zap.String("identity", identity),
+		zap.String("lease", namespace+"/"+name),
+	)
+	elector.Run(ctx)
+	if lostLeadership {
+		return fmt.Errorf("manager controller leadership lost")
+	}
+	return nil
+}
+
+func managerLeaderElectionName() string {
+	if name := strings.TrimSpace(os.Getenv(config.ManagerLeaderElectionNameEnv)); name != "" {
+		return name
+	}
+	return defaultManagerLeaderElectionName
+}
+
+func managerLeaderElectionNamespace() string {
+	if namespace := strings.TrimSpace(os.Getenv("POD_NAMESPACE")); namespace != "" {
+		return namespace
+	}
+	if data, err := os.ReadFile(serviceAccountNamespacePath); err == nil {
+		if namespace := strings.TrimSpace(string(data)); namespace != "" {
+			return namespace
+		}
+	}
+	return metav1.NamespaceDefault
+}
+
+func managerLeaderElectionIdentity() (string, error) {
+	if identity := strings.TrimSpace(os.Getenv("POD_NAME")); identity != "" {
+		return identity, nil
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", fmt.Errorf("resolve manager leader election identity: %w", err)
+	}
+	hostname = strings.TrimSpace(hostname)
+	if hostname == "" {
+		return "", fmt.Errorf("resolve manager leader election identity: hostname is empty")
+	}
+	return fmt.Sprintf("%s-%d", hostname, os.Getpid()), nil
+}

--- a/manager/cmd/manager/leader_election_test.go
+++ b/manager/cmd/manager/leader_election_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestManagerLeaderElectionUsesPodIdentityAndConfiguredLease(t *testing.T) {
+	t.Setenv("POD_NAME", "manager-a")
+	t.Setenv("POD_NAMESPACE", "sandbox0-system")
+	t.Setenv(config.ManagerLeaderElectionNameEnv, "demo-manager")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	client := fake.NewSimpleClientset()
+	go func() {
+		done <- runManagerLeaderElection(ctx, client, zap.NewNop(), func(context.Context) {
+			close(started)
+		}, cancel)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("manager did not acquire controller leadership")
+	}
+	lease, err := client.CoordinationV1().Leases("sandbox0-system").Get(
+		context.Background(),
+		"demo-manager",
+		metav1.GetOptions{},
+	)
+	if err != nil {
+		t.Fatalf("get leader election lease: %v", err)
+	}
+	if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity != "manager-a" {
+		t.Fatalf("lease holder = %v, want manager-a", lease.Spec.HolderIdentity)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runManagerLeaderElection() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("manager leader election did not stop")
+	}
+}
+
+func TestManagerLeaderElectionDefaults(t *testing.T) {
+	t.Setenv(config.ManagerLeaderElectionNameEnv, "")
+	t.Setenv("POD_NAMESPACE", "default-a")
+
+	if got := managerLeaderElectionName(); got != defaultManagerLeaderElectionName {
+		t.Fatalf("leader election name = %q, want %q", got, defaultManagerLeaderElectionName)
+	}
+	if got := managerLeaderElectionNamespace(); got != "default-a" {
+		t.Fatalf("leader election namespace = %q, want default-a", got)
+	}
+}

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -572,7 +572,6 @@ func main() {
 			clk,
 			logger,
 		)
-		go templateReconciler.Start(ctx)
 	} else {
 		logger.Info("Template reconciliation disabled; durable template build queue remains enabled")
 	}
@@ -698,97 +697,115 @@ func main() {
 		}
 	}
 
-	startSandboxObservabilityLogProducer(ctx, cfg, k8sClient, podLister, sandboxLogWorker, logger, clk)
-	go func() {
-		if err := sandboxCrashLogCollector.Run(ctx, 2); err != nil && !errors.Is(err, context.Canceled) {
-			logger.Error("Sandbox crash log collector failed", zap.Error(err))
+	startControllers := func(controllerCtx context.Context) {
+		if templateReconciler != nil {
+			go templateReconciler.Start(controllerCtx)
 		}
-	}()
-	go func() {
-		if err := sandboxCrashRecoveryController.Run(ctx, 2); err != nil && !errors.Is(err, context.Canceled) {
-			logger.Error("Sandbox crash recovery controller failed", zap.Error(err))
-		}
-	}()
-
-	if templateBuildWorker != nil {
+		startSandboxObservabilityLogProducer(controllerCtx, cfg, k8sClient, podLister, sandboxLogWorker, logger, clk)
 		go func() {
-			if err := templateBuildWorker.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
-				logger.Error("Template image build worker stopped", zap.Error(err))
+			if err := sandboxCrashLogCollector.Run(controllerCtx, 2); err != nil && !errors.Is(err, context.Canceled) {
+				logger.Error("Sandbox crash log collector failed", zap.Error(err))
 			}
 		}()
-		logger.Info("Template image build worker started",
-			zap.String("clusterID", naming.ClusterIDOrDefault(&cfg.DefaultClusterId)),
-		)
-	}
-
-	// Start operator
-	go func() {
-		if err := operator.Run(ctx, 2); err != nil {
-			logger.Fatal("Operator failed", zap.Error(err))
-		}
-	}()
-
-	// Start cleanup controller
-	go func() {
-		if err := cleanupController.Start(ctx); err != nil && err != context.Canceled {
-			logger.Error("Cleanup controller failed", zap.Error(err))
-		}
-	}()
-
-	go func() {
-		if err := sandboxLifecycleController.Run(ctx, 2); err != nil && err != context.Canceled {
-			logger.Error("Sandbox lifecycle controller failed", zap.Error(err))
-		}
-	}()
-
-	go func() {
-		if err := hotClaimReservationController.Run(ctx, 1); err != nil && err != context.Canceled {
-			logger.Error("Hot claim reservation controller failed", zap.Error(err))
-		}
-	}()
-
-	go func() {
-		if err := sandboxPauseController.Run(ctx, 2); err != nil && err != context.Canceled {
-			logger.Error("Sandbox pause controller failed", zap.Error(err))
-		}
-	}()
-	if !cfg.RootFSMaintenance.Disabled {
-		if rootFSObjectStoreErr != nil {
-			logger.Warn("Rootfs maintenance disabled; object store is not configured", zap.Error(rootFSObjectStoreErr))
-		} else if rootFSObjectStore == nil {
-			logger.Warn("Rootfs maintenance disabled; object store is not configured")
-		} else {
-			rootFSMaintenanceController := service.NewRootFSMaintenanceController(
-				sandboxStore,
-				rootFSObjectStore,
-				rootFSMaintenanceControllerConfig(cfg),
-				logger,
-				managerMetrics,
-			)
-			rootFSMaintenanceController.SetObjectInspector(rootFSObjectStoreInspector{store: rootFSObjectStore})
-			if meteringRepo != nil {
-				rootFSMaintenanceController.SetStorageMeteringRecorder(meteringRepo)
+		go func() {
+			if err := sandboxCrashRecoveryController.Run(controllerCtx, 2); err != nil && !errors.Is(err, context.Canceled) {
+				logger.Error("Sandbox crash recovery controller failed", zap.Error(err))
 			}
+		}()
+
+		if templateBuildWorker != nil {
 			go func() {
-				if err := rootFSMaintenanceController.Run(ctx); err != nil && err != context.Canceled {
-					logger.Error("Rootfs maintenance controller failed", zap.Error(err))
+				if err := templateBuildWorker.Run(controllerCtx); err != nil && !errors.Is(err, context.Canceled) {
+					logger.Error("Template image build worker stopped", zap.Error(err))
 				}
 			}()
+			logger.Info("Template image build worker started",
+				zap.String("clusterID", naming.ClusterIDOrDefault(&cfg.DefaultClusterId)),
+			)
 		}
-	} else {
-		logger.Info("Rootfs maintenance controller disabled by config")
+
+		go func() {
+			if err := operator.Run(controllerCtx, 2); err != nil {
+				logger.Fatal("Operator failed", zap.Error(err))
+			}
+		}()
+
+		go func() {
+			if err := cleanupController.Start(controllerCtx); err != nil && err != context.Canceled {
+				logger.Error("Cleanup controller failed", zap.Error(err))
+			}
+		}()
+
+		go func() {
+			if err := sandboxLifecycleController.Run(controllerCtx, 2); err != nil && err != context.Canceled {
+				logger.Error("Sandbox lifecycle controller failed", zap.Error(err))
+			}
+		}()
+
+		go func() {
+			if err := hotClaimReservationController.Run(controllerCtx, 1); err != nil && err != context.Canceled {
+				logger.Error("Hot claim reservation controller failed", zap.Error(err))
+			}
+		}()
+
+		go func() {
+			if err := sandboxPauseController.Run(controllerCtx, 2); err != nil && err != context.Canceled {
+				logger.Error("Sandbox pause controller failed", zap.Error(err))
+			}
+		}()
+		if !cfg.RootFSMaintenance.Disabled {
+			if rootFSObjectStoreErr != nil {
+				logger.Warn("Rootfs maintenance disabled; object store is not configured", zap.Error(rootFSObjectStoreErr))
+			} else if rootFSObjectStore == nil {
+				logger.Warn("Rootfs maintenance disabled; object store is not configured")
+			} else {
+				rootFSMaintenanceController := service.NewRootFSMaintenanceController(
+					sandboxStore,
+					rootFSObjectStore,
+					rootFSMaintenanceControllerConfig(cfg),
+					logger,
+					managerMetrics,
+				)
+				rootFSMaintenanceController.SetObjectInspector(rootFSObjectStoreInspector{store: rootFSObjectStore})
+				if meteringRepo != nil {
+					rootFSMaintenanceController.SetStorageMeteringRecorder(meteringRepo)
+				}
+				go func() {
+					if err := rootFSMaintenanceController.Run(controllerCtx); err != nil && err != context.Canceled {
+						logger.Error("Rootfs maintenance controller failed", zap.Error(err))
+					}
+				}()
+			}
+		} else {
+			logger.Info("Rootfs maintenance controller disabled by config")
+		}
+
+		go sandboxService.StartSystemVolumeReconciler(controllerCtx, cfg.ResyncPeriod.Duration)
 	}
 
-	go sandboxService.StartSystemVolumeReconciler(ctx, cfg.ResyncPeriod.Duration)
-
-	// Start HTTP server
+	// HTTP and metrics remain available on every replica. Only background
+	// reconcilers that mutate pool and sandbox state are leader-scoped.
 	go func() {
 		if err := httpServer.Start(ctx); err != nil && err != http.ErrServerClosed {
 			logger.Fatal("HTTP server failed", zap.Error(err))
 		}
 	}()
 
-	logger.Info("Manager is running")
+	if cfg.LeaderElection {
+		go func() {
+			if err := runManagerLeaderElection(ctx, k8sClient, logger, startControllers, cancel); err != nil {
+				logger.Error("Manager controller leader election stopped", zap.Error(err))
+				cancel()
+			}
+		}()
+	} else {
+		logger.Warn("Manager controller leader election is disabled")
+		startControllers(ctx)
+	}
+
+	logger.Info("Manager is running",
+		zap.Bool("leaderElection", cfg.LeaderElection),
+	)
 
 	// Wait for termination signal
 	<-ctx.Done()

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -79,6 +80,10 @@ const (
 	HotClaimCompletionProtocolRecordV1   = "record-status-v1"
 
 	unhealthyIdlePodRepairGracePeriod = 2 * time.Minute
+	warmPoolRolloutRequeueAfter       = 2 * time.Second
+
+	warmPoolRolloutMaxUnavailablePercent int32 = 10
+	warmPoolRolloutMaxUnavailableLimit   int32 = 10
 )
 
 func TemplateLogicalID(template *v1alpha1.SandboxTemplate) string {
@@ -174,8 +179,12 @@ func (pm *PoolManager) ReconcilePool(ctx context.Context, template *v1alpha1.San
 		return 0, fmt.Errorf("reconcile replicaset template: %w", err)
 	}
 
-	// 3. Drain stale idle pods atomically with delete preconditions.
-	if err := pm.drainStaleIdlePods(ctx, template, desiredTemplateHash); err != nil {
+	// 3. Drain stale idle pods in availability-bounded batches. A following
+	// batch is not released until replacements from the previous batch are
+	// ready, which prevents a manager rollout from recreating the whole pool at
+	// once.
+	rolloutPending, err := pm.drainStaleIdlePods(ctx, template, desiredTemplateHash)
+	if err != nil {
 		return 0, fmt.Errorf("drain stale idle pods: %w", err)
 	}
 
@@ -191,11 +200,18 @@ func (pm *PoolManager) ReconcilePool(ctx context.Context, template *v1alpha1.San
 	// pods after the burst ends.
 	currentReplicas := getInt32Value(rs.Spec.Replicas)
 	desiredReplicas := desiredPoolReplicas(template)
+	requeueAfter := time.Duration(0)
 	if rs.Spec.Replicas == nil || currentReplicas != desiredReplicas {
-		return pm.reconcileReplicaSetReplicas(ctx, template, rs, desiredReplicas)
+		requeueAfter, err = pm.reconcileReplicaSetReplicas(ctx, template, rs, desiredReplicas)
+		if err != nil {
+			return 0, err
+		}
+	}
+	if rolloutPending && (requeueAfter <= 0 || warmPoolRolloutRequeueAfter < requeueAfter) {
+		requeueAfter = warmPoolRolloutRequeueAfter
 	}
 
-	return 0, nil
+	return requeueAfter, nil
 }
 
 // reconcileReplicaSetReplicas updates the warm-pool size to the configured minimum.
@@ -494,29 +510,87 @@ func (pm *PoolManager) reconcileReplicaSetTemplate(
 	return updatedRS, nil
 }
 
-func (pm *PoolManager) drainStaleIdlePods(ctx context.Context, template *v1alpha1.SandboxTemplate, desiredTemplateHash string) error {
-	pods, err := pm.podLister.Pods(template.Namespace).List(labels.SelectorFromSet(map[string]string{
+func (pm *PoolManager) drainStaleIdlePods(
+	ctx context.Context,
+	template *v1alpha1.SandboxTemplate,
+	desiredTemplateHash string,
+) (bool, error) {
+	selector := labels.SelectorFromSet(map[string]string{
 		LabelTemplateID: template.Name,
 		LabelPoolType:   PoolTypeIdle,
-	}))
+	})
+	podList, err := pm.k8sClient.CoreV1().Pods(template.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: selector.String(),
+	})
 	if err != nil {
-		return err
+		return false, err
+	}
+	pods := make([]*corev1.Pod, 0, len(podList.Items))
+	for idx := range podList.Items {
+		pods = append(pods, &podList.Items[idx])
 	}
 
-	drained := 0
+	desiredReplicas := desiredPoolReplicas(template)
+	maxUnavailable := warmPoolRolloutMaxUnavailable(desiredReplicas)
+	availabilityFloor := desiredReplicas - maxUnavailable
+	if availabilityFloor < 0 {
+		availabilityFloor = 0
+	}
+
+	readyIdlePods := int32(0)
+	stalePods := make([]*corev1.Pod, 0)
+	rolloutPending := false
 	for _, pod := range pods {
-		if pod.DeletionTimestamp != nil {
-			continue
-		}
 		if IsHotClaimReservedPod(pod) {
 			continue
+		}
+		if pod.DeletionTimestamp == nil && IsPodReady(pod) {
+			readyIdlePods++
 		}
 		if pod.Annotations[AnnotationTemplateSpecHash] == desiredTemplateHash {
 			continue
 		}
+		rolloutPending = true
+		if pod.DeletionTimestamp == nil {
+			stalePods = append(stalePods, pod)
+		}
+	}
+
+	// Unready stale pods do not contribute to pool availability, so replace
+	// them before spending the availability budget on ready pods.
+	sort.SliceStable(stalePods, func(i, j int) bool {
+		iReady := IsPodReady(stalePods[i])
+		jReady := IsPodReady(stalePods[j])
+		if iReady != jReady {
+			return !iReady
+		}
+		return stalePods[i].Name < stalePods[j].Name
+	})
+
+	remainingBatch := maxUnavailable
+	readyDeletionBudget := readyIdlePods - availabilityFloor
+	if readyDeletionBudget < 0 {
+		readyDeletionBudget = 0
+	}
+	drained := 0
+	for _, pod := range stalePods {
+		if remainingBatch <= 0 {
+			break
+		}
+		podReady := IsPodReady(pod)
+		if podReady && readyDeletionBudget <= 0 {
+			continue
+		}
+		// Consume the snapshot budget even when the guarded live delete finds
+		// that a concurrent actor already changed the pod. A stale observation
+		// must never allow this reconcile to move on and delete extra pods.
+		remainingBatch--
+		if podReady {
+			readyDeletionBudget--
+		}
 		deleted, err := pm.deleteStaleIdlePodWithRetry(ctx, template.Namespace, pod.Name, desiredTemplateHash)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if deleted {
 			drained++
@@ -525,14 +599,31 @@ func (pm *PoolManager) drainStaleIdlePods(ctx context.Context, template *v1alpha
 
 	if drained > 0 {
 		pm.recorder.Eventf(template, corev1.EventTypeNormal, "StaleIdlePodsDrained",
-			"Drained %d stale idle pod(s) with outdated template hash", drained)
-		pm.logger.Info("Drained stale idle pods",
+			"Drained %d stale idle pod(s) with outdated template hash in rollout batch", drained)
+		pm.logger.Info("Drained stale idle pod rollout batch",
 			zap.String("template", template.Name),
 			zap.Int("count", drained),
+			zap.Int32("readyIdle", readyIdlePods),
+			zap.Int32("availabilityFloor", availabilityFloor),
+			zap.Int32("maxUnavailable", maxUnavailable),
 			zap.String("desiredHash", desiredTemplateHash),
 		)
 	}
-	return nil
+	return rolloutPending, nil
+}
+
+func warmPoolRolloutMaxUnavailable(desiredReplicas int32) int32 {
+	if desiredReplicas <= 0 {
+		return 1
+	}
+	maxUnavailable := (desiredReplicas*warmPoolRolloutMaxUnavailablePercent + 99) / 100
+	if maxUnavailable < 1 {
+		maxUnavailable = 1
+	}
+	if maxUnavailable > warmPoolRolloutMaxUnavailableLimit {
+		maxUnavailable = warmPoolRolloutMaxUnavailableLimit
+	}
+	return maxUnavailable
 }
 
 func (pm *PoolManager) repairUnhealthyIdlePods(ctx context.Context, template *v1alpha1.SandboxTemplate, desiredTemplateHash string) error {

--- a/manager/pkg/controller/pool_manager_test.go
+++ b/manager/pkg/controller/pool_manager_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -256,8 +257,9 @@ func TestDrainStaleIdlePodsUsesDeletePreconditions(t *testing.T) {
 		logger:    zap.NewNop(),
 	}
 
-	err := pm.drainStaleIdlePods(context.Background(), template, "new-hash")
+	rolloutPending, err := pm.drainStaleIdlePods(context.Background(), template, "new-hash")
 	require.NoError(t, err)
+	assert.True(t, rolloutPending)
 	assert.Equal(t, 1, deleteActions)
 }
 
@@ -304,8 +306,9 @@ func TestDrainStaleIdlePodsSkipsAlreadyDeletingPod(t *testing.T) {
 		logger:    zap.NewNop(),
 	}
 
-	err := pm.drainStaleIdlePods(context.Background(), template, "new-hash")
+	rolloutPending, err := pm.drainStaleIdlePods(context.Background(), template, "new-hash")
 	require.NoError(t, err)
+	assert.True(t, rolloutPending)
 	assert.Equal(t, 0, deleteActions)
 }
 
@@ -353,8 +356,9 @@ func TestDrainStaleIdlePodsSkipsPodDeletingAfterList(t *testing.T) {
 		logger:    zap.NewNop(),
 	}
 
-	err := pm.drainStaleIdlePods(context.Background(), template, "new-hash")
+	rolloutPending, err := pm.drainStaleIdlePods(context.Background(), template, "new-hash")
 	require.NoError(t, err)
+	assert.True(t, rolloutPending)
 	assert.Equal(t, 0, deleteActions)
 }
 
@@ -400,9 +404,144 @@ func TestDrainStaleIdlePodsSkipsClaimedActivePods(t *testing.T) {
 		logger:    zap.NewNop(),
 	}
 
-	err := pm.drainStaleIdlePods(context.Background(), template, "new-hash")
+	rolloutPending, err := pm.drainStaleIdlePods(context.Background(), template, "new-hash")
 	require.NoError(t, err)
+	assert.False(t, rolloutPending)
 	assert.Equal(t, 0, deleteActions)
+}
+
+func TestWarmPoolRolloutMaxUnavailable(t *testing.T) {
+	tests := []struct {
+		name     string
+		desired  int32
+		expected int32
+	}{
+		{name: "empty pool", desired: 0, expected: 1},
+		{name: "small pool", desired: 3, expected: 1},
+		{name: "twenty pod pool", desired: 20, expected: 2},
+		{name: "large pool", desired: 180, expected: 10},
+		{name: "capped pool", desired: 1000, expected: 10},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, warmPoolRolloutMaxUnavailable(test.desired))
+		})
+	}
+}
+
+func TestDrainStaleIdlePodsLimitsRolloutBatch(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "template-a", Namespace: "default"},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			Pool: v1alpha1.PoolStrategy{MinIdle: 20},
+		},
+	}
+	objects := make([]runtime.Object, 0, 20)
+	podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for i := 0; i < 20; i++ {
+		pod := readyIdlePoolPod(
+			fmt.Sprintf("idle-stale-%02d", i),
+			types.UID(fmt.Sprintf("uid-%02d", i)),
+			"old-hash",
+		)
+		objects = append(objects, pod)
+		require.NoError(t, podIndexer.Add(pod))
+	}
+	client := fake.NewSimpleClientset(objects...)
+	deleteActions := 0
+	client.PrependReactor("delete", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		deleteActions++
+		return false, nil, nil
+	})
+	pm := &PoolManager{
+		k8sClient: client,
+		podLister: corelisters.NewPodLister(podIndexer),
+		recorder:  record.NewFakeRecorder(10),
+		logger:    zap.NewNop(),
+	}
+
+	rolloutPending, err := pm.drainStaleIdlePods(context.Background(), template, "new-hash")
+	require.NoError(t, err)
+	assert.True(t, rolloutPending)
+	assert.Equal(t, 2, deleteActions)
+}
+
+func TestDrainStaleIdlePodsWaitsForReplacementReadiness(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "template-a", Namespace: "default"},
+		Spec: v1alpha1.SandboxTemplateSpec{
+			Pool: v1alpha1.PoolStrategy{MinIdle: 20},
+		},
+	}
+	objects := make([]runtime.Object, 0, 20)
+	podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for i := 0; i < 18; i++ {
+		pod := readyIdlePoolPod(
+			fmt.Sprintf("idle-stale-%02d", i),
+			types.UID(fmt.Sprintf("uid-stale-%02d", i)),
+			"old-hash",
+		)
+		objects = append(objects, pod)
+		require.NoError(t, podIndexer.Add(pod))
+	}
+	for i := 0; i < 2; i++ {
+		pod := idlePoolPod(
+			fmt.Sprintf("idle-replacement-%02d", i),
+			types.UID(fmt.Sprintf("uid-replacement-%02d", i)),
+			"new-hash",
+		)
+		objects = append(objects, pod)
+		require.NoError(t, podIndexer.Add(pod))
+	}
+	client := fake.NewSimpleClientset(objects...)
+	deleteActions := 0
+	client.PrependReactor("delete", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		deleteActions++
+		return false, nil, nil
+	})
+	pm := &PoolManager{
+		k8sClient: client,
+		podLister: corelisters.NewPodLister(podIndexer),
+		recorder:  record.NewFakeRecorder(10),
+		logger:    zap.NewNop(),
+	}
+
+	rolloutPending, err := pm.drainStaleIdlePods(context.Background(), template, "new-hash")
+	require.NoError(t, err)
+	assert.True(t, rolloutPending)
+	assert.Equal(t, 0, deleteActions)
+}
+
+func idlePoolPod(name string, uid types.UID, templateHash string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       "default",
+			UID:             uid,
+			ResourceVersion: string(uid),
+			Labels: map[string]string{
+				LabelTemplateID: "template-a",
+				LabelPoolType:   PoolTypeIdle,
+			},
+			Annotations: map[string]string{
+				AnnotationTemplateSpecHash: templateHash,
+			},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodPending},
+	}
+}
+
+func readyIdlePoolPod(name string, uid types.UID, templateHash string) *corev1.Pod {
+	pod := idlePoolPod(name, uid, templateHash)
+	pod.Status = corev1.PodStatus{
+		Phase: corev1.PodRunning,
+		Conditions: []corev1.PodCondition{{
+			Type:   corev1.PodReady,
+			Status: corev1.ConditionTrue,
+		}},
+	}
+	return pod
 }
 
 func TestRepairUnhealthyIdlePodsDeletesStuckCurrentHashIdlePod(t *testing.T) {

--- a/manager/pkg/service/sandbox_lifecycle_controller.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller.go
@@ -519,6 +519,19 @@ func (s *SandboxService) unbindDeletedSandboxVolumePortals(ctx context.Context, 
 	if s == nil || !s.config.CtldEnabled || len(info.VolumePortals) == 0 {
 		return nil
 	}
+	if strings.TrimSpace(info.HostIP) == "" && strings.TrimSpace(info.NodeName) == "" {
+		// A pod that was never assigned to a node could not have bound a ctld
+		// volume portal. Treat the absent node identity as proof that there is
+		// no node-local state to clean up so deletion can finish.
+		if s.logger != nil {
+			s.logger.Info("Skipping sandbox volume portal cleanup for unscheduled pod",
+				zap.String("sandboxID", info.SandboxID),
+				zap.String("namespace", info.Namespace),
+				zap.String("pod", info.PodName),
+			)
+		}
+		return nil
+	}
 	if s.ctldClient == nil {
 		return fmt.Errorf("ctld client is not configured")
 	}

--- a/manager/pkg/service/sandbox_lifecycle_controller_test.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -130,6 +131,40 @@ func TestSandboxLifecycleControllerCleansAndRemovesFinalizer(t *testing.T) {
 	}
 	if hasSandboxCleanupFinalizer(updated) {
 		t.Fatal("sandbox cleanup finalizer was not removed")
+	}
+}
+
+func TestSandboxLifecycleControllerRemovesFinalizerForUnscheduledPod(t *testing.T) {
+	deletionTime := metav1.NewTime(time.Now().UTC())
+	pod := newLifecycleTestPod()
+	pod.UID = types.UID("pod-uid-a")
+	pod.Finalizers = []string{sandboxCleanupFinalizer}
+	pod.DeletionTimestamp = &deletionTime
+	pod.Annotations[controller.AnnotationWebhookStateVolumeID] = "volume-a"
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	cleaner := &SandboxService{
+		config: SandboxServiceConfig{CtldEnabled: true},
+		logger: zap.NewNop(),
+	}
+	lifecycleController := NewSandboxLifecycleController(client, nil, cleaner, zap.NewNop())
+
+	err := lifecycleController.reconcile(
+		context.Background(),
+		sandboxLifecycleItemFromInfo(SandboxLifecycleInfo{
+			Namespace: pod.Namespace,
+			PodName:   pod.Name,
+			SandboxID: pod.Name,
+		}, false),
+	)
+	if err != nil {
+		t.Fatalf("reconcile() error = %v", err)
+	}
+	updated, err := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get updated pod: %v", err)
+	}
+	if hasSandboxCleanupFinalizer(updated) {
+		t.Fatal("sandbox cleanup finalizer was not removed for unscheduled pod")
 	}
 }
 
@@ -531,6 +566,29 @@ func TestSandboxServiceCleanupDeletedSandboxUnbindsVolumePortals(t *testing.T) {
 	}
 	if got.SandboxVolumeID != "vol-1" || got.MountPath != "/workspace/data" || got.PortalName != "data" {
 		t.Fatalf("unexpected volume portal unbind request: %+v", got)
+	}
+}
+
+func TestSandboxServiceCleanupDeletedSandboxStillRequiresCtldForScheduledPod(t *testing.T) {
+	svc := &SandboxService{
+		config: SandboxServiceConfig{CtldEnabled: true},
+		logger: zap.NewNop(),
+	}
+
+	err := svc.CleanupDeletedSandbox(context.Background(), SandboxLifecycleInfo{
+		Namespace: "ns-a",
+		PodName:   "sandbox-a",
+		SandboxID: "sandbox-a",
+		PodUID:    "pod-uid-a",
+		NodeName:  "sandbox-node-a",
+		VolumePortals: []SandboxLifecycleVolumePortal{{
+			SandboxVolumeID: "vol-1",
+			MountPoint:      "/workspace/data",
+			PortalName:      "data",
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "ctld client is not configured") {
+		t.Fatalf("CleanupDeletedSandbox() error = %v, want missing ctld client", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- roll stale warm-pool pods in availability-bounded batches instead of deleting the full pool at once
- run manager background reconcilers only on the Kubernetes Lease leader, and use a no-surge manager rollout so the first upgrade from a non-leader-aware version is safe
- let never-scheduled sandbox pods skip ctld portal unbinds and complete cleanup finalization

## Root cause

A manager image update changes the generated warm-pool pod spec hash through the `procd-bin` image reference. The pool reconciler treated every old-hash idle pod as stale and deleted all of them in one pass. During a rolling manager Deployment, the old and new manager processes could also reconcile concurrently because the existing `leader_election` setting was not implemented.

Separately, deletion cleanup assumed every pod with volume portals had a node identity. A pod that never scheduled has neither `nodeName` nor `hostIP`, so ctld lookup failed forever and kept the cleanup finalizer attached.

## Impact

- warm-pool replacements preserve at least 90% availability, with a maximum batch of 10 pods
- only one manager replica runs pool, lifecycle, cleanup, pause, crash recovery, template build, observability producer, and maintenance controllers
- a single-replica manager uses `maxSurge: 0` / `maxUnavailable: 1`, which trades a brief API gap during manager upgrades for a safe first rollout from versions that do not understand the Lease
- unscheduled sandbox pods no longer remain indefinitely in `Terminating`; scheduled pods still surface real ctld cleanup failures

## Validation

- `go test ./manager/... -count=1`
- `go test ./infra-operator/... -count=1`
- `go vet ./manager/... ./infra-operator/...`
- targeted `go test -race` for leader election, warm-pool rollout, and lifecycle cleanup
- Aliyun Singapore persistent kind environment:
  - `Sandbox0Infra` reached `Ready` (`10/10`)
  - a 20-pod warm-pool rollout held `min_ready=18`, `max_unavailable=2`, and `max_fresh_unready=2`
  - two manager replicas produced one Lease holder and one `Starting operator`; deleting the leader completed a safe handoff
  - an unscheduled active pod with a volume portal received the cleanup finalizer and was fully removed one second after deletion
  - the default warm-pool pod reached `Ready`

The broad local `go test ./...` run passed all non-e2e packages; its local e2e entrypoint could not start because `kind` is not installed locally. Runtime validation was performed in the remote kind environment above.
