### PR TITLE
Bound ClickHouse metering export memory

### DIFF
--- a/pkg/metering/clickhouse/repository.go
+++ b/pkg/metering/clickhouse/repository.go
@@ -16,6 +16,7 @@ const (
 	dateTime64NanoPlaceholder         = "fromUnixTimestamp64Nano(?, 'UTC')"
 	nullableDateTime64NanoPlaceholder = "if(toUInt8(?), fromUnixTimestamp64Nano(?, 'UTC'), NULL)"
 	maxMeteringInsertBatchSize        = 500
+	maxWindowDetailBatchSize          = 200
 	meteringInsertReliabilitySettings = " SETTINGS async_insert = 0, wait_for_async_insert = 1"
 )
 
@@ -505,9 +506,161 @@ func (r *Repository) listWindows(ctx context.Context, teamID string, windowType 
 	if err != nil {
 		return nil, "", err
 	}
-	where, args := windowWhere(teamID, windowType, decoded)
+	keys, err := r.listWindowKeys(ctx, teamID, windowType, decoded, limit)
+	if err != nil {
+		return nil, "", err
+	}
+	if len(keys) == 0 {
+		return []*metering.Window{}, "", nil
+	}
+	details, err := r.loadWindowDetails(ctx, keys)
+	if err != nil {
+		return nil, "", err
+	}
+
+	windows := make([]*metering.Window, 0, len(keys))
+	for _, key := range keys {
+		window, ok := details[key.identity()]
+		if !ok {
+			return nil, "", fmt.Errorf(
+				"usage window %q from producer %q disappeared while loading its selected version",
+				key.WindowID,
+				key.Producer,
+			)
+		}
+		if !window.RecordedAt.Equal(key.RecordedAt) {
+			return nil, "", fmt.Errorf(
+				"usage window %q from producer %q changed while loading its selected version",
+				key.WindowID,
+				key.Producer,
+			)
+		}
+		if teamID != "" && window.TeamID != teamID {
+			return nil, "", fmt.Errorf(
+				"usage window %q from producer %q changed team while loading its selected version",
+				key.WindowID,
+				key.Producer,
+			)
+		}
+		if windowType != "" && window.WindowType != windowType {
+			return nil, "", fmt.Errorf(
+				"usage window %q from producer %q changed type while loading its selected version",
+				key.WindowID,
+				key.Producer,
+			)
+		}
+		windows = append(windows, window)
+	}
+	next, err := nextWindowCursor(windows)
+	if err != nil {
+		return nil, "", err
+	}
+	return windows, next, nil
+}
+
+type windowLookupIdentity struct {
+	RegionID string
+	Producer string
+	WindowID string
+}
+
+type windowLookupKey struct {
+	RecordedAt time.Time
+	RegionID   string
+	Producer   string
+	WindowID   string
+	Version    uint64
+}
+
+func (k windowLookupKey) identity() windowLookupIdentity {
+	return windowLookupIdentity{
+		RegionID: k.RegionID,
+		Producer: k.Producer,
+		WindowID: k.WindowID,
+	}
+}
+
+// listWindowKeys keeps FINAL limited to the narrow cursor and primary-key
+// columns. Selecting the full row under FINAL makes ClickHouse retain hundreds
+// of MiB while resolving ReplacingMergeTree versions.
+func (r *Repository) listWindowKeys(
+	ctx context.Context,
+	teamID string,
+	windowType string,
+	cursor *pageCursor,
+	limit int,
+) ([]windowLookupKey, error) {
+	where, args := windowWhere(teamID, windowType, cursor)
 	args = append(args, limit)
 	rows, err := r.db.QueryContext(ctx, fmt.Sprintf(`
+SELECT
+    recorded_at, region_id, producer, window_id, version
+FROM %s FINAL
+%s
+ORDER BY recorded_at ASC, producer ASC, window_id ASC
+LIMIT ?
+`, qualified(r.cfg.Database, r.cfg.WindowsTable), where), args...)
+	if err != nil {
+		return nil, fmt.Errorf("query usage window keys: %w", err)
+	}
+	defer rows.Close()
+
+	keys := make([]windowLookupKey, 0, limit)
+	seen := make(map[windowLookupIdentity]struct{}, limit)
+	for rows.Next() {
+		key := windowLookupKey{}
+		if err := rows.Scan(
+			&key.RecordedAt,
+			&key.RegionID,
+			&key.Producer,
+			&key.WindowID,
+			&key.Version,
+		); err != nil {
+			return nil, fmt.Errorf("scan usage window key: %w", err)
+		}
+		identity := key.identity()
+		if _, ok := seen[identity]; ok {
+			return nil, fmt.Errorf(
+				"usage window key %q from producer %q is duplicated after FINAL",
+				key.WindowID,
+				key.Producer,
+			)
+		}
+		seen[identity] = struct{}{}
+		keys = append(keys, key)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate usage window keys: %w", err)
+	}
+	return keys, nil
+}
+
+// loadWindowDetails reads raw primary-key ranges in bounded batches and
+// selects exactly the version chosen by the FINAL key query. Avoiding FINAL on
+// the wide row set bounds memory without allowing a concurrent replacement to
+// advance the export cursor past an unseen version.
+func (r *Repository) loadWindowDetails(
+	ctx context.Context,
+	keys []windowLookupKey,
+) (map[windowLookupIdentity]*metering.Window, error) {
+	details := make(map[windowLookupIdentity]*metering.Window, len(keys))
+	for offset := 0; offset < len(keys); offset += maxWindowDetailBatchSize {
+		end := min(offset+maxWindowDetailBatchSize, len(keys))
+		batch := keys[offset:end]
+		expectedVersions := make(map[windowLookupIdentity]uint64, len(batch))
+		var predicates strings.Builder
+		args := make([]any, 0, len(batch)*3)
+		for index, key := range batch {
+			identity := key.identity()
+			expectedVersions[identity] = key.Version
+			if index > 0 {
+				predicates.WriteString(", ")
+			}
+			predicates.WriteString("(?, ?, ?)")
+			args = append(args, key.RegionID, key.Producer, key.WindowID)
+		}
+
+		rows, err := r.db.QueryContext(ctx, fmt.Sprintf(`
 SELECT
     sequence, window_id, producer, region_id, window_type,
     subject_type, subject_id,
@@ -515,43 +668,55 @@ SELECT
     sandbox_id, volume_id, snapshot_id,
     template_id, cluster_id,
     window_start, window_end,
-    value, unit, recorded_at, data
-FROM %s FINAL
-%s
-ORDER BY recorded_at ASC, producer ASC, window_id ASC
-LIMIT ?
-`, qualified(r.cfg.Database, r.cfg.WindowsTable), where), args...)
-	if err != nil {
-		return nil, "", fmt.Errorf("query usage windows: %w", err)
-	}
-	defer rows.Close()
-
-	windows := make([]*metering.Window, 0, limit)
-	for rows.Next() {
-		window := &metering.Window{}
-		var data string
-		if err := rows.Scan(
-			&window.Sequence, &window.WindowID, &window.Producer, &window.RegionID, &window.WindowType,
-			&window.SubjectType, &window.SubjectID,
-			&window.TeamID, &window.UserID,
-			&window.SandboxID, &window.VolumeID, &window.SnapshotID,
-			&window.TemplateID, &window.ClusterID,
-			&window.WindowStart, &window.WindowEnd,
-			&window.Value, &window.Unit, &window.RecordedAt, &data,
-		); err != nil {
-			return nil, "", fmt.Errorf("scan usage window: %w", err)
+    value, unit, recorded_at, data, version
+FROM %s
+WHERE (region_id, producer, window_id) IN (%s)
+ORDER BY region_id ASC, producer ASC, window_id ASC, version DESC
+`, qualified(r.cfg.Database, r.cfg.WindowsTable), predicates.String()), args...)
+		if err != nil {
+			return nil, fmt.Errorf("query usage window details: %w", err)
 		}
-		window.Data = json.RawMessage(data)
-		windows = append(windows, window)
+
+		for rows.Next() {
+			window := &metering.Window{}
+			var data string
+			var version uint64
+			if err := rows.Scan(
+				&window.Sequence, &window.WindowID, &window.Producer, &window.RegionID, &window.WindowType,
+				&window.SubjectType, &window.SubjectID,
+				&window.TeamID, &window.UserID,
+				&window.SandboxID, &window.VolumeID, &window.SnapshotID,
+				&window.TemplateID, &window.ClusterID,
+				&window.WindowStart, &window.WindowEnd,
+				&window.Value, &window.Unit, &window.RecordedAt, &data, &version,
+			); err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("scan usage window detail: %w", err)
+			}
+			identity := windowLookupIdentity{
+				RegionID: window.RegionID,
+				Producer: window.Producer,
+				WindowID: window.WindowID,
+			}
+			expectedVersion, ok := expectedVersions[identity]
+			if !ok || version != expectedVersion {
+				continue
+			}
+			if _, ok := details[identity]; ok {
+				continue
+			}
+			window.Data = json.RawMessage(data)
+			details[identity] = window
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("iterate usage window details: %w", err)
+		}
+		if err := rows.Close(); err != nil {
+			return nil, fmt.Errorf("close usage window details: %w", err)
+		}
 	}
-	if err := rows.Err(); err != nil {
-		return nil, "", fmt.Errorf("iterate usage windows: %w", err)
-	}
-	next, err := nextWindowCursor(windows)
-	if err != nil {
-		return nil, "", err
-	}
-	return windows, next, nil
+	return details, nil
 }
 
 func windowWhere(teamID string, windowType string, cursor *pageCursor) (string, []any) {

--- a/pkg/metering/clickhouse/repository_test.go
+++ b/pkg/metering/clickhouse/repository_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -36,6 +39,7 @@ type captureConn struct {
 	queries     []string
 	argsHistory [][]driver.NamedValue
 	failExec    int
+	queryRows   []*captureRows
 }
 
 func (c *captureConn) Prepare(string) (driver.Stmt, error) {
@@ -59,6 +63,52 @@ func (c *captureConn) ExecContext(_ context.Context, query string, args []driver
 		return nil, errors.New("injected ClickHouse failure")
 	}
 	return driver.RowsAffected(1), nil
+}
+
+func (c *captureConn) QueryContext(_ context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	c.query = query
+	c.args = append([]driver.NamedValue(nil), args...)
+	c.queries = append(c.queries, query)
+	c.argsHistory = append(c.argsHistory, append([]driver.NamedValue(nil), args...))
+	if len(c.queryRows) == 0 {
+		return nil, errors.New("no captured query rows configured")
+	}
+	rows := c.queryRows[0]
+	c.queryRows = c.queryRows[1:]
+	return rows, nil
+}
+
+type captureRows struct {
+	columns []string
+	values  [][]driver.Value
+	index   int
+	err     error
+}
+
+func (r *captureRows) Columns() []string {
+	return r.columns
+}
+
+func (r *captureRows) Close() error {
+	return nil
+}
+
+func (r *captureRows) Next(dest []driver.Value) error {
+	if r.index >= len(r.values) {
+		return r.errOrEOF()
+	}
+	copy(dest, r.values[r.index])
+	r.index++
+	return nil
+}
+
+func (r *captureRows) errOrEOF() error {
+	if r.err != nil {
+		err := r.err
+		r.err = nil
+		return err
+	}
+	return io.EOF
 }
 
 func newCaptureRepository(t *testing.T) (*Repository, *captureConn) {
@@ -441,6 +491,232 @@ func TestWatermarkAndProjectionStatePreserveNanosecondTimestamps(t *testing.T) {
 	}
 }
 
+func TestListTeamWindowsUsesNarrowFinalKeysAndRawSelectedVersions(t *testing.T) {
+	repo, conn := newCaptureRepository(t)
+	firstRecordedAt := time.Date(2026, 7, 30, 21, 17, 23, 123, time.UTC)
+	secondRecordedAt := firstRecordedAt.Add(time.Nanosecond)
+	first := testUsageWindow(
+		"window-1",
+		"producer-1",
+		"region-1",
+		"team-1",
+		firstRecordedAt,
+	)
+	second := testUsageWindow(
+		"window-2",
+		"producer-2",
+		"region-1",
+		"team-1",
+		secondRecordedAt,
+	)
+	concurrentReplacement := testUsageWindow(
+		first.WindowID,
+		first.Producer,
+		first.RegionID,
+		"another-team",
+		firstRecordedAt.Add(time.Minute),
+	)
+	conn.queryRows = []*captureRows{
+		{
+			columns: []string{"recorded_at", "region_id", "producer", "window_id", "version"},
+			values: [][]driver.Value{
+				{firstRecordedAt, first.RegionID, first.Producer, first.WindowID, int64(11)},
+				{secondRecordedAt, second.RegionID, second.Producer, second.WindowID, int64(22)},
+			},
+		},
+		{
+			columns: windowDetailColumns(),
+			values: [][]driver.Value{
+				windowDetailValues(concurrentReplacement, 12),
+				windowDetailValues(first, 11),
+				windowDetailValues(first, 10),
+				windowDetailValues(second, 22),
+			},
+		},
+	}
+
+	windows, next, err := repo.ListTeamWindows(
+		context.Background(),
+		" team-1 ",
+		metering.WindowTypeSandboxEgressBytes,
+		"",
+		2,
+	)
+	if err != nil {
+		t.Fatalf("ListTeamWindows() error = %v", err)
+	}
+	if len(windows) != 2 ||
+		windows[0].WindowID != first.WindowID ||
+		windows[1].WindowID != second.WindowID {
+		t.Fatalf("ListTeamWindows() windows = %#v", windows)
+	}
+	decoded, err := decodeCursor(next)
+	if err != nil {
+		t.Fatalf("decode next cursor: %v", err)
+	}
+	if decoded == nil ||
+		!decoded.RecordedAt.Equal(secondRecordedAt) ||
+		decoded.Producer != second.Producer ||
+		decoded.ID != second.WindowID {
+		t.Fatalf("next cursor = %#v", decoded)
+	}
+	if len(conn.queries) != 2 {
+		t.Fatalf("window query count = %d, want 2", len(conn.queries))
+	}
+	if !strings.Contains(conn.queries[0], "FROM `sandbox0_metering`.`usage_windows` FINAL") ||
+		strings.Contains(conn.queries[0], "sequence, window_id") ||
+		!strings.Contains(conn.queries[0], "recorded_at, region_id, producer, window_id, version") {
+		t.Fatalf("key query is not a narrow FINAL lookup: %s", conn.queries[0])
+	}
+	if strings.Contains(conn.queries[1], " FINAL") ||
+		!strings.Contains(conn.queries[1], "data, version") ||
+		strings.Count(conn.queries[1], "(?, ?, ?)") != 2 {
+		t.Fatalf("detail query is not a bounded raw-version lookup: %s", conn.queries[1])
+	}
+	if got := len(conn.argsHistory[0]); got != 3 {
+		t.Fatalf("key query argument count = %d, want 3", got)
+	}
+	if got := len(conn.argsHistory[1]); got != 6 {
+		t.Fatalf("detail query argument count = %d, want 6", got)
+	}
+}
+
+func TestLoadWindowDetailsUsesBoundedBatches(t *testing.T) {
+	repo, conn := newCaptureRepository(t)
+	keys := make([]windowLookupKey, 0, maxWindowDetailBatchSize+1)
+	firstBatch := make([][]driver.Value, 0, maxWindowDetailBatchSize)
+	for index := 0; index <= maxWindowDetailBatchSize; index++ {
+		recordedAt := time.Date(2026, 7, 30, 22, 0, 0, index, time.UTC)
+		window := testUsageWindow(
+			fmt.Sprintf("window-%03d", index),
+			"producer",
+			"region",
+			"team",
+			recordedAt,
+		)
+		version := uint64(index + 1)
+		keys = append(keys, windowLookupKey{
+			RecordedAt: recordedAt,
+			RegionID:   window.RegionID,
+			Producer:   window.Producer,
+			WindowID:   window.WindowID,
+			Version:    version,
+		})
+		values := windowDetailValues(window, version)
+		if index < maxWindowDetailBatchSize {
+			firstBatch = append(firstBatch, values)
+			continue
+		}
+		conn.queryRows = []*captureRows{
+			{
+				columns: windowDetailColumns(),
+				values:  firstBatch,
+			},
+			{
+				columns: windowDetailColumns(),
+				values:  [][]driver.Value{values},
+			},
+		}
+	}
+
+	details, err := repo.loadWindowDetails(context.Background(), keys)
+	if err != nil {
+		t.Fatalf("loadWindowDetails() error = %v", err)
+	}
+	if len(details) != len(keys) {
+		t.Fatalf("loaded detail count = %d, want %d", len(details), len(keys))
+	}
+	if len(conn.queries) != 2 {
+		t.Fatalf("detail query count = %d, want 2", len(conn.queries))
+	}
+	if got := strings.Count(conn.queries[0], "(?, ?, ?)"); got != maxWindowDetailBatchSize {
+		t.Fatalf("first detail batch size = %d, want %d", got, maxWindowDetailBatchSize)
+	}
+	if got := strings.Count(conn.queries[1], "(?, ?, ?)"); got != 1 {
+		t.Fatalf("second detail batch size = %d, want 1", got)
+	}
+}
+
+func TestListWindowsRejectsMissingSelectedVersion(t *testing.T) {
+	repo, conn := newCaptureRepository(t)
+	recordedAt := time.Date(2026, 7, 30, 22, 0, 0, 0, time.UTC)
+	window := testUsageWindow("window", "producer", "region", "team", recordedAt)
+	conn.queryRows = []*captureRows{
+		{
+			columns: []string{"recorded_at", "region_id", "producer", "window_id", "version"},
+			values: [][]driver.Value{{
+				recordedAt,
+				window.RegionID,
+				window.Producer,
+				window.WindowID,
+				int64(7),
+			}},
+		},
+		{
+			columns: windowDetailColumns(),
+			values:  [][]driver.Value{windowDetailValues(window, 8)},
+		},
+	}
+
+	if _, _, err := repo.ListWindows(context.Background(), "", 1); err == nil ||
+		!strings.Contains(err.Error(), "disappeared while loading its selected version") {
+		t.Fatalf("ListWindows() error = %v, want missing selected version", err)
+	}
+}
+
+func testUsageWindow(
+	windowID string,
+	producer string,
+	regionID string,
+	teamID string,
+	recordedAt time.Time,
+) *metering.Window {
+	return &metering.Window{
+		Sequence:    10,
+		WindowID:    windowID,
+		Producer:    producer,
+		RegionID:    regionID,
+		WindowType:  metering.WindowTypeSandboxEgressBytes,
+		SubjectType: metering.SubjectTypeSandbox,
+		SubjectID:   "sandbox-1",
+		TeamID:      teamID,
+		UserID:      "user-1",
+		SandboxID:   "sandbox-1",
+		TemplateID:  "template-1",
+		ClusterID:   "cluster-1",
+		WindowStart: recordedAt.Add(-time.Minute),
+		WindowEnd:   recordedAt,
+		Value:       42,
+		Unit:        metering.WindowUnitBytes,
+		RecordedAt:  recordedAt,
+		Data:        json.RawMessage(`{"source":"test"}`),
+	}
+}
+
+func windowDetailColumns() []string {
+	return []string{
+		"sequence", "window_id", "producer", "region_id", "window_type",
+		"subject_type", "subject_id",
+		"team_id", "user_id",
+		"sandbox_id", "volume_id", "snapshot_id",
+		"template_id", "cluster_id",
+		"window_start", "window_end",
+		"value", "unit", "recorded_at", "data", "version",
+	}
+}
+
+func windowDetailValues(window *metering.Window, version uint64) []driver.Value {
+	return []driver.Value{
+		window.Sequence, window.WindowID, window.Producer, window.RegionID, window.WindowType,
+		window.SubjectType, window.SubjectID,
+		window.TeamID, window.UserID,
+		window.SandboxID, window.VolumeID, window.SnapshotID,
+		window.TemplateID, window.ClusterID,
+		window.WindowStart, window.WindowEnd,
+		window.Value, window.Unit, window.RecordedAt, string(window.Data), int64(version),
+	}
+}
+
 func TestCursorAndSchemaKeepNanosecondAndSequenceContracts(t *testing.T) {
 	recordedAt := time.Date(2026, 7, 17, 1, 2, 3, 123456789, time.UTC)
 	where, args := cursorWhere(&pageCursor{RecordedAt: recordedAt, Producer: "producer-1", ID: "event-1"}, "event_id")
@@ -458,6 +734,12 @@ func TestCursorAndSchemaKeepNanosecondAndSequenceContracts(t *testing.T) {
 	statements := strings.Join(schemaStatements(cfg), "\n")
 	if strings.Count(statements, "ADD COLUMN IF NOT EXISTS sequence Int64") != 2 {
 		t.Fatalf("schema does not upgrade both export tables with sequence columns: %s", statements)
+	}
+	if !strings.Contains(
+		statements,
+		"ADD INDEX IF NOT EXISTS usage_windows_recorded_at_minmax recorded_at TYPE minmax",
+	) {
+		t.Fatalf("schema does not add the recorded_at window skip index: %s", statements)
 	}
 	if query := watermarkStatusQuery("metering.watermarks"); !strings.Contains(query, "MAX(complete_before)") || strings.Contains(query, "MIN(complete_before)") {
 		t.Fatalf("watermark status query does not use the global delivered frontier: %s", query)

--- a/pkg/metering/clickhouse/schema.go
+++ b/pkg/metering/clickhouse/schema.go
@@ -81,6 +81,10 @@ ORDER BY (region_id, producer, window_id)
 `, windows),
 		fmt.Sprintf("ALTER TABLE %s ADD COLUMN IF NOT EXISTS sequence Int64 DEFAULT 0", events),
 		fmt.Sprintf("ALTER TABLE %s ADD COLUMN IF NOT EXISTS sequence Int64 DEFAULT 0", windows),
+		fmt.Sprintf(
+			"ALTER TABLE %s ADD INDEX IF NOT EXISTS usage_windows_recorded_at_minmax recorded_at TYPE minmax GRANULARITY 1",
+			windows,
+		),
 		fmt.Sprintf(`
 CREATE TABLE IF NOT EXISTS %s (
     producer String,


### PR DESCRIPTION
## What changed

- Split ClickHouse window export into a narrow `FINAL` key/version query and bounded raw detail queries.
- Reconstruct the page in cursor order using exactly the versions selected by the first query.
- Validate selected-version presence and team/type scope before advancing the cursor.
- Bound detail batches to 200 keys and add a durable `recorded_at` minmax index definition.

## Root cause

`usage_windows` is ordered by `(region_id, producer, window_id)`, while export pagination orders by `(recorded_at, producer, window_id)`. Selecting every wide column under `FINAL` forced ClickHouse to read and resolve millions of rows and repeatedly crossed the 512 MiB per-query memory limit.

## Impact

The export keeps ReplacingMergeTree version semantics without holding the wide row set under `FINAL`. On the production-sized table, a 200-key detail lookup dropped from roughly 511 MiB peak memory to 32.95 MiB. This unblocks the regional metering export consumed by the cloud billing worker without raising ClickHouse memory limits.

## Validation

- `go test ./pkg/metering/... ./pkg/gateway/http/handlers/...`
- `go vet ./pkg/metering/... ./pkg/gateway/http/handlers/...`
- targeted race tests for ClickHouse metering and gateway handlers
- tests for narrow key selection, selected-version consistency, missing-version failure, and 200-key batching
- live ClickHouse probes at the existing 512 MiB limit
