### PR TITLE
Fix credential bindings across sandbox resume

### DIFF
--- a/manager/pkg/service/sandbox_service_network.go
+++ b/manager/pkg/service/sandbox_service_network.go
@@ -266,7 +266,14 @@ func (s *SandboxService) loadCredentialBindings(ctx context.Context, pod *corev1
 	if sandboxID == "" {
 		sandboxID = pod.Name
 	}
-	record, err := s.credentialStore.GetBindings(ctx, sandboxTeamID(pod), sandboxID)
+	return s.loadCredentialBindingsForSandbox(ctx, sandboxTeamID(pod), sandboxID)
+}
+
+func (s *SandboxService) loadCredentialBindingsForSandbox(ctx context.Context, teamID, sandboxID string) ([]v1alpha1.CredentialBinding, error) {
+	if s.credentialStore == nil {
+		return nil, nil
+	}
+	record, err := s.credentialStore.GetBindings(ctx, teamID, sandboxID)
 	if err != nil {
 		return nil, err
 	}

--- a/manager/pkg/service/sandbox_service_network_test.go
+++ b/manager/pkg/service/sandbox_service_network_test.go
@@ -545,6 +545,49 @@ func TestTemplateCredentialBindingsUsesNestedNetworkBindings(t *testing.T) {
 	assert.Equal(t, "nested-ref", bindings[0].Ref)
 }
 
+func TestRestoreResumeCredentialBindingsAddsPersistedBindingsToClaim(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryBindingStore()
+	require.NoError(t, store.UpsertBindings(ctx, &egressauth.BindingRecord{
+		SandboxID: "sandbox-a",
+		TeamID:    "team-a",
+		Bindings: []egressauth.CredentialBinding{{
+			Ref:           "data-api",
+			SourceRef:     "data-api",
+			SourceID:      1,
+			SourceVersion: 1,
+			Projection: egressauth.ProjectionSpec{
+				Type: egressauth.CredentialProjectionTypeHTTPHeaders,
+				HTTPHeaders: &egressauth.HTTPHeadersProjection{
+					Headers: []egressauth.ProjectedHeader{{
+						Name:          "Authorization",
+						ValueTemplate: "Basic {{ .value }}",
+					}},
+				},
+			},
+		}},
+	}))
+	persistedPolicy := sanitizedNetworkPolicyForPersistence(
+		testNetworkPolicy("data-api", "Basic {{ .value }}"),
+	)
+	req := &ClaimRequest{
+		TeamID:    "team-a",
+		SandboxID: "sandbox-a",
+		Config:    &SandboxConfig{Network: persistedPolicy},
+	}
+	svc := &SandboxService{credentialStore: store}
+
+	require.NoError(t, svc.restoreResumeCredentialBindings(ctx, req))
+	require.True(t, req.mayHaveExistingCredentialBindings)
+	require.NotNil(t, req.Config)
+	require.NotNil(t, req.Config.Network)
+	require.Len(t, req.Config.Network.CredentialBindings, 1)
+	assert.Equal(t, "data-api", req.Config.Network.CredentialBindings[0].Ref)
+	require.Len(t, req.Config.Network.Egress.CredentialRules, 1)
+	assert.Equal(t, "data-api", req.Config.Network.Egress.CredentialRules[0].CredentialRef)
+	assert.Empty(t, persistedPolicy.CredentialBindings)
+}
+
 func TestSyncCredentialBindingsSkipsLookupForFreshSandbox(t *testing.T) {
 	store := newMemoryBindingStore()
 	svc := &SandboxService{credentialStore: store}

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -203,6 +203,10 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 		if record == nil || !restoreNeeded {
 			return s.GetSandbox(ctx, sandboxID)
 		}
+		if err := s.restoreResumeCredentialBindings(ctx, req); err != nil {
+			_ = s.abortLifecycleTxn(context.Background(), sandboxID, txn.ID, err.Error())
+			return nil, fmt.Errorf("restore credential bindings: %w", err)
+		}
 		var err error
 		pod, err = s.claimIdlePod(ctx, template, req)
 		if err != nil {
@@ -249,6 +253,32 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 	}
 	s.enqueueHotClaimReservation(restoredPod)
 	return s.GetSandbox(ctx, sandboxID)
+}
+
+// restoreResumeCredentialBindings rejoins bindings stored outside the sanitized
+// sandbox config before a paused sandbox claims its replacement runtime pod.
+func (s *SandboxService) restoreResumeCredentialBindings(ctx context.Context, req *ClaimRequest) error {
+	if req == nil {
+		return nil
+	}
+	req.mayHaveExistingCredentialBindings = true
+	bindings, err := s.loadCredentialBindingsForSandbox(ctx, req.TeamID, req.SandboxID)
+	if err != nil {
+		return err
+	}
+	if len(bindings) == 0 {
+		return nil
+	}
+	config := cloneSandboxConfig(req.Config)
+	if config == nil {
+		config = &SandboxConfig{}
+	}
+	if config.Network == nil {
+		config.Network = &v1alpha1.SandboxNetworkPolicy{}
+	}
+	config.Network.CredentialBindings = bindings
+	req.Config = config
+	return nil
 }
 
 func (s *SandboxService) recordResumeLifecycleRuntime(ctx context.Context, sandboxID string, txn *SandboxLifecycleTxn, pod *corev1.Pod) error {


### PR DESCRIPTION
## Summary

- reload persisted sandbox credential bindings before claiming a replacement runtime during resume
- merge the bindings into the cloned claim config without changing the sanitized durable config
- preserve the existing binding set while the resumed pod network policy is compiled

## Root cause

Paused sandboxes persist credential rules in `manager.sandboxes.config`, while credential bindings live in the separate binding store. The resume path rebuilt a runtime from the sanitized config without joining those bindings back in. Policy compilation dropped the dangling credential rules, and binding synchronization could then delete the previous bindings.

## Tests

- `go test ./manager/pkg/service -count=1`