### PR TITLE
fix: reconcile stale starting sandbox lifecycle

### DIFF
--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -861,6 +861,157 @@ func TestResumePausedSandboxRuntimeJoinsResumingRuntime(t *testing.T) {
 	}
 }
 
+func TestResumePausedSandboxRuntimeReconcilesStaleStartingRecord(t *testing.T) {
+	pod := runtimeIdentityPod("ns-a", "pod-a", "sandbox-a")
+	pod.Annotations[controller.AnnotationRuntimeGeneration] = "4"
+	pod.Status.Phase = corev1.PodRunning
+	pod.Status.PodIP = "10.0.0.4"
+	markRuntimeIdentityPodReady(t, pod)
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-a": {
+			ID:                  "sandbox-a",
+			TeamID:              "team-a",
+			UserID:              "user-a",
+			TemplateID:          "default",
+			TemplateName:        "default",
+			TemplateNamespace:   "tpl-default",
+			Status:              SandboxStatusStarting,
+			CurrentPodName:      "pod-a",
+			CurrentPodNamespace: "ns-a",
+			RuntimeGeneration:   4,
+			TemplateSpec:        v1alpha1.SandboxTemplateSpec{},
+		},
+	}}
+	svc := &SandboxService{
+		k8sClient:    fake.NewSimpleClientset(pod.DeepCopy()),
+		podLister:    runtimeIdentityPodLister(t, pod),
+		sandboxStore: store,
+		config:       SandboxServiceConfig{ProcdPort: 49983},
+		logger:       zap.NewNop(),
+	}
+
+	sandbox, err := svc.ResumePausedSandboxRuntime(context.Background(), "sandbox-a")
+	if err != nil {
+		t.Fatalf("ResumePausedSandboxRuntime() error = %v, want nil", err)
+	}
+	if sandbox.Status != SandboxStatusRunning {
+		t.Fatalf("status = %q, want running", sandbox.Status)
+	}
+	if got := store.records["sandbox-a"].Status; got != SandboxStatusRunning {
+		t.Fatalf("stored status = %q, want running", got)
+	}
+	if store.saves != 1 {
+		t.Fatalf("store saves = %d, want 1", store.saves)
+	}
+}
+
+func TestResumePausedSandboxRuntimeReconcilesStaleStartingRecordWithoutPod(t *testing.T) {
+	idlePod := newClaimTestPod("tpl-default", "idle-a", "default", true)
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-a": {
+			ID:                "sandbox-a",
+			TeamID:            "team-a",
+			UserID:            "user-a",
+			TemplateID:        "default",
+			TemplateName:      "default",
+			TemplateNamespace: "tpl-default",
+			Status:            SandboxStatusStarting,
+			RuntimeGeneration: 3,
+			TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
+		},
+	}}
+	client := fake.NewSimpleClientset(idlePod.DeepCopy())
+	client.PrependReactor("patch", "pods", func(_ ktesting.Action) (bool, runtime.Object, error) {
+		if store.pauses != 1 {
+			t.Errorf("runtime pause reconciliations = %d, want 1", store.pauses)
+		}
+		txn, err := store.GetActiveLifecycleTxn(context.Background(), "sandbox-a")
+		if err != nil {
+			t.Errorf("GetActiveLifecycleTxn() error = %v", err)
+		} else if txn == nil || txn.Kind != SandboxLifecycleKindResume {
+			t.Errorf("active lifecycle transaction = %+v, want resume", txn)
+		}
+		return true, nil, errors.New("stop reconciled hot claim")
+	})
+	svc := &SandboxService{
+		k8sClient:    client,
+		podLister:    runtimeIdentityPodLister(t, idlePod),
+		sandboxStore: store,
+		config:       SandboxServiceConfig{ProcdPort: 49983},
+		clock:        fixedClock{now: time.Date(2026, time.March, 7, 12, 0, 0, 0, time.UTC)},
+		logger:       zap.NewNop(),
+	}
+
+	_, err := svc.ResumePausedSandboxRuntime(context.Background(), "sandbox-a")
+	if err == nil || !strings.Contains(err.Error(), "stop reconciled hot claim") {
+		t.Fatalf("ResumePausedSandboxRuntime() error = %v, want hot claim failure", err)
+	}
+	if store.pauses != 1 {
+		t.Fatalf("runtime pause reconciliations = %d, want 1", store.pauses)
+	}
+	if got := store.records["sandbox-a"].Status; got != SandboxStatusPaused {
+		t.Fatalf("stored status after failed claim = %q, want paused", got)
+	}
+}
+
+func TestRequestPauseSandboxRuntimeReconcilesStaleStartingRecord(t *testing.T) {
+	pod := runtimeIdentityPod("ns-a", "pod-a", "sandbox-a")
+	pod.Annotations[controller.AnnotationRuntimeGeneration] = "4"
+	pod.Status.Phase = corev1.PodRunning
+	pod.Status.PodIP = "10.0.0.4"
+	markRuntimeIdentityPodReady(t, pod)
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-a": {
+			ID:                  "sandbox-a",
+			TeamID:              "team-a",
+			UserID:              "user-a",
+			TemplateID:          "default",
+			TemplateName:        "default",
+			TemplateNamespace:   "tpl-default",
+			Status:              SandboxStatusStarting,
+			CurrentPodName:      "pod-a",
+			CurrentPodNamespace: "ns-a",
+			RuntimeGeneration:   4,
+			TemplateSpec:        v1alpha1.SandboxTemplateSpec{},
+		},
+	}}
+	enqueuer := &recordingPauseEnqueuer{}
+	svc := &SandboxService{
+		k8sClient:     fake.NewSimpleClientset(pod.DeepCopy()),
+		podLister:     runtimeIdentityPodLister(t, pod),
+		sandboxStore:  store,
+		ctldClient:    NewCtldClient(CtldClientConfig{}),
+		pauseEnqueuer: enqueuer,
+		config: SandboxServiceConfig{
+			CtldEnabled: true,
+			ProcdPort:   49983,
+		},
+		clock:  systemTime{},
+		logger: zap.NewNop(),
+	}
+
+	status, err := svc.RequestPauseSandboxRuntime(context.Background(), "sandbox-a")
+	if err != nil {
+		t.Fatalf("RequestPauseSandboxRuntime() error = %v, want nil", err)
+	}
+	if status != SandboxStatusRunning {
+		t.Fatalf("status = %q, want running", status)
+	}
+	if got := store.records["sandbox-a"].Status; got != SandboxStatusRunning {
+		t.Fatalf("stored status = %q, want running", got)
+	}
+	active, err := store.GetActiveLifecycleTxn(context.Background(), "sandbox-a")
+	if err != nil {
+		t.Fatalf("GetActiveLifecycleTxn() error = %v", err)
+	}
+	if active == nil || active.Kind != SandboxLifecycleKindPause {
+		t.Fatalf("active txn = %+v, want pause", active)
+	}
+	if len(enqueuer.calls) != 1 || enqueuer.calls[0] != "sandbox-a" {
+		t.Fatalf("pause queue calls = %#v, want sandbox-a", enqueuer.calls)
+	}
+}
+
 func TestResumeSandboxSingleflightPreventsConcurrentSandboxLocks(t *testing.T) {
 	pod := runtimeIdentityPod("ns-a", "pod-a", "sandbox-a")
 	pod.Annotations[controller.AnnotationRuntimeGeneration] = "4"

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -128,8 +128,6 @@ func (s *SandboxService) requestPauseSandboxRuntime(ctx context.Context, sandbox
 		case SandboxStatusPaused:
 			status = SandboxStatusPaused
 			return nil
-		case SandboxStatusStarting:
-			return k8serrors.NewConflict(schema.GroupResource{Resource: "sandbox"}, sandboxID, fmt.Errorf("sandbox lifecycle operation %q is in progress", record.Status))
 		}
 
 		pod, err := s.getSandboxPod(lockCtx, sandboxID)
@@ -145,6 +143,18 @@ func (s *SandboxService) requestPauseSandboxRuntime(ctx context.Context, sandbox
 		}
 		generation := runtimeGenerationFromPod(pod)
 		status = record.Status
+		if record.Status == SandboxStatusStarting {
+			// Without an active resume transaction, the Pod is authoritative for
+			// recovering a record left in starting by a timed-out resume request.
+			observedStatus := s.podToSandboxStatus(pod)
+			if observedStatus != SandboxStatusRunning {
+				return k8serrors.NewConflict(schema.GroupResource{Resource: "sandbox"}, sandboxID, fmt.Errorf("sandbox runtime is still %q", observedStatus))
+			}
+			if err := tx.SaveRuntime(lockCtx, sandboxID, pod.Namespace, pod.Name, observedStatus, generation, parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt), sandboxRuntimeMetadataFromPod(pod)); err != nil {
+				return err
+			}
+			status = observedStatus
+		}
 		source := strings.TrimSpace(opts.source)
 		if source == "" {
 			source = SandboxLifecycleSourceManual

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -72,12 +72,6 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 					return nil
 				}
 			}
