### PR TITLE
Allow federated admission state projection

### DIFF
--- a/pkg/gateway/admission/repository_integration_test.go
+++ b/pkg/gateway/admission/repository_integration_test.go
@@ -57,7 +57,22 @@ func TestRepositoryPostgresIntegration(t *testing.T) {
 		t.Fatalf("migrate up: %v", err)
 	}
 	if err := migrate.Down(ctx, pool, ".", migrationOptions...); err != nil {
-		t.Fatalf("migrate down: %v", err)
+		t.Fatalf("migrate admission decoupling down: %v", err)
+	}
+	var admissionForeignKey *string
+	if err := adminPool.QueryRow(ctx, `
+		SELECT conname
+		FROM pg_constraint
+		WHERE conrelid = to_regclass($1)
+		  AND conname = 'team_admission_states_team_id_fkey'
+	`, schema+".team_admission_states").Scan(&admissionForeignKey); err != nil {
+		t.Fatalf("look up restored admission foreign key: %v", err)
+	}
+	if admissionForeignKey == nil || *admissionForeignKey != "team_admission_states_team_id_fkey" {
+		t.Fatalf("restored admission foreign key = %v", admissionForeignKey)
+	}
+	if err := migrate.Down(ctx, pool, ".", migrationOptions...); err != nil {
+		t.Fatalf("migrate admission table down: %v", err)
 	}
 	var admissionTable *string
 	if err := adminPool.QueryRow(ctx, "SELECT to_regclass($1)::text", schema+".team_admission_states").Scan(&admissionTable); err != nil {
@@ -71,7 +86,7 @@ func TestRepositoryPostgresIntegration(t *testing.T) {
 	}
 
 	repository := NewRepository(pool)
-	teamID := createAdmissionTestTeam(t, ctx, pool, "monotonic")
+	teamID := uuid.NewString()
 	if _, found, err := repository.Get(ctx, teamID); err != nil || found {
 		t.Fatalf("default Get() found = %v, error = %v", found, err)
 	}
@@ -107,7 +122,7 @@ func TestRepositoryPostgresIntegration(t *testing.T) {
 		t.Fatalf("final admission = %#v", record)
 	}
 
-	conflictTeamID := createAdmissionTestTeam(t, ctx, pool, "conflict")
+	conflictTeamID := uuid.NewString()
 	conflictUpdates := []Update{
 		{Version: 1, State: StateAllowed, Source: "integration", Reason: "a"},
 		{Version: 1, State: StateRestricted, Source: "integration", Reason: "b"},
@@ -139,7 +154,7 @@ func TestRepositoryPostgresIntegration(t *testing.T) {
 		t.Fatalf("conflicting results: successes = %d, conflicts = %d", successes, conflicts)
 	}
 
-	replayTeamID := createAdmissionTestTeam(t, ctx, pool, "replay")
+	replayTeamID := uuid.NewString()
 	replay := Update{Version: 1, State: StateRestricted, Source: "integration", Reason: "same"}
 	replayApplied := make(chan bool, 2)
 	replayErrors := make(chan error, 2)
@@ -170,10 +185,18 @@ func TestRepositoryPostgresIntegration(t *testing.T) {
 		t.Fatalf("replayed Put() applied count = %d, want 1", appliedCount)
 	}
 
-	if _, err := pool.Exec(ctx, "DELETE FROM teams WHERE id = $1", replayTeamID); err != nil {
+	localTeamID := createAdmissionTestTeam(t, ctx, pool, "cleanup")
+	if _, err := repository.Put(ctx, localTeamID, Update{
+		Version: 1,
+		State:   StateAllowed,
+		Source:  "integration",
+	}); err != nil {
+		t.Fatalf("Put() local team admission state: %v", err)
+	}
+	if _, err := pool.Exec(ctx, "DELETE FROM teams WHERE id = $1", localTeamID); err != nil {
 		t.Fatalf("delete team: %v", err)
 	}
-	if _, found, err := repository.Get(ctx, replayTeamID); err != nil || found {
+	if _, found, err := repository.Get(ctx, localTeamID); err != nil || found {
 		t.Fatalf("Get() after team delete found = %v, error = %v", found, err)
 	}
 }

--- a/pkg/gateway/migrations/00016_decouple_team_admission_state.sql
+++ b/pkg/gateway/migrations/00016_decouple_team_admission_state.sql
@@ -1,0 +1,37 @@
+-- +goose Up
+-- Regional gateways receive team IDs from the global identity directory, so
+-- admission projection must not require a duplicate local team row.
+ALTER TABLE team_admission_states
+DROP CONSTRAINT IF EXISTS team_admission_states_team_id_fkey;
+
+COMMENT ON COLUMN team_admission_states.team_id IS
+    'Team identifier owned by the authoritative identity directory; it may not exist in this regional teams table.';
+
+-- +goose StatementBegin
+CREATE FUNCTION delete_local_team_admission_state()
+RETURNS TRIGGER AS $$
+BEGIN
+    DELETE FROM team_admission_states WHERE team_id = OLD.id;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER delete_local_team_admission_state
+AFTER DELETE ON teams
+FOR EACH ROW EXECUTE FUNCTION delete_local_team_admission_state();
+
+-- +goose Down
+DROP TRIGGER IF EXISTS delete_local_team_admission_state ON teams;
+DROP FUNCTION IF EXISTS delete_local_team_admission_state();
+
+COMMENT ON COLUMN team_admission_states.team_id IS NULL;
+
+ALTER TABLE team_admission_states
+DROP CONSTRAINT IF EXISTS team_admission_states_team_id_fkey;
+
+-- Keep pre-existing federated projection rows during rollback. The unvalidated
+-- constraint still restores the old behavior for subsequent writes.
+ALTER TABLE team_admission_states
+ADD CONSTRAINT team_admission_states_team_id_fkey
+FOREIGN KEY (team_id) REFERENCES teams(id) ON DELETE CASCADE NOT VALID;

--- a/pkg/gateway/teamresources/inventory_test.go
+++ b/pkg/gateway/teamresources/inventory_test.go
@@ -91,7 +91,7 @@ func TestDiscoveryHelpers(t *testing.T) {
 		t.Fatal("team_members should be ignored because team deletion cascades membership")
 	}
 	if !isIgnoredDiscoveredTable("shared_gateway", "team_admission_states") {
-		t.Fatal("team_admission_states should be ignored because team deletion cascades admission state")
+		t.Fatal("team_admission_states should be ignored because team deletion triggers admission state cleanup")
 	}
 	if isIgnoredDiscoveredTable("manager", "sandboxes") {
 		t.Fatal("sandboxes should not be ignored")


### PR DESCRIPTION
## What changed

- remove the regional `team_admission_states.team_id` foreign key to the local `teams` table
- retain self-hosted cleanup semantics with a local-team deletion trigger
- cover migration rollback, globally owned team IDs, monotonic projection, replay, conflicts, and local-team cleanup

## Root cause

Hosted regional gateways validate identities owned by the global gateway and do not replicate every team into the regional `teams` table. The admission projection table nevertheless required a local team row, so every cloud delivery failed with `team_admission_states_team_id_fkey`.

## Impact

Billing admission state can now be projected to a team's home region without duplicating global identity state. Existing shadow-mode outbox rows will drain on retry after this migration is deployed. Local self-hosted team deletion still removes its admission state.

## Validation

- PostgreSQL migration up/down integration test
- admission repository concurrency, replay, conflict, federated-ID, and cleanup integration test
- all 200 non-e2e Go packages in `sandbox0`

Deployment order: deploy this regional migration before enabling the stricter billing-worker readiness change.
