### PR TITLE
Make team creation atomic

### DIFF
--- a/pkg/gateway/http/handlers/team.go
+++ b/pkg/gateway/http/handlers/team.go
@@ -17,7 +17,7 @@ import (
 
 type teamRepository interface {
 	GetTeamsByUserID(ctx context.Context, userID string) ([]*identity.Team, error)
-	CreateTeam(ctx context.Context, team *identity.Team) error
+	CreateTeamWithMember(ctx context.Context, team *identity.Team, member *identity.TeamMember) error
 	GetTeamMember(ctx context.Context, teamID, userID string) (*identity.TeamMember, error)
 	GetTeamByID(ctx context.Context, id string) (*identity.Team, error)
 	UpdateTeam(ctx context.Context, team *identity.Team) error
@@ -152,21 +152,15 @@ func (h *TeamHandler) CreateTeam(c *gin.Context) {
 		OwnerID:      &authCtx.UserID,
 		HomeRegionID: homeRegionID,
 	}
-
-	if err := h.repo.CreateTeam(c.Request.Context(), team); err != nil {
-		h.logger.Error("Failed to create team", zap.Error(err))
-		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to create team")
-		return
-	}
-
-	// Add creator as admin member
 	member := &identity.TeamMember{
-		TeamID: team.ID,
 		UserID: authCtx.UserID,
 		Role:   "admin",
 	}
-	if err := h.repo.AddTeamMember(c.Request.Context(), member); err != nil {
-		h.logger.Warn("Failed to add creator as member", zap.Error(err))
+
+	if err := h.repo.CreateTeamWithMember(c.Request.Context(), team, member); err != nil {
+		h.logger.Error("Failed to create team with owner membership", zap.Error(err))
+		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, "failed to create team")
+		return
 	}
 
 	spec.JSONSuccess(c, http.StatusCreated, team)

--- a/pkg/gateway/http/handlers/team_test.go
+++ b/pkg/gateway/http/handlers/team_test.go
@@ -28,27 +28,38 @@ const (
 )
 
 type stubTeamRepository struct {
-	createdTeam     *identity.Team
-	updatedTeam     *identity.Team
-	addedTeamMember *identity.TeamMember
-	teams           map[string]*identity.Team
-	members         map[string]*identity.TeamMember
-	memberLists     map[string][]*identity.TeamMemberWithUser
-	searchMembers   []*identity.TeamMemberWithUser
-	searchTeamID    string
-	searchQuery     string
-	deletedTeamID   string
+	createdTeam             *identity.Team
+	updatedTeam             *identity.Team
+	addedTeamMember         *identity.TeamMember
+	createTeamWithMemberErr error
+	teams                   map[string]*identity.Team
+	members                 map[string]*identity.TeamMember
+	memberLists             map[string][]*identity.TeamMemberWithUser
+	searchMembers           []*identity.TeamMemberWithUser
+	searchTeamID            string
+	searchQuery             string
+	deletedTeamID           string
 }
 
 func (s *stubTeamRepository) GetTeamsByUserID(context.Context, string) ([]*identity.Team, error) {
 	return nil, nil
 }
 
-func (s *stubTeamRepository) CreateTeam(_ context.Context, team *identity.Team) error {
+func (s *stubTeamRepository) CreateTeamWithMember(
+	_ context.Context,
+	team *identity.Team,
+	member *identity.TeamMember,
+) error {
+	if s.createTeamWithMemberErr != nil {
+		return s.createTeamWithMemberErr
+	}
 	copyTeam := *team
 	copyTeam.ID = testTeamID
 	s.createdTeam = &copyTeam
 	team.ID = copyTeam.ID
+	member.TeamID = copyTeam.ID
+	copyMember := *member
+	s.addedTeamMember = &copyMember
 	return nil
 }
 
@@ -342,8 +353,32 @@ func TestTeamHandlerCreateTeamAllowsMissingHomeRegionWithoutGlobalRequirement(t 
 	if repo.createdTeam.HomeRegionID != nil {
 		t.Fatalf("expected nil home region, got %#v", repo.createdTeam.HomeRegionID)
 	}
-	if repo.addedTeamMember == nil || repo.addedTeamMember.TeamID != testTeamID {
+	if repo.addedTeamMember == nil ||
+		repo.addedTeamMember.TeamID != testTeamID ||
+		repo.addedTeamMember.UserID != testCreatorUserID ||
+		repo.addedTeamMember.Role != "admin" {
 		t.Fatalf("expected creator to be added as team member, got %#v", repo.addedTeamMember)
+	}
+}
+
+func TestTeamHandlerCreateTeamFailsWhenOwnerMembershipCannotBeCreated(t *testing.T) {
+	t.Setenv("GIN_MODE", "release")
+	gin.SetMode(gin.ReleaseMode)
+
+	repo := &stubTeamRepository{
+		createTeamWithMemberErr: errors.New("insert team member"),
+	}
+	handler := NewTeamHandler(repo, zap.NewNop())
+
+	rec := performCreateTeamRequest(t, handler, map[string]any{
+		"name": "Example Team",
+	})
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusInternalServerError, rec.Body.String())
+	}
+	if repo.createdTeam != nil || repo.addedTeamMember != nil {
+		t.Fatalf("team creation should fail atomically: team=%#v member=%#v", repo.createdTeam, repo.addedTeamMember)
 	}
 }
 

--- a/pkg/gateway/identity/team_repository.go
+++ b/pkg/gateway/identity/team_repository.go
@@ -12,14 +12,51 @@ import (
 
 // CreateTeam creates a new team.
 func (r *Repository) CreateTeam(ctx context.Context, team *Team) error {
+	return insertTeam(ctx, r.pool, team)
+}
+
+// CreateTeamWithMember creates a team and its initial member in one transaction.
+func (r *Repository) CreateTeamWithMember(ctx context.Context, team *Team, member *TeamMember) error {
+	tx, err := r.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin create team with member: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	createdTeam := *team
+	if err := insertTeam(ctx, tx, &createdTeam); err != nil {
+		return err
+	}
+
+	createdMember := *member
+	createdMember.TeamID = createdTeam.ID
+	if err := insertTeamMember(ctx, tx, &createdMember); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit create team with member: %w", err)
+	}
+	*team = createdTeam
+	*member = createdMember
+	return nil
+}
+
+type rowQuerier interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+func insertTeam(ctx context.Context, querier rowQuerier, team *Team) error {
 	if team.Slug == "" {
 		team.Slug = generateSlug(team.Name)
 	}
 
-	err := r.pool.QueryRow(ctx, `
-		INSERT INTO teams (name, slug, owner_id, home_region_id)
-		VALUES ($1, $2, $3, $4)
-		RETURNING id, created_at, updated_at
+	err := querier.QueryRow(ctx, `
+			INSERT INTO teams (name, slug, owner_id, home_region_id)
+			VALUES ($1, $2, $3, $4)
+			RETURNING id, created_at, updated_at
 	`, team.Name, team.Slug, team.OwnerID, team.HomeRegionID).Scan(&team.ID, &team.CreatedAt, &team.UpdatedAt)
 	if err != nil {
 		return fmt.Errorf("insert team: %w", err)
@@ -191,10 +228,14 @@ func (r *Repository) ListTeamGrantsByUserID(ctx context.Context, userID string) 
 
 // AddTeamMember adds a user to a team.
 func (r *Repository) AddTeamMember(ctx context.Context, member *TeamMember) error {
-	err := r.pool.QueryRow(ctx, `
-		INSERT INTO team_members (team_id, user_id, role)
-		VALUES ($1, $2, $3)
-		RETURNING id, joined_at
+	return insertTeamMember(ctx, r.pool, member)
+}
+
+func insertTeamMember(ctx context.Context, querier rowQuerier, member *TeamMember) error {
+	err := querier.QueryRow(ctx, `
+			INSERT INTO team_members (team_id, user_id, role)
+			VALUES ($1, $2, $3)
+			RETURNING id, joined_at
 	`, member.TeamID, member.UserID, member.Role).Scan(&member.ID, &member.JoinedAt)
 	if err != nil {
 		if isDuplicateKeyError(err) {

--- a/pkg/gateway/identity/team_repository_test.go
+++ b/pkg/gateway/identity/team_repository_test.go
@@ -52,6 +52,69 @@ func TestTeamRepositoryAllowsDuplicateNamesAndSlugs(t *testing.T) {
 	}
 }
 
+func TestTeamRepositoryCreateTeamWithMemberIsAtomic(t *testing.T) {
+	pool, _ := newGatewayIdentityTestPool(t)
+	if pool == nil {
+		return
+	}
+
+	ctx := context.Background()
+	repo := NewRepository(pool)
+	owner := &User{Email: "atomic-team-owner@example.com", Name: "Atomic Owner"}
+	if err := repo.CreateUser(ctx, owner); err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+
+	ownerID := owner.ID
+	team := &Team{Name: "Atomic Team", OwnerID: &ownerID}
+	member := &TeamMember{UserID: owner.ID, Role: "admin"}
+	if err := repo.CreateTeamWithMember(ctx, team, member); err != nil {
+		t.Fatalf("create team with member: %v", err)
+	}
+	if team.ID == "" || member.ID == "" || member.TeamID != team.ID {
+		t.Fatalf("created team=%#v member=%#v", team, member)
+	}
+	storedMember, err := repo.GetTeamMember(ctx, team.ID, owner.ID)
+	if err != nil {
+		t.Fatalf("get owner membership: %v", err)
+	}
+	if storedMember.Role != "admin" {
+		t.Fatalf("owner membership role = %q, want admin", storedMember.Role)
+	}
+
+	teams, err := repo.GetTeamsByUserID(ctx, owner.ID)
+	if err != nil {
+		t.Fatalf("list owner teams: %v", err)
+	}
+	if len(teams) != 1 || teams[0].ID != team.ID {
+		t.Fatalf("owner teams = %#v, want team %s", teams, team.ID)
+	}
+
+	rolledBackTeam := &Team{Name: "Rolled Back Team", OwnerID: &ownerID}
+	rolledBackMember := &TeamMember{
+		UserID: "00000000-0000-0000-0000-000000000000",
+		Role:   "admin",
+	}
+	if err := repo.CreateTeamWithMember(ctx, rolledBackTeam, rolledBackMember); err == nil {
+		t.Fatal("create team with missing member user error = nil")
+	}
+	if rolledBackTeam.ID != "" || rolledBackMember.TeamID != "" {
+		t.Fatalf("failed creation mutated inputs: team=%#v member=%#v", rolledBackTeam, rolledBackMember)
+	}
+
+	var rolledBackCount int
+	if err := pool.QueryRow(
+		ctx,
+		`SELECT COUNT(*) FROM teams WHERE name = $1`,
+		rolledBackTeam.Name,
+	).Scan(&rolledBackCount); err != nil {
+		t.Fatalf("count rolled back teams: %v", err)
+	}
+	if rolledBackCount != 0 {
+		t.Fatalf("rolled back team count = %d, want 0", rolledBackCount)
+	}
+}
+
 func TestGatewayMigration14RepairsProductionSlugConstraint(t *testing.T) {
 	pool, schema := newGatewayIdentityTestPool(t)
 	if pool == nil {


### PR DESCRIPTION
## Summary

- create a team and its initial admin membership in one PostgreSQL transaction
- keep repository inputs unchanged unless the transaction commits
- make the team handler fail the request when either insert fails
- cover the successful owner membership and rollback paths

## Why

`POST /teams` previously inserted the team and creator membership separately. A
membership insert failure could leave an orphaned team while the handler still
returned a successful response.

## Companion

- Dashboard New team flow: https://github.com/sandbox0-ai/sandbox0-cloud/pull/273

## Testing

- `go test ./pkg/gateway/...`