-			switch locked.Status {
-			case SandboxStatusStarting:
-				waitErr = errSandboxLifecycleResuming
-				return nil
-			}
-
 			existing, getErr := s.getSandboxPod(lockCtx, sandboxID)
 			if getErr == nil {
 				if existing.DeletionTimestamp != nil {
@@ -123,6 +117,16 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 			}
 			if getErr != nil && !k8serrors.IsNotFound(getErr) {
 				return fmt.Errorf("get current runtime pod: %w", getErr)
+			}
+			if locked.Status == SandboxStatusStarting {
+				// No active resume transaction owns this state. Reconcile it before
+				// creating a replacement runtime so a timed-out caller cannot leave
+				// the durable record permanently stuck in starting.
+				if err := tx.MarkRuntimePaused(lockCtx, sandboxID, locked.RuntimeGeneration, s.now()); err != nil {
+					return err
+				}
+				waitErr = errSandboxRuntimeStateReconciled
+				return nil
 			}
 			if locked.Status != SandboxStatusPaused {
 				return k8serrors.NewConflict(corev1.Resource("sandbox"), sandboxID, fmt.Errorf("sandbox runtime for status %q is not available", locked.Status))
@@ -194,6 +198,8 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 			if err := s.waitForSandboxRuntimePodDeletion(ctx, deletingPodRef.namespace, deletingPodRef.name); err != nil {
 				return nil, err
 			}
+			continue
+		case errors.Is(err, errSandboxRuntimeStateReconciled):
 			continue
 		default:
 			return nil, err
@@ -335,6 +341,7 @@ var (
 	errSandboxLifecycleResuming            = errors.New("sandbox lifecycle resume is in progress")
 	errSandboxLifecycleRootFSCheckpointing = errors.New("sandbox lifecycle rootfs checkpoint is in progress")
 	errSandboxRuntimeDeleting              = errors.New("sandbox runtime pod deletion is in progress")
+	errSandboxRuntimeStateReconciled       = errors.New("sandbox runtime state was reconciled")
 )
 
 type sandboxRuntimePodRef struct {


### PR DESCRIPTION
## Summary

- Reconcile a stale starting record against the actual runtime Pod when no lifecycle transaction is active.
- Let pause proceed when that Pod is ready instead of permanently returning a lifecycle conflict.
- Reset a no-Pod stale starting record to paused before creating a replacement runtime.
- Add regression coverage for running-Pod and no-Pod recovery paths.

## Validation

- GOTOOLCHAIN=go1.25.0+auto go test -buildvcs=false -race -count=1 ./manager/...
- Final manager/pkg/service race suite after all regression cases were added
- golangci-lint v2.5.0: 0 issues
- Persistent Aliyun remote kind deployment reached Ready 10/10
- Remote fault injection passed: stale starting plus running Pod pauses; stale starting plus no Pod resumes; stale starting plus running Pod resumes immediately
- Remote test Sandbox cleaned up and ECS returned to StopCharging