### PR TITLE
docs: make reference pages easier to scan

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -42,6 +42,10 @@
           "title": "Overview"
         },
         {
+          "slug": "observability",
+          "title": "Observability"
+        },
+        {
           "slug": "pause-resume",
           "title": "Pause And Resume"
         },
@@ -242,6 +246,10 @@
         {
           "slug": "configuration",
           "title": "Configuration"
+        },
+        {
+          "slug": "observability",
+          "title": "Observability"
         },
         {
           "slug": "quotas",

--- a/docs/sandbox/observability/page.mdx
+++ b/docs/sandbox/observability/page.mdx
@@ -1,0 +1,233 @@
+# Observability
+
+Sandbox0 provides runtime metrics, historical logs, and a signed audit ledger for each sandbox. These APIs read historical data without waking a paused sandbox.
+
+| Data | Endpoint | Use it for |
+|------|----------|------------|
+| Runtime metrics | <code>GET /api/v1/sandboxes/{'{id}'}/metrics</code> | Chart-ready CPU, memory, network, process, and writable-rootfs series |
+| Metric catalog | <code>GET /api/v1/sandboxes/{'{id}'}/metrics/catalog</code> | Discover supported metric names, kinds, units, and dimensions |
+| Historical logs | <code>GET /api/v1/sandboxes/{'{id}'}/observability/logs</code> | Query or watch retained stdout, stderr, and PTY output |
+| Audit events | <code>GET /api/v1/sandboxes/{'{id}'}/observability/events</code> | Query or watch canonical signed audit facts |
+
+<Callout variant="info">
+Audit ingestion and the audit event API require the enterprise `sandbox_audit` feature and the `sandboxaudit:read` permission. Historical logs, runtime metrics, and the metric catalog do not require that enterprise feature.
+</Callout>
+
+Per-sandbox historical data is separate from [platform telemetry](/docs/sandbox/self-hosted/observability#platform-telemetry) and the metering usage ledger.
+
+## Runtime Metrics
+
+<Endpoint method="GET">
+/api/v1/sandboxes/{'{id}'}/metrics
+</Endpoint>
+
+The metrics endpoint returns bounded, server-downsampled series ready for charts. The default query covers the last hour and requests CPU utilization, memory utilization, and network I/O. A query cannot span more than 30 days.
+
+### Query Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `start_time` | RFC3339 timestamp | Start of the window; defaults to one hour before `end_time` |
+| `end_time` | RFC3339 timestamp | End of the window; defaults to the current time |
+| `metrics` | comma-separated string | Canonical metric names from the catalog |
+| `step_seconds` | integer | Requested bucket width; the server uses at least 15 seconds and may increase it to honor `max_points` |
+| `statistic` | string | `auto`, `average`, `minimum`, `maximum`, `last`, or `rate`; `auto` averages gauges and rates counters |
+| `max_points` | integer | Maximum points per series (default: 240, max: 1000) |
+
+### Metric Catalog
+
+<Endpoint method="GET">
+/api/v1/sandboxes/{'{id}'}/metrics/catalog
+</Endpoint>
+
+| Metric | Kind | Unit | Meaning |
+|--------|------|------|---------|
+| `sandbox.cpu.utilization` | gauge | ratio | CPU usage divided by the configured CPU limit |
+| `sandbox.cpu.usage` | gauge | cores | CPU cores currently used |
+| `sandbox.cpu.time` | counter | seconds | Cumulative CPU time; `auto` returns its rate in cores |
+| `sandbox.cpu.limit` | gauge | cores | Configured CPU limit |
+| `sandbox.memory.usage` | gauge | bytes | Cgroup memory usage |
+| `sandbox.memory.working_set` | gauge | bytes | Memory working set |
+| `sandbox.memory.available` | gauge | bytes | Memory available within the sandbox limit |
+| `sandbox.memory.limit` | gauge | bytes | Configured memory limit |
+| `sandbox.memory.utilization` | gauge | ratio | Working set divided by the configured memory limit |
+| `sandbox.network.io` | counter | bytes | Receive or transmit bytes, selected by the `direction` dimension; `auto` returns bytes per second |
+| `sandbox.network.errors` | counter | count | Receive or transmit errors, selected by the `direction` dimension; `auto` returns errors per second |
+| `sandbox.process.count` | gauge | count | Current sandbox process count |
+| `sandbox.rootfs.writable.usage` | gauge | bytes | Main runtime container writable-layer usage when the CRI reports it |
+| `sandbox.rootfs.writable.inodes` | gauge | count | Main runtime container writable-layer inodes when the CRI reports them |
+
+Each series contains zero or more continuous `segments`:
+
+- runtime resets and collection gaps start a new segment; clients must not connect lines across segments
+- typed `gaps` explain missing intervals
+- the response reports freshness, the effective `step_seconds`, and whether the result is `partial`
+- missing or unsupported observations are omitted and never synthesized as zero
+
+```typescript
+import { Client, SandboxRuntimeMetricName } from "sandbox0";
+
+const client = new Client({ token: process.env.SANDBOX0_TOKEN! });
+const metrics = await client.sandbox("sb_abc123").getMetrics({
+    startTime: new Date(Date.now() - 60 * 60 * 1000),
+    metrics: [
+        SandboxRuntimeMetricName.SandboxCpuUtilization,
+        SandboxRuntimeMetricName.SandboxMemoryWorkingSet,
+        SandboxRuntimeMetricName.SandboxNetworkIo,
+    ],
+    maxPoints: 120,
+});
+```
+
+## Historical Logs
+
+<Endpoint method="GET">
+/api/v1/sandboxes/{'{id}'}/observability/logs
+</Endpoint>
+
+Use this endpoint for retained logs. It is separate from the live output streams exposed by process and session APIs.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `start_time` | RFC3339 timestamp | Include entries that occurred at or after this time |
+| `end_time` | RFC3339 timestamp | Include entries that occurred at or before this time |
+| `limit` | integer | Maximum entries to return (default: 100, max: 1000) |
+| `cursor` | string | Opaque cursor from a previous response; in watch mode, use a `watermark` cursor |
+| `watch` | boolean | Stream matching records as NDJSON until the client disconnects |
+| `context_id` | string | Restrict results to one process context |
+| `stream` | string | `stdout`, `stderr`, or `pty` |
+
+## Audit Events
+
+<Endpoint method="GET">
+/api/v1/sandboxes/{'{id}'}/observability/events
+</Endpoint>
+
+The audit endpoint reads canonical signed facts from ClickHouse. It returns `403 feature_not_licensed` when audit is not enabled or the cluster-gateway license does not contain `sandbox_audit`.
+
+### Query Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `start_time` | RFC3339 timestamp | Include events that occurred at or after this time |
+| `end_time` | RFC3339 timestamp | Include events that occurred at or before this time |
+| `limit` | integer | Maximum events to return (default: 100, max: 1000); exact `event_id` lookup ignores it and returns at most two payload variants |
+| `cursor` | string | Opaque cursor from a previous response; in watch mode, use a `watermark` cursor |
+| `watch` | boolean | Stream matching records as NDJSON until the client disconnects |
+| `source` | string | Trusted producer, such as `cluster_gateway` or `netd`; `netd` identifies ctld network-runtime events |
+| `event_type` | string | Category such as `api_access` or `network_audit` |
+| `outcome` | string | `completed`, `denied`, `error`, `succeeded`, `failed`, `accepted`, or `unknown` |
+| `actor_kind` | string | Trusted actor kind, such as `human`, `api_key`, `service`, or `sandbox_workload` |
+| `actor_id` | string | Trusted user, API key, service, or workload identifier |
+| `action` | string | Stable action such as `sandbox.pause`, `process.exec`, `file.write`, or `network.connect` |
+| `resource_type` | string | Resource category such as `sandbox` or `sandbox_network` |
+| `operation_id` | string | Correlates the attempt and result of one operation |
+| `event_id` | UUID | Exact lookup for one stable audit ID; cannot be combined with time, cursor, watch, or other event filters |
+
+### Event Model And Integrity
+
+| Field | Meaning |
+|-------|---------|
+| `event_id` | Stable UUID for the audit fact |
+| `phase` | `attempt`, `result`, or `effect` |
+| `actor`, `action`, `resource` | Who acted, what they did, and the affected resource |
+| `producer` | Trusted service and producer sequence |
+| `operation_id` | Correlation ID shared by facts from the same operation |
+| `request` | Bounded request metadata |
+| `integrity.payload_hash` | Canonical SHA-256 payload digest |
+| `integrity.signature` | Ed25519 signature |
+| `integrity.signing_key_id` | Signing key identifier |
+| `integrity.signature_status` | Query-time result: `verified`, `invalid`, or `unavailable` |
+
+List and watch responses recompute each returned row's digest and verify its signature. An exact `event_id` lookup also detects reused IDs:
+
+- one canonical payload returns one row
+- conflicting payload hashes return at most two variants and set `event_id_conflict=true`
+- `event_id_conflict` does not replace `signature_status`, so callers can distinguish an ID collision from a signature failure
+
+Pagination cursors and watch watermarks are response metadata. They are not repeated inside each signed event.
+
+### Audit Delivery
+
+Gateway operations produce an `attempt` before authorization or execution and a `result` after the downstream response or a failed admission decision.
+
+| Operation | `durable_async` | `canonical_sync` |
+|-----------|-----------------|------------------|
+| Non-mutating Sandbox API and public exposure | May proceed after local durable enqueue; ClickHouse visibility follows asynchronously | Waits for ClickHouse to acknowledge the attempt before proceeding |
+| New allowed network flow | Opens after the ctld node-local spool fsyncs the attempt | Waits for ClickHouse acknowledgement before opening, including server-first SSH probes |
+| State-changing Sandbox API | Always waits for ClickHouse acknowledgement before execution and before returning the signed result | Same strict behavior |
+
+The default `durable_async` path normally becomes query-visible after immediate delivery wakeups and the one-second flush/replay cycle. It is not a read-after-write guarantee.
+
+Failure behavior is fail-closed at the applicable admission boundary:
+
+| Failure | Caller-visible behavior |
+|---------|-------------------------|
+| Local buffer cannot accept an event | Sandbox0 tries synchronous canonical delivery; the operation is denied if that also fails |
+| Canonical admission fails for a mutation | The downstream operation is not executed; the caller receives `503` |
+| A mutation executes but its result is only buffered for retry | The caller receives `503`, not a success response |
+| A downstream `5xx` or panic has an uncertain execution result | The audit result uses `outcome=unknown` |
+| ClickHouse is unavailable in `durable_async` | Eligible traffic can continue while the durable buffer remains writable, but audit queries lag until replay succeeds |
+| ClickHouse is unavailable in `canonical_sync` | New audited operations and flows fail closed |
+
+A failed canonical mutation admission records a correlated result when result custody succeeds:
+
+| Field | Value |
+|-------|-------|
+| `outcome` | `failed` |
+| HTTP status | `503` |
+| `execution_started` | `false` |
+| `operation_executed` | `false` |
+| `failure_stage` | `canonical_audit_admission` |
+| `failure_code` | `canonical_ack_unavailable` |
+
+If terminal-result custody also fails, the response reports `audit_result=unrecorded`. Investigate the surviving attempt as an audit-completeness incident, not evidence that the operation ran.
+
+### Network Flow Events
+
+Network audit records the connection lifecycle:
+
+- an allowed flow has one attempt and one result when the flow closes
+- a long-lived keep-alive connection therefore has one allow attempt and one eventual flow result
+- parsed HTTP or MCP operations may appear in bounded protocol details rather than as separate connections
+- raw proxy and credential-resolution errors stay in local diagnostics because they may contain upstream or credential details
+
+## Watch Logs Or Events
+
+Set `watch=true` on the logs or events endpoint to receive `application/x-ndjson` in ingestion order.
+
+| Line type | Meaning |
+|-----------|---------|
+| `event` or `log` | One matching record |
+| `watermark` | Resume cursor for a later watch request |
+| `heartbeat` | Keeps an idle stream active |
+| `error` | Backend failure after streaming started; the stream then ends |
+
+Watch behavior:
+
+- without `cursor` or `start_time`, the stream starts at request time and does not replay history
+- `end_time` is not supported with `watch=true`
+- runtime metrics use bounded time-series queries and do not expose a watch mode
+
+## Storage And Coverage
+
+ClickHouse is the only audit read source. Fsync-backed buffers retain pending events for retry, but buffered events are invisible to list and watch queries until ClickHouse acknowledges them. Logs and runtime samples use separate historical projections with independent retention periods.
+
+Current producers are:
+
+- cluster-gateway for authenticated Sandbox API access, including regional detail requests
+- the ctld network runtime for network attempts and results
+- manager for historical logs
+- node-local ctld collectors for sandbox-wide CRI runtime samples, collected every 15 seconds with jitter
+
+Historical queries return `503` when their backend is disabled or unavailable. The static metric catalog remains available so clients can build selectors without probing storage.
+
+### Coverage Limits
+
+- Metering windows remain separate usage-ledger records for quota, showback, and billing export.
+- `process.*` and `file.*` facts prove authenticated gateway requests and their HTTP results. They do not observe every process effect, SSH/SFTP command, POSIX write, direct SandboxVolume operation, or manager-initiated reconciliation.
+- Public exposure streams and WebSockets record a durable open attempt, but abrupt node or process loss can prevent the eventual close result.
+- Cluster-gateway pending events require reattachable durable storage. Node-local network-flow buffers survive same-node Pod restarts, not permanent node loss.
+- Per-row signatures detect modified returned facts. They do not prove that a privileged ClickHouse administrator never deleted a row.
+
+Deployments that require completeness across node loss should preserve audit signing public keys and export signed facts or checkpoints to independently controlled immutable storage. See [Self-hosted Observability](/docs/sandbox/self-hosted/observability) for ClickHouse, retention, delivery persistence, and signing-key configuration.

--- a/docs/sandbox/page.mdx
+++ b/docs/sandbox/page.mdx
@@ -288,113 +288,17 @@ console.log('Status:', status.status);`
 
 ## Observability
 
-Sandbox0 exposes chart-ready runtime metrics, historical logs, and a canonical per-sandbox audit ledger. Audit is stored directly in ClickHouse and never wakes a paused sandbox. It is separate from platform service telemetry and the metering usage ledger. Audit ingestion and the observability-event query and watch API require the enterprise `sandbox_audit` feature; logs, runtime metrics, and the metric catalog do not.
+Sandbox0 exposes runtime metrics, historical logs, and signed audit events without waking a paused sandbox.
 
-<Endpoint method="GET">
-/api/v1/sandboxes/{'{id}'}/observability/events
-</Endpoint>
+| Data | Use it for | Endpoint |
+|------|------------|----------|
+| Runtime metrics | Chart-ready CPU, memory, network, process, and rootfs series | <code>GET /api/v1/sandboxes/{'{id}'}/metrics</code> |
+| Historical logs | Retained stdout, stderr, and PTY output | <code>GET /api/v1/sandboxes/{'{id}'}/observability/logs</code> |
+| Audit events | Canonical signed activity records | <code>GET /api/v1/sandboxes/{'{id}'}/observability/events</code> |
 
-<Endpoint method="GET">
-/api/v1/sandboxes/{'{id}'}/observability/logs
-</Endpoint>
+Audit ingestion and audit queries require the enterprise `sandbox_audit` feature. Logs, runtime metrics, and the metric catalog do not.
 
-<Endpoint method="GET">
-/api/v1/sandboxes/{'{id}'}/metrics
-</Endpoint>
-
-<Endpoint method="GET">
-/api/v1/sandboxes/{'{id}'}/metrics/catalog
-</Endpoint>
-
-### Runtime metrics
-
-The metrics endpoint returns bounded, server-downsampled series ready for charts. The default query covers the last hour and requests CPU utilization, memory utilization, and network I/O. A query cannot span more than 30 days.
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `start_time` | RFC3339 timestamp | Start of the window; defaults to one hour before `end_time` |
-| `end_time` | RFC3339 timestamp | End of the window; defaults to the current time |
-| `metrics` | comma-separated string | Canonical metric names from the catalog |
-| `step_seconds` | integer | Requested bucket width; the server uses at least 15 seconds and may increase it to honor `max_points` |
-| `statistic` | string | `auto`, `average`, `minimum`, `maximum`, `last`, or `rate`; `auto` averages gauges and rates counters |
-| `max_points` | integer | Maximum points per series (default: 240, max: 1000) |
-
-The built-in catalog is intentionally bounded:
-
-| Metric | Kind | Unit | Meaning |
-|--------|------|------|---------|
-| `sandbox.cpu.utilization` | gauge | ratio | CPU usage divided by the configured CPU limit |
-| `sandbox.cpu.usage` | gauge | cores | CPU cores currently used |
-| `sandbox.cpu.time` | counter | seconds | Cumulative CPU time; `auto` returns its rate in cores |
-| `sandbox.cpu.limit` | gauge | cores | Configured CPU limit |
-| `sandbox.memory.usage` | gauge | bytes | Cgroup memory usage |
-| `sandbox.memory.working_set` | gauge | bytes | Memory working set |
-| `sandbox.memory.available` | gauge | bytes | Memory available within the sandbox limit |
-| `sandbox.memory.limit` | gauge | bytes | Configured memory limit |
-| `sandbox.memory.utilization` | gauge | ratio | Working set divided by the configured memory limit |
-| `sandbox.network.io` | counter | bytes | Receive or transmit bytes, selected by the `direction` dimension; `auto` returns bytes per second |
-| `sandbox.network.errors` | counter | count | Receive or transmit errors, selected by the `direction` dimension; `auto` returns errors per second |
-| `sandbox.process.count` | gauge | count | Current sandbox process count |
-| `sandbox.rootfs.writable.usage` | gauge | bytes | Main runtime container writable-layer usage when the CRI reports it |
-| `sandbox.rootfs.writable.inodes` | gauge | count | Main runtime container writable-layer inodes when the CRI reports them |
-
-Each series contains zero or more continuous `segments`. Runtime resets and collection gaps start a new segment, so clients must not connect lines across segments. The response also reports typed `gaps`, freshness relative to the requested `end_time`, the effective `step_seconds`, and whether the result is `partial`. Missing or unsupported observations are omitted and never synthesized as zero.
-
-```typescript
-import { Client, SandboxRuntimeMetricName } from "sandbox0";
-
-const client = new Client({ token: process.env.SANDBOX0_TOKEN! });
-const metrics = await client.sandbox("sb_abc123").getMetrics({
-    startTime: new Date(Date.now() - 60 * 60 * 1000),
-    metrics: [
-        SandboxRuntimeMetricName.SandboxCpuUtilization,
-        SandboxRuntimeMetricName.SandboxMemoryWorkingSet,
-        SandboxRuntimeMetricName.SandboxNetworkIo,
-    ],
-    maxPoints: 120,
-});
-```
-
-### Logs and audit events
-
-The upgraded `/observability/events` endpoint is the only public audit-event read API. It returns `403 feature_not_licensed` unless audit is explicitly enabled and cluster-gateway has a valid enterprise license containing `sandbox_audit`. The caller also needs the independent `sandboxaudit:read` permission.
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `start_time` | RFC3339 timestamp | Include events that occurred at or after this time |
-| `end_time` | RFC3339 timestamp | Include events that occurred at or before this time |
-| `limit` | integer | Maximum events to return (default: 100, max: 1000); ignored in exact `event_id` mode, which returns at most two payload variants |
-| `cursor` | string | Opaque cursor from a previous response; in watch mode, use the cursor from a `watermark` line |
-| `watch` | boolean | Stream matching records as `application/x-ndjson` until the client disconnects |
-| `context_id` | string | Log context filter |
-| `stream` | string | Log stream filter: `stdout`, `stderr`, or `pty` |
-| `source` | string | Trusted event producer, including `cluster_gateway` or `netd` (`netd` identifies ctld network-runtime events) |
-| `event_type` | string | Audit category such as `api_access` or `network_audit` |
-| `outcome` | string | `completed`, `denied`, `error`, `succeeded`, `failed`, `accepted`, or `unknown` |
-| `actor_kind` | string | `human`, `api_key`, `service`, or `sandbox_workload` and other trusted actor kinds |
-| `actor_id` | string | Trusted user, API key, service, or workload identifier |
-| `action` | string | Stable action such as `sandbox.pause`, `process.exec`, `file.write`, or `network.connect` |
-| `resource_type` | string | Resource category such as `sandbox` or `sandbox_network` |
-| `operation_id` | string | Correlates the attempt and result of one operation |
-| `event_id` | UUID | Exact lookup mode for one stable audit ID; cannot be combined with time, cursor, watch, or other event filters |
-
-Every audit fact includes a stable `event_id`, schema version, trusted actor, action, resource, producer, operation correlation, outcome, and bounded request metadata. Pagination cursors and watch watermarks are response transport metadata and are not repeated inside each signed event. `integrity` contains the canonical SHA-256 payload digest, Ed25519 signature, signing key ID, and query-time `signature_status`. List and watch responses recompute each returned row's digest and verify its signature. An exact `event_id` lookup fetches enough rows to set `event_id_conflict=true` when the same stable ID appears with multiple payload hashes; this marker does not overwrite `signature_status`, so callers can distinguish payload collisions from signature failures.
-
-Gateway operations produce an `attempt` before authorization or execution and a `result` after either the downstream response or a failed admission decision. ClickHouse is the only audit read source: the fsync-backed delivery buffer holds pending events for retry, but list and watch reads cannot see an event until ClickHouse acknowledges it. With the default `durable_async` mode, non-mutating and public-exposure operations may proceed after local durable enqueue, and healthy canonical visibility is normally delayed by the asynchronous delivery path and its default one-second flush/replay cycles. `canonical_sync` instead requires ClickHouse acknowledgement before admission and adds that round trip to the critical path.
-
-State-changing Sandbox API operations are always strict, regardless of the configured delivery mode. Cluster-gateway requires ClickHouse to acknowledge the attempt before execution, buffers the HTTP response, and requires ClickHouse acknowledgement for the signed result before returning that response. If canonical admission fails after the attempt is durably buffered, the downstream operation is not executed and cluster-gateway attempts to append a correlated signed `failed` result with HTTP `503`, `execution_started=false`, `operation_executed=false`, `failure_stage=canonical_audit_admission`, and `failure_code=canonical_ack_unavailable` for replay. If terminal-result custody also fails, the response reports `audit_result=unrecorded`; the orphan attempt is an audit-completeness incident, not evidence that the operation ran. If a result from an operation that did execute is only buffered for retry, the caller receives `503` rather than a false success. A `5xx` or panic result after execution is recorded as `unknown`, because the downstream operation may have completed even if the gateway did not receive a definitive response.
-
-Network allow decisions are fsynced to a node-local spool before the ctld network runtime opens the upstream connection. In `durable_async`, canonical delivery follows asynchronously; in `canonical_sync`, ClickHouse must acknowledge the allow attempt first, including for server-first SSH probes. A ClickHouse outage therefore delays audit-query visibility in `durable_async` but denies new flows in `canonical_sync`; an unwritable local buffer also fails closed unless synchronous canonical fallback succeeds. The result is appended when the flow closes. Consequently a long-lived keep-alive connection has one allow attempt and one eventual flow result; parsed HTTP or MCP operations may appear inside its bounded protocol details rather than as separate connections. Raw proxy and credential-resolution error strings remain local diagnostics and are not copied into the canonical ledger because they may contain upstream or credential details.
-
-Set `watch=true` to stream matching log or event records as NDJSON in ingestion order. Without `cursor` or `start_time`, a watch stream starts at request time and does not replay historical rows. When `watch=true`, `end_time` is not supported. A watch stream emits `event` or `log` lines, `watermark` lines with a resume cursor, periodic `heartbeat` lines, and an `error` line before termination if the backend fails after the stream starts. Runtime metrics are queried as bounded time series and do not expose a watch mode.
-
-ClickHouse-backed deployments store canonical audit facts in `sandbox_audit_events`; logs and wide runtime samples remain separate historical projections with independent retention TTLs. Cluster-gateway records authenticated Sandbox API access (including regional detail requests), the ctld network runtime records network attempts and results, manager publishes logs, and node-local ctld instances collect sandbox-wide CRI runtime samples every 15 seconds with jitter.
-
-Historical data query endpoints return `503` when the backend is disabled or unavailable. The static metric catalog remains available so clients can build selectors without probing storage.
-
-<Callout variant="info">
-Metering windows are separate usage-ledger records for quota, showback, and billing export. Audit does not duplicate metering state even when both use the same region ClickHouse component. `process.*` and `file.*` facts currently prove authenticated gateway requests and their HTTP result; they do not observe every process effect, SSH/SFTP command, arbitrary POSIX write, direct SandboxVolume operation, or manager-initiated lifecycle reconciliation. Public exposure streams and WebSockets have a durably captured open attempt, but an abrupt node/process loss can prevent their eventual close result. Cluster-gateway pending audit events use a PVC that production deployments must back with reattachable durable storage; node-local ctld network-flow buffers survive same-node Pod restarts but not permanent node loss. Deployments that must prove completeness across node loss should preserve audit signing public keys and export signed facts/checkpoints to independently controlled immutable storage. Per-row signatures detect modified returned facts; by themselves they do not prove that a privileged ClickHouse administrator never deleted a row.
-</Callout>
+See [Observability](/docs/sandbox/observability) for metric names, query filters, watch streams, audit integrity, delivery modes, and coverage limits.
 
 ---
 

--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -34,21 +34,35 @@ On nodes using the containerd overlayfs snapshotter, `ctld` checkpoints only the
 
 Pause a sandbox to release compute while keeping its identity, configuration, services, mounted durable storage, and latest writable rootfs checkpoint available for a later resume.
 
-The pause endpoint accepts the lifecycle transition and returns the current committed state. Rootfs checkpoint upload and runtime pod deletion continue in the background. Until the pause transaction commits, sandbox details continue to report the previous committed runtime state, usually `running`. Poll sandbox details until `status` is `paused` and `paused` is `true` before treating the checkpoint as resume-ready.
+The pause request is asynchronous. Poll sandbox details until `status` is `paused` and `paused` is `true` before treating the checkpoint as resume-ready.
 
-Runtime access paths do not expose `pausing` or `resuming` states. File, context, public service, and SSH requests are linearized to a committed runtime generation: they either use the currently committed runtime or wait for the lifecycle transaction to commit before continuing after resume. Lifecycle work in progress should not be handled as a caller-visible `409 Conflict`; conflicts are reserved for real policy or state conflicts such as disabled auto-resume, non-restartable service routes, quota limits, deletion, or paused-only operations.
+| Situation | Behavior |
+|-----------|----------|
+| Pause request accepted | The API returns the current committed state while checkpoint upload and runtime pod deletion continue |
+| Pause not yet committed | Sandbox details still show the previous committed state, usually `running` |
+| File, context, service, or SSH access during a transition | The request uses the committed runtime generation or waits for the transaction, then continues after resume |
+| Runtime access reaches an automatic TTL pause before commit | Sandbox0 cancels the automatic pause and continues on the existing runtime generation |
+| Runtime access reaches an explicit pause | The explicit pause commits; access can then resume the sandbox when auto-resume is allowed |
 
-Automatic pause from `ttl` is opportunistic. If supported runtime access arrives before an automatic pause reaches its commit point, Sandbox0 cancels that automatic pause, releases the runtime barrier, and continues on the existing runtime generation. Explicit pause requests are not canceled by runtime access; those requests wait for the committed pause and then resume if auto-resume is allowed.
+`pausing` and `resuming` are not caller-visible states. A lifecycle transaction in progress is not a `409 Conflict`; that status is reserved for actual policy or state conflicts such as disabled auto-resume, non-restartable routes, quota limits, deletion, or paused-only operations.
 
 ## Runtime Failure Recovery
 
-If the `procd` container in a claimed sandbox exits unexpectedly, including an OOM termination, Sandbox0 leaves that container attempt stopped while `manager` starts a non-cancelable crash-recovery pause. `ctld` checkpoints the exact terminated containerd snapshot, then `manager` atomically commits the new rootfs head and paused state before deleting the old runtime pod. A supported runtime request waits for this transaction and can resume from the recovered checkpoint when auto-resume is allowed.
+Sandbox0 uses the durable pause flow to replace a failed runtime.
 
-Explicit sandbox deletion and `hard_ttl` still take precedence over crash recovery. Recovery also depends on the terminated snapshot remaining available on the same node. If the old runtime pod or containerd snapshot disappears before `ctld` can read it, Sandbox0 records the degraded recovery and falls back to the last committed rootfs checkpoint. Files written after that checkpoint may be lost. Mounted Sandbox Volumes keep their independently durable state.
+| Failure or condition | Recovery behavior |
+|----------------------|-------------------|
+| `procd` exits unexpectedly, including OOM | Manager starts a non-cancelable recovery pause; ctld checkpoints the terminated containerd snapshot, then manager atomically commits the new rootfs head and paused state before deleting the old pod |
+| Runtime liveness failure is transient | The existing runtime is not replaced |
+| Runtime liveness fails continuously for 90 seconds | Manager starts the same durable pause flow and reconstructs the sandbox with a new `runtime_generation` |
+| Runtime cannot produce a checkpoint within the bounded attempt | Recovery keeps the last committed rootfs head and replaces the stuck runtime |
+| Explicit delete or `hard_ttl` occurs | Deletion takes precedence over crash recovery |
 
-Sandbox0 treats a sustained runtime liveness failure as an internal platform fault. A transient failure does not replace the runtime, but after the failure continues for 90 seconds, manager starts the same durable pause flow and reconstructs the runtime as a new `runtime_generation`. This recovery is independent of the sandbox `auto_resume` access policy.
+Recovery is independent of the sandbox `auto_resume` access policy. A supported runtime request waits for recovery to commit, then resumes when auto-resume is allowed.
 
-For an unresponsive runtime, `ctld` gets a bounded checkpoint attempt. If the runtime cannot produce a new checkpoint, recovery preserves the last committed rootfs head and continues so a stuck runtime cannot block replacement indefinitely. Mounted Sandbox Volumes remain independently durable.
+<Callout variant="warning">
+Recovering the latest writes requires the terminated containerd snapshot to remain available on the same node. If the old pod or snapshot disappears first, Sandbox0 falls back to the last committed rootfs checkpoint and records degraded recovery. Files written after that checkpoint may be lost; mounted Sandbox Volumes retain their independently durable state.
+</Callout>
 
 <Endpoint method="POST">
 /api/v1/sandboxes/{'{id}'}/pause
@@ -89,9 +103,14 @@ console.log("Pause requested");`
 
 Resume a sandbox that was paused manually or by TTL expiry.
 
-Resume first restores the writable rootfs checkpoint onto a runtime pod created from the current template image. If that restore fails, Sandbox0 retries once with a runtime pod pinned to the checkpoint's recorded base image digest. Kubernetes pulls and garbage-collects that image through the normal kubelet image lifecycle.
+| Situation | Restore behavior |
+|-----------|------------------|
+| Normal resume | Creates a runtime pod from the current template image and restores the latest committed rootfs checkpoint |
+| Restore fails against the current template image | Retries once with the checkpoint's recorded base image digest; kubelet manages that image normally |
+| Existing runtime pod is terminal | Waits for crash recovery to commit, then restores the recovered rootfs head |
+| Terminated snapshot is unavailable | Restores the last committed checkpoint |
 
-If the current runtime pod reaches a terminal phase, explicit resume or a supported access path first waits for any crash-recovery checkpoint to commit. The replacement runtime then restores that recovered rootfs head. When the terminated snapshot is no longer available, the replacement restores the last committed checkpoint instead. Mounted Sandbox Volumes are remounted from their durable state.
+Mounted Sandbox Volumes are remounted from their durable state.
 
 <Endpoint method="POST">
 /api/v1/sandboxes/{'{id}'}/resume

--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -72,11 +72,33 @@ After quota admission, manager claims a ready idle pod or creates a cold pod dir
 
 ## Metering Boundary
 
-Sandbox0 records usage truth in the region usage ledger and exports it from the region-scoped metering endpoints. Metering is disabled by default. When `spec.metering.enabled` is `true`, metering requires `spec.clickHouse.type` to be `builtin` or `external`. ClickHouse is the long-term usage ledger and the only metering query/export backend. PostgreSQL holds only a compact transactional delivery outbox and producer projection state; it is not a second queryable usage ledger. Producers capture stable, idempotent ClickHouse operations in that outbox, storage mutations use the same PostgreSQL business transaction, and manager retries the oldest transaction batch until ClickHouse accepts it.
+Metering is disabled by default. Set `spec.metering.enabled: true` and configure `spec.clickHouse.type` as `builtin` or `external` to enable the region usage ledger.
 
-Metering export is therefore eventually consistent. Manager lifecycle events and storage mutations are normally visible after the projector poll (about two seconds). Network byte windows from ctld add `meteringReportInterval` (10 seconds by default), while periodic storage byte-hour windows add up to one minute. A ClickHouse outage increases this delay without discarding committed outbox operations; after the one-time projection-state bootstrap has completed, producers can also restart while ClickHouse is unavailable. The outbox is globally ordered, so the exported `complete_before` value is the greatest producer watermark that has reached ClickHouse; projecting it proves that every older committed batch has also been delivered, and historical producer instances do not pin the frontier. Monitor `manager_metering_outbox_pending_operations` and `manager_metering_outbox_oldest_pending_age_seconds` for delivery backlog. Billing systems should consume the exported watermark and rate usage windows outside the open-source data plane.
+| Component | Responsibility |
+|-----------|----------------|
+| PostgreSQL | Transactional producer state and an ordered delivery outbox; storage mutations enqueue usage in the same business transaction |
+| Manager projector | Retries the oldest stable, idempotent operation batch until ClickHouse accepts it |
+| ClickHouse | Long-term usage ledger and the only metering query and export backend |
+| Billing system | Consumes exported windows and watermarks, then applies pricing outside the open-source data plane |
 
-New event and window rows expose their PostgreSQL outbox operation sequence. Rows projected before the sequence column was introduced retain `sequence: 0`; cursor-based pagination is the canonical export contract across upgrades. Metering timestamps are written to ClickHouse as signed Unix nanoseconds so `DateTime64(9)` window boundaries and cursors preserve their full precision.
+Metering export is eventually consistent:
+
+| Producer | Normal additional delay |
+|----------|-------------------------|
+| Manager lifecycle and storage mutations | Projector poll, about two seconds |
+| ctld network byte windows | `meteringReportInterval`, 10 seconds by default |
+| Periodic storage byte-hour windows | Up to one minute |
+
+A ClickHouse outage increases the delay without discarding committed outbox operations. After projection-state bootstrap, producers can also restart while ClickHouse is unavailable.
+
+Export and upgrade rules:
+
+- `complete_before` is the greatest globally ordered producer watermark delivered to ClickHouse; every older committed batch has also been delivered
+- new rows expose their PostgreSQL outbox sequence; rows created before that column use `sequence: 0`
+- cursor pagination is the canonical export contract across upgrades
+- signed Unix nanosecond timestamps preserve `DateTime64(9)` boundaries and cursor precision
+
+Monitor `manager_metering_outbox_pending_operations` and `manager_metering_outbox_oldest_pending_age_seconds` for delivery backlog.
 
 Sandbox compute uses a serverless-style contract:
 
@@ -92,203 +114,29 @@ Sandbox compute uses a serverless-style contract:
 
 Public template idle pools are platform cost. Team-owned template warm pools are attributed to the owning team with `subject_type=template`.
 
-OSS request windows are usage facts only; Sandbox0 does not attach prices. The
-manager and ctld aggregate provider HTTP attempts for one minute before writing
-them to the PostgreSQL metering outbox. Successful volume requests are
-attributed from `sandboxvolumes/<team_id>/<volume_id>`, and rootfs requests from
-`sandbox-rootfs/<team_id>/<sandbox_id>`. Window `data` records `provider`,
-`bucket`, `billing_item`, `operation`, `cost_scope`, and `prefix_class`.
-Requests to customer-configured external S3 volumes are excluded because the
-customer owns that object-store account. Reconcile these windows with provider
-access and metering logs before using them for cost reporting.
+Object-store request windows are usage facts; Sandbox0 does not attach prices.
+
+- manager and ctld aggregate provider HTTP attempts for one minute before writing them to the PostgreSQL outbox
+- volume requests are attributed from `sandboxvolumes/<team_id>/<volume_id>`
+- rootfs requests are attributed from `sandbox-rootfs/<team_id>/<sandbox_id>`
+- window `data` records `provider`, `bucket`, `billing_item`, `operation`, `cost_scope`, and `prefix_class`
+- requests to customer-owned external S3 volumes are excluded
+
+Reconcile these windows with provider access and metering logs before using them for cost reporting.
 
 ## Platform Observability
 
-Sandbox0 platform services emit logs to container stdout and expose Prometheus-compatible metrics on their metrics ports. Configure `spec.observability` when you want the operator to export sandbox0-owned platform telemetry to your observability stack.
+Sandbox0 separates three data paths:
 
-Platform telemetry export is disabled by default. The operator owns collection and export integration only: it can point platform services at an external collector, or install OpenTelemetry Collectors that export to your OTLP endpoint. The per-sandbox historical observability APIs are separate from this platform telemetry layer; they require a configured query backend and return `503 unavailable` when that backend is disabled or unavailable. The historical observability tables are separate from the metering usage ledger even when both use the same region ClickHouse component.
+| Data path | Configuration | Purpose |
+|-----------|---------------|---------|
+| Platform telemetry | `spec.observability` | Export service logs, metrics, and traces to your observability stack |
+| Per-sandbox history | `spec.clickHouse`, `spec.sandboxObservability` | Retain sandbox metrics, logs, and signed audit events |
+| Metering | `spec.clickHouse`, `spec.metering` | Maintain usage truth and region-scoped exports |
 
-For cold-start diagnosis, manager exposes `manager_pod_lifecycle_stage_duration_seconds`. Its `stage` label separates scheduling, the `PodReadyToStartContainers` sandbox/network boundary, procd container start, first PodIP observation, and Sandbox0 startup/readiness probe completion. The sandbox boundary is a Kubernetes lifecycle timestamp, not the duration of an individual CRI call. Collect kubelet `kubelet_runtime_operations_duration_seconds{operation_type=~"run_podsandbox|create_container|start_container"}` when exact node-level CRI operation latency is required.
+See [Self-hosted Observability](/docs/sandbox/self-hosted/observability) for collector setup, ClickHouse examples, audit persistence, retention, key management, and monitoring. See [Sandbox Observability](/docs/sandbox/observability) for the user-facing query and watch APIs.
 
-ClickHouse is configured once on the `Sandbox0Infra` CR under `spec.clickHouse`. The infra-operator owns builtin provisioning or external DSN resolution, the same way it owns built-in or external PostgreSQL and Redis wiring. Feature configs such as `spec.sandboxObservability` and `spec.metering` consume this region component. Do not configure separate ClickHouse backends on cluster-gateway, manager, or ctld when deploying through `Sandbox0Infra`.
-
-Historical logs and runtime metrics are available whenever sandbox observability is enabled. Centralized sandbox audit is an enterprise feature: set `spec.sandboxObservability.audit.enabled` to `true` and provide a signed enterprise license containing the `sandbox_audit` feature. The license is mounted only into cluster-gateway, which authorizes audit ingestion and the public observability-event query and watch API.
-
-ClickHouse is the canonical audit store. Audit facts are written to `sandbox_audit_events` with stable event IDs, trusted actor and producer identity, a canonical payload digest, and an Ed25519 gateway signature. PostgreSQL is not a second audit store. The infra-operator creates separate network-producer and audit-signing key pairs: the active ctld process receives only the producer private key, while cluster-gateway receives its public key and the independent signing key. Fsync-backed buffers are delivery state, not competing audit ledgers or query sources; the public observability-event list and watch responses read only canonical ClickHouse rows and include `signature_status`, with event-ID payload conflicts reported separately as `event_id_conflict`. A buffered event is therefore not visible to audit readers until ClickHouse acknowledges it. Cluster-gateway uses a persistent volume claim for pending audit events, while each node-local ctld network runtime keeps its flow buffer on that node. Delivery records are deleted only after ClickHouse acknowledges the exact event.
-
-The v2 audit schema deliberately uses a new `sandbox_audit_events` table. Older `sandbox_events` rows do not have trustworthy actor or signature data and are retained as legacy observability history rather than being retroactively signed. Existing CRs whose persisted table value is the old default are routed to the new canonical table. At startup, audit-enabled cluster-gateway validates the actual ClickHouse engine, partition key, sorting key, and required columns, and refuses to serve audit operations against an old or incompatible custom table.
-
-Use builtin ClickHouse when you want the infra-operator to install ClickHouse for the region:
-
-```yaml
-spec:
-    enterpriseLicense:
-        secretRef:
-            name: sandbox0-enterprise-license
-            key: license.lic
-    clickHouse:
-        type: builtin
-        builtin:
-            image: clickhouse/clickhouse-server:24.8
-            persistence:
-                size: 50Gi
-        databases:
-            observability: sandbox0_observability
-            metering: sandbox0_metering
-        schemaMigration:
-            enabled: true
-    sandboxObservability:
-        enabled: true
-        backend: clickhouse
-        audit:
-            enabled: true
-            deliveryMode: durable_async
-            deliveryPersistence:
-                size: 1Gi
-        retention:
-            auditDays: 90
-            logDays: 7
-            runtimeSampleDays: 30
-        ingest:
-            queueSize: 1024
-            batchSize: 100
-            flushInterval:
-                duration: 1s
-            requestTimeout:
-                duration: 2s
-            maxRetries: 3
-            retryBackoff:
-                duration: 100ms
-    metering:
-        enabled: true
-        clickHouse:
-            eventsTable: usage_events
-            windowsTable: usage_windows
-            watermarksTable: producer_watermarks
-            sandboxStateTable: sandbox_projection_state
-            storageStateTable: storage_projection_state
-```
-
-Audit retention is measured from the cluster-gateway-owned `ingested_at` timestamp, not the producer's potentially delayed `occurred_at`. This timestamp marks when cluster-gateway creates or normalizes the canonical event; it is not a ClickHouse acknowledgement timestamp. An event delayed in a delivery buffer may therefore have less than the configured retention period remaining when it becomes query-visible.
-
-`spec.sandboxObservability.audit.deliveryMode` selects the admission boundary for non-mutating Sandbox API requests, public-exposure requests, and new network flows handled by ctld:
-
-- `durable_async` is the default. The operation may proceed after its attempt or event is fsynced to the local delivery buffer; ClickHouse ingestion and audit-query visibility follow asynchronously. On a healthy deployment, visibility is driven by immediate delivery wakeups plus the default one-second flush/replay cycles, so it is not a read-after-write guarantee.
-- `canonical_sync` waits for ClickHouse to acknowledge the admission event before the operation or flow proceeds. This puts a ClickHouse round trip on the critical path and fails closed when canonical acknowledgement is unavailable.
-
-State-changing Sandbox API requests are always strict regardless of this setting. Cluster-gateway requires canonical acknowledgement for the attempt before execution, buffers the downstream response, and requires canonical acknowledgement for the signed result before returning that response. The delivery buffer is still used to preserve a pending fact for replay, but it never turns a mutation into a successful response before ClickHouse acknowledges the fact. If canonical admission fails after the attempt is durably buffered, cluster-gateway does not execute the downstream handler and attempts to append a correlated signed `failed` result with HTTP `503`, `execution_started=false`, `operation_executed=false`, `failure_stage=canonical_audit_admission`, and `failure_code=canonical_ack_unavailable`. When result custody succeeds, both facts become query-visible after replay. If the result buffer and canonical fallback both fail, the operation remains unexecuted, the response reports `audit_result=unrecorded`, and the surviving orphan attempt is an audit-completeness incident that requires investigation.
-
-During a ClickHouse outage, `durable_async` traffic can continue only while the local delivery buffer remains writable and durable; audit readers will lag until replay succeeds, with no fixed visibility bound during the outage. If the buffer cannot accept an event, Sandbox0 tries a synchronous canonical fallback and fails closed when neither path can take custody. `canonical_sync` traffic and all mutations fail closed on canonical timeout or outage. Choose `canonical_sync` when immediate canonical admission is worth the added latency and availability coupling; choose `durable_async` when durable capture with eventual canonical visibility is the preferred default.
-
-Use the external backend when you already operate ClickHouse:
-
-```yaml
-spec:
-    enterpriseLicense:
-        secretRef:
-            name: sandbox0-enterprise-license
-            key: license.lic
-    clickHouse:
-        type: external
-        external:
-            dsnSecret:
-                name: sandbox0-clickhouse
-                key: dsn
-            connectTimeout:
-                duration: 10s
-        databases:
-            observability: sandbox0_observability
-            metering: sandbox0_metering
-    sandboxObservability:
-        enabled: true
-        backend: clickhouse
-        audit:
-            enabled: true
-            deliveryMode: durable_async
-            deliveryPersistence:
-                size: 1Gi
-        retention:
-            auditDays: 90
-            logDays: 7
-            runtimeSampleDays: 30
-    metering:
-        enabled: true
-```
-
-Set `spec.sandboxObservability.enabled` to `false` or omit the field to keep all historical APIs disabled. Leave `spec.sandboxObservability.audit.enabled` unset or `false` to keep canonical audit ingestion and event queries disabled while retaining historical logs and runtime metrics. Set `spec.metering.enabled` to `false` or omit `spec.metering` to keep metering producers, quota usage reads, and metering export readers disabled. Legacy `spec.sandboxObservability.type` fields are still accepted for compatibility, but new installs should use `spec.clickHouse` for ClickHouse provisioning. Disabling audit stops new facts but does not delete existing rows. `retention.auditDays` is the retention policy for the canonical ClickHouse audit table; set it to the period required by your organization before enabling audit in production. Metering remains a separate ledger.
-
-When the backend is enabled, infra-operator injects bounded internal ingest endpoints into ctld for sandbox-wide CRI runtime samples and manager for historical logs. When licensed audit is also enabled, it injects the selected delivery mode and durable event-buffer configuration into cluster-gateway and the ctld network runtime. In `durable_async`, ctld opens an allowed upstream connection after its producer attempt is fsynced locally; cluster-gateway later normalizes and signs that event during canonical ingestion. In `canonical_sync`, ctld waits for cluster-gateway and ClickHouse to acknowledge the attempt. Gateway mutation responses are always held until their signed result is acknowledged; pending results return `503` and replay from disk.
-
-Audit currently requires `spec.services.clusterGateway.replicas: 1`. Infra-operator mounts a `ReadWriteOnce` audit-event delivery PVC and uses the `Recreate` deployment strategy so the same buffer is detached and reattached before a replacement gateway starts. In production, set `audit.deliveryPersistence.storageClass` to durable, encrypted storage that supports cross-node volume reattachment; the cluster default is used when it is omitted. Ctld network flow buffers remain node-local and survive same-node Pod restarts, but not permanent node loss. All delivery records are removed only after ClickHouse acknowledgement. Preserve the generated audit-signing Secret for the full retention period. Inline verification currently uses only the active public key, so events signed by a retained historical key report `signature_status=unavailable`; destructive key replacement therefore requires retaining previous public keys outside the cluster for historical offline verification.
-
-The ctld network runtime exports `sandbox0_netd_audit_ingest_events_total` and `sandbox0_netd_audit_ingest_batches_total`; alert on `persist_failed`, `corrupt`, `retrying`, `replay_failed`, and `ack_failed` results. Only `canonical_sync` admission adds a ClickHouse round trip to each new audited flow; the default `durable_async` path pays for local fsync and gains ClickHouse visibility asynchronously. HTTP requests multiplexed over one existing connection remain protocol operations beneath that flow rather than independent network connections.
-
-The built-in controls provide durable delivery, authenticated producer identity, tenant scoping, append-only application behavior, and tamper-evident row signatures. Regulatory certification still depends on deployment controls outside the process: highly available ClickHouse storage, restricted ClickHouse mutation credentials, encrypted backups, tested restore procedures, retention and legal-hold policy, clock synchronization, and independent preservation of signing public keys or exported checkpoints. A database administrator who can rewrite the complete table and its backups is outside the protection of a per-row signature alone.
-
-In `managedCollector` mode sandbox0 installs collectors for logs, metrics, and traces, then exports to your OTLP endpoint:
-
-```yaml
-spec:
-    observability:
-        backend:
-            type: external
-            external:
-                mode: managedCollector
-                otlp:
-                    endpoint: otel-gateway.example.com:4317
-                    insecure: false
-        resourceAttributes:
-            deployment.environment: production
-        collection:
-            logs:
-                enabled: true
-            metrics:
-                enabled: true
-            traces:
-                enabled: true
-```
-
-If your platform already runs collectors, use `existingCollector`. In this mode sandbox0 does not install collectors; it only injects standard OTEL trace environment variables into platform services:
-
-```yaml
-spec:
-    observability:
-        backend:
-            type: external
-            external:
-                mode: existingCollector
-                otlp:
-                    endpoint: http://otel-collector.observability.svc.cluster.local:4317
-                    headersSecret:
-                        name: otel-export-headers
-                        key: headers
-                    insecure: true
-```
-
-The legacy direct trace exporter config remains supported and overrides export-derived trace endpoint defaults:
-
-```yaml
-spec:
-    observability:
-        traces:
-            enabled: true
-            exporter: otlp
-            endpoint: http://otel-collector.observability.svc.cluster.local:4317
-            insecure: true
-            timeout: 10s
-            sampleRate: "0.25"
-```
-
-The operator adds built-in resource attributes such as `service.name`, `sandbox0.region.id`, `sandbox0.cluster.id`, `k8s.namespace.name`, `k8s.pod.name`, and `k8s.node.name`. Built-in attributes win over user-provided keys so dashboards and trace queries can rely on stable names.
-
-When traces are not enabled through `collection.traces` or the legacy `traces` block, services keep the default noop trace exporter. Existing direct environment overrides still work; standard OpenTelemetry variables such as `OTEL_TRACES_EXPORTER`, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, `OTEL_EXPORTER_OTLP_TRACES_HEADERS`, and `OTEL_RESOURCE_ATTRIBUTES` take precedence over operator-injected defaults.
-
-Official sample manifests:
-
-- <GitHubRawLink repo="sandbox0" path="infra-operator/chart/samples/single-cluster/fullmode.yaml">single-cluster/fullmode.yaml</GitHubRawLink>
-- <GitHubRawLink repo="sandbox0" path="infra-operator/chart/samples/single-cluster/fullmode-gke-gvisor.yaml">single-cluster/fullmode-gke-gvisor.yaml</GitHubRawLink>
-- <GitHubRawLink repo="sandbox0" path="infra-operator/chart/samples/multi-cluster/control-plane.yaml">multi-cluster/control-plane.yaml</GitHubRawLink>
-- <GitHubRawLink repo="sandbox0" path="infra-operator/chart/samples/multi-cluster/data-plane.yaml">multi-cluster/data-plane.yaml</GitHubRawLink>
+For cold-start diagnosis, collect `manager_pod_lifecycle_stage_duration_seconds`. Use kubelet `kubelet_runtime_operations_duration_seconds{operation_type=~"run_podsandbox|create_container|start_container"}` when you need individual CRI operation latency.
 
 ## What Usually Changes First
 

--- a/docs/self-hosted/observability/page.mdx
+++ b/docs/self-hosted/observability/page.mdx
@@ -1,0 +1,279 @@
+# Observability
+
+Self-hosted Sandbox0 has three separate data paths. Configure each one for its own purpose.
+
+| Data path | Purpose | Main configuration | Storage or destination |
+|-----------|---------|--------------------|------------------------|
+| Platform telemetry | Operate Sandbox0 services | `spec.observability` | Your OpenTelemetry or Prometheus stack |
+| Per-sandbox history | Runtime metrics, logs, and audit events | `spec.clickHouse`, `spec.sandboxObservability` | Region ClickHouse |
+| Metering | Usage truth, quota, showback, and export | `spec.clickHouse`, `spec.metering` | PostgreSQL outbox projected to region ClickHouse |
+
+<Callout variant="info">
+This page covers operator configuration. See [Sandbox Observability](/docs/sandbox/observability) for API filters, metric names, audit delivery behavior, watch streams, and coverage limits.
+</Callout>
+
+## Platform Telemetry
+
+Sandbox0 services write logs to container stdout and expose Prometheus-compatible metrics on their metrics ports. `spec.observability` can export Sandbox0-owned logs, metrics, and traces to your platform stack.
+
+For cold-start diagnosis, collect `manager_pod_lifecycle_stage_duration_seconds`. Its `stage` label separates:
+
+- scheduling
+- the `PodReadyToStartContainers` sandbox and network boundary
+- procd container start
+- first PodIP observation
+- Sandbox0 startup and readiness probe completion
+
+The sandbox boundary is a Kubernetes lifecycle timestamp, not an individual CRI call duration. Collect `kubelet_runtime_operations_duration_seconds{operation_type=~"run_podsandbox|create_container|start_container"}` when you need node-level CRI timing.
+
+### Managed Collector
+
+Use `managedCollector` when Sandbox0 should install OpenTelemetry Collectors and export to your OTLP endpoint.
+
+```yaml
+spec:
+    observability:
+        backend:
+            type: external
+            external:
+                mode: managedCollector
+                otlp:
+                    endpoint: otel-gateway.example.com:4317
+                    insecure: false
+        resourceAttributes:
+            deployment.environment: production
+        collection:
+            logs:
+                enabled: true
+            metrics:
+                enabled: true
+            traces:
+                enabled: true
+```
+
+### Existing Collector
+
+Use `existingCollector` when your platform already operates collectors. Sandbox0 does not install collectors in this mode; it injects standard OpenTelemetry trace environment variables into platform services.
+
+```yaml
+spec:
+    observability:
+        backend:
+            type: external
+            external:
+                mode: existingCollector
+                otlp:
+                    endpoint: http://otel-collector.observability.svc.cluster.local:4317
+                    headersSecret:
+                        name: otel-export-headers
+                        key: headers
+                    insecure: true
+```
+
+The legacy direct trace exporter remains supported and overrides trace endpoints derived from the export configuration:
+
+```yaml
+spec:
+    observability:
+        traces:
+            enabled: true
+            exporter: otlp
+            endpoint: http://otel-collector.observability.svc.cluster.local:4317
+            insecure: true
+            timeout: 10s
+            sampleRate: "0.25"
+```
+
+The operator adds stable attributes such as `service.name`, `sandbox0.region.id`, `sandbox0.cluster.id`, `k8s.namespace.name`, `k8s.pod.name`, and `k8s.node.name`. Built-in values take precedence over user-provided values for the same keys.
+
+When traces are not enabled through `collection.traces` or the legacy `traces` block, services use the noop trace exporter. Direct environment overrides still take precedence over operator defaults, including:
+
+- `OTEL_TRACES_EXPORTER`
+- `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
+- `OTEL_EXPORTER_OTLP_TRACES_HEADERS`
+- `OTEL_RESOURCE_ATTRIBUTES`
+
+Official sample manifests:
+
+- <GitHubRawLink repo="sandbox0" path="infra-operator/chart/samples/single-cluster/fullmode.yaml">single-cluster/fullmode.yaml</GitHubRawLink>
+- <GitHubRawLink repo="sandbox0" path="infra-operator/chart/samples/single-cluster/fullmode-gke-gvisor.yaml">single-cluster/fullmode-gke-gvisor.yaml</GitHubRawLink>
+- <GitHubRawLink repo="sandbox0" path="infra-operator/chart/samples/multi-cluster/control-plane.yaml">multi-cluster/control-plane.yaml</GitHubRawLink>
+- <GitHubRawLink repo="sandbox0" path="infra-operator/chart/samples/multi-cluster/data-plane.yaml">multi-cluster/data-plane.yaml</GitHubRawLink>
+
+## Per-Sandbox Historical Data
+
+Configure ClickHouse once under `spec.clickHouse`. `spec.sandboxObservability` and `spec.metering` consume that region component; do not configure separate ClickHouse backends on individual services.
+
+| Data | Required configuration | Enterprise license |
+|------|------------------------|--------------------|
+| Historical logs | `sandboxObservability.enabled: true` | No |
+| Runtime metrics | `sandboxObservability.enabled: true` | No |
+| Signed audit events | `sandboxObservability.audit.enabled: true` | `sandbox_audit` |
+| Metering ledger | `metering.enabled: true` | No |
+
+Historical queries return `503 unavailable` when their backend is disabled or unavailable. They are separate from platform telemetry and from the metering usage ledger.
+
+### Builtin ClickHouse
+
+Use builtin ClickHouse when the infra-operator should install the region component.
+
+```yaml
+spec:
+    enterpriseLicense:
+        secretRef:
+            name: sandbox0-enterprise-license
+            key: license.lic
+    clickHouse:
+        type: builtin
+        builtin:
+            image: clickhouse/clickhouse-server:24.8
+            persistence:
+                size: 50Gi
+        databases:
+            observability: sandbox0_observability
+            metering: sandbox0_metering
+        schemaMigration:
+            enabled: true
+    sandboxObservability:
+        enabled: true
+        backend: clickhouse
+        audit:
+            enabled: true
+            deliveryMode: durable_async
+            deliveryPersistence:
+                size: 1Gi
+        retention:
+            auditDays: 90
+            logDays: 7
+            runtimeSampleDays: 30
+        ingest:
+            queueSize: 1024
+            batchSize: 100
+            flushInterval:
+                duration: 1s
+            requestTimeout:
+                duration: 2s
+            maxRetries: 3
+            retryBackoff:
+                duration: 100ms
+    metering:
+        enabled: true
+        clickHouse:
+            eventsTable: usage_events
+            windowsTable: usage_windows
+            watermarksTable: producer_watermarks
+            sandboxStateTable: sandbox_projection_state
+            storageStateTable: storage_projection_state
+```
+
+### External ClickHouse
+
+Use an external backend when you already operate ClickHouse.
+
+```yaml
+spec:
+    enterpriseLicense:
+        secretRef:
+            name: sandbox0-enterprise-license
+            key: license.lic
+    clickHouse:
+        type: external
+        external:
+            dsnSecret:
+                name: sandbox0-clickhouse
+                key: dsn
+            connectTimeout:
+                duration: 10s
+        databases:
+            observability: sandbox0_observability
+            metering: sandbox0_metering
+    sandboxObservability:
+        enabled: true
+        backend: clickhouse
+        audit:
+            enabled: true
+            deliveryMode: durable_async
+            deliveryPersistence:
+                size: 1Gi
+        retention:
+            auditDays: 90
+            logDays: 7
+            runtimeSampleDays: 30
+    metering:
+        enabled: true
+```
+
+## Audit Operations
+
+Cluster-gateway authorizes audit ingestion and the public event query and watch API. The enterprise license is mounted only into cluster-gateway.
+
+The infra-operator also manages two independent key pairs:
+
+- the active ctld process receives the network-producer private key
+- cluster-gateway receives the corresponding producer public key
+- cluster-gateway receives the independent audit-signing private key
+
+ClickHouse table `sandbox_audit_events` is the canonical audit store. PostgreSQL is not a second audit store, and fsync-backed buffers are delivery state rather than query sources.
+
+### Delivery Mode
+
+`spec.sandboxObservability.audit.deliveryMode` controls admission for non-mutating Sandbox API requests, public exposure requests, and new ctld network flows.
+
+| Mode | Admission point | Operational tradeoff |
+|------|-----------------|----------------------|
+| `durable_async` | Local durable enqueue | Default; lower ClickHouse coupling, eventual query visibility |
+| `canonical_sync` | ClickHouse acknowledgement | Immediate canonical admission, added latency and availability coupling |
+
+State-changing Sandbox API requests always require canonical acknowledgement before execution and before returning their signed result. See [Audit Delivery](/docs/sandbox/observability#audit-delivery) for failure behavior and caller-visible results.
+
+Audit retention starts at cluster-gateway's `ingested_at` timestamp, when it creates or normalizes the canonical event. It does not start at the producer's `occurred_at` time or at ClickHouse acknowledgement. A delayed event can therefore have less than the configured retention period remaining when it becomes query-visible.
+
+### Persistence And Keys
+
+Audit currently requires `spec.services.clusterGateway.replicas: 1`. Infra-operator uses a `ReadWriteOnce` event-delivery PVC and the `Recreate` deployment strategy so a replacement gateway reattaches the same buffer before starting.
+
+Production requirements:
+
+- set `audit.deliveryPersistence.storageClass` to durable, encrypted storage that can reattach across nodes; omitting it uses the cluster default
+- preserve the generated audit-signing Secret for the entire retention period
+- retain previous public keys outside the cluster before destructive key replacement; inline verification uses only the active public key and reports older retained keys as `signature_status=unavailable`
+- account for ctld network-flow buffers being node-local: they survive a same-node Pod restart, not permanent node loss
+- alert on delivery records that have not reached ClickHouse; records are removed only after exact-event acknowledgement
+
+### Schema Compatibility
+
+Audit schema v2 uses `sandbox_audit_events`. Older `sandbox_events` rows lack trusted actor and signature data, so Sandbox0 retains them as legacy history rather than retroactively signing them.
+
+At startup, an audit-enabled cluster-gateway validates the actual ClickHouse engine, partition key, sorting key, and required columns. It refuses audit operations against an old or incompatible custom table. Existing CRs that persisted the old default table value are routed to the canonical v2 table.
+
+### Monitoring
+
+The ctld network runtime exports:
+
+- `sandbox0_netd_audit_ingest_events_total`
+- `sandbox0_netd_audit_ingest_batches_total`
+
+Alert on `persist_failed`, `corrupt`, `retrying`, `replay_failed`, and `ack_failed` results. Also monitor the ClickHouse service, cluster-gateway delivery PVC capacity and latency, and audit query errors.
+
+### External Controls
+
+Sandbox0 provides durable delivery, authenticated producer identity, tenant scoping, append-only application behavior, and tamper-evident row signatures. A production compliance design must also provide:
+
+- highly available ClickHouse storage
+- restricted ClickHouse mutation credentials
+- encrypted backups and tested restores
+- retention and legal-hold policy
+- clock synchronization
+- independent preservation of signing public keys or exported checkpoints
+
+A per-row signature does not protect against an administrator who can rewrite the complete table and all of its backups.
+
+## Disable Or Retain Features
+
+| Goal | Configuration |
+|------|---------------|
+| Disable all per-sandbox historical APIs | Omit `spec.sandboxObservability` or set `enabled: false` |
+| Keep logs and runtime metrics but disable audit | Omit `audit.enabled` or set it to `false` |
+| Disable metering | Omit `spec.metering` or set `enabled: false` |
+
+Disabling audit stops new facts but does not delete existing rows. Set `retention.auditDays` to your required retention period before enabling audit in production. Legacy `spec.sandboxObservability.type` fields remain accepted for compatibility, but new installs should configure ClickHouse through `spec.clickHouse`.

--- a/docs/template/page.mdx
+++ b/docs/template/page.mdx
@@ -42,7 +42,14 @@ You do not need a new template ID for every initialized environment. If the base
 
 For platform-owned builtin templates, the operator manages the warm pool. That lets teams reuse warm builtin capacity and store only the initialized rootfs state for their own dependency set instead of maintaining a separate custom template pool for each variation.
 
-Rootfs snapshots do not create template IDs and do not appear in `s0 template list`. Claiming with `snapshot_id` creates a new running sandbox from the selected rootfs snapshot while the requested template still controls image, default resources, mounts, services, and network defaults. A claim or runtime update can override only the sandbox memory limit; CPU is derived from the platform memory-per-CPU ratio with a `150m` minimum limit. Snapshot and fork accept a running or paused source sandbox. Restore remains useful for rolling back an existing paused sandbox. See [Snapshot And Restore](/docs/sandbox/snapshot-restore) for the lifecycle requirements and API workflow, or read [Initialize Once, Claim Many](/blog/2026-06/initialize-once-fork-many-custom-ai-agent-sandboxes) for the custom-rootfs pattern.
+Rootfs snapshot behavior:
+
+- snapshots do not create template IDs and do not appear in `s0 template list`
+- claiming with `snapshot_id` creates a new running sandbox; the requested template still supplies the image, default resources, mounts, services, and network defaults
+- resource overrides at claim or runtime update can change memory only; CPU follows the platform memory-per-CPU ratio with a `150m` minimum limit
+- snapshot and fork accept a running or paused source; restore rolls an existing paused sandbox back
+
+See [Snapshot And Restore](/docs/sandbox/snapshot-restore) for lifecycle requirements and APIs, or [Initialize Once, Claim Many](/blog/2026-06/initialize-once-fork-many-custom-ai-agent-sandboxes) for the custom-rootfs pattern.
 
 ---
 

--- a/docs/volume/mounts/page.mdx
+++ b/docs/volume/mounts/page.mdx
@@ -89,7 +89,15 @@ Mounted `RWO` volumes use one active writable owner at a time.
 
 This is what keeps file changes visible both from inside the sandbox and through the volume file API.
 
-Operator-managed deployments keep one active and one synchronized standby ctld process on each sandbox node. The standby holds a second channel for every kernel FUSE connection and the backend recovery state needed to take over without unpublishing the portal. The elected primary also owns kubelet CSI registration, which is recreated by the promoted standby so new mounts resume after a retry. This protects existing mounts and restores new mount operations after a single ctld process or Pod failure; it does not preserve mounts across a node reboot or simultaneous loss of both processes.
+Operator-managed deployments run an active and synchronized standby ctld process on each sandbox node.
+
+| Mechanism | Result |
+|-----------|--------|
+| A second channel for every kernel FUSE connection | The standby can take over without unpublishing existing portals |
+| Replicated backend recovery state | Existing mounts survive one ctld process or Pod failure |
+| CSI registration recreated after promotion | New mount operations resume after kubelet retries |
+
+This node-local failover does not preserve mounts across a node reboot or simultaneous loss of both ctld processes.
 
 ## File Operations
 


### PR DESCRIPTION
## Summary

- replace the dense observability block in Sandbox Overview with a compact capability table and a focused guide
- add separate user-facing and self-hosted observability pages so API behavior and operator configuration each have one clear home
- turn metering, audit delivery, pause/recovery, template snapshot, and ctld failover prose into tables and checklists
- add both new pages to the docs manifest and navigation

## Why

Sandbox Overview had accumulated implementation-level audit details in several long paragraphs. The same pattern appeared in Self-hosted Configuration and parts of the pause/resume, template, and volume guides. This keeps the technical guarantees while making overview and reference pages easier to scan and reducing duplicated explanations.

## Validation

- generated the docs registry successfully for all 46 manifest pages
- compiled all 46 MDX pages with the website MDX toolchain
- rendered both new MDX pages to static HTML
- `jq empty docs/manifest.json`
- `git diff --check`
