### PR TITLE
fix(rootfs): make /tmp ephemeral and reduce restore I/O

### DIFF
--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
 	ctldha "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/ha"
 	ctldregistration "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/kubeletregistration"
 	ctldportal "github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/portal"
@@ -346,13 +347,18 @@ func runPrimary(parent context.Context, options primaryRunOptions) error {
 	}
 	podCache := buildNodePodCache(ctx, k8sClient, runtimeWatchHandler)
 	probeController := buildProbeController(k8sClient, obsProvider, podCache)
-	containerdRuntime := buildContainerdRuntime()
+	var rootFSMetricsRegistry prometheus.Registerer
+	if obsProvider != nil {
+		rootFSMetricsRegistry = obsProvider.MetricsRegistryOrNil()
+	}
+	rootFSObserver := ctldrootfs.NewObserver(rootFSMetricsRegistry, zapLogger)
+	containerdRuntime := buildContainerdRuntime(rootFSObserver)
 	defer containerdRuntime.Close()
 	runtimeMetricsHandle := startCtldRuntimeMetrics(ctx, ctldCfg, containerdRuntime, podCache, obsProvider, zapLogger)
 	httpServer := newHTTPServer(httpAddr, combinedController{
 		Controller:  probeController,
 		Portal:      portalManager,
-		RootFS:      buildRootFSController(ctx, storageCfg, objectStoreRequestMeter, portalManager, containerdRuntime),
+		RootFS:      buildRootFSController(ctx, storageCfg, objectStoreRequestMeter, portalManager, containerdRuntime, rootFSObserver),
 		ReadyCheck:  serviceReady,
 		HealthCheck: serviceHealthy,
 	})
@@ -583,22 +589,24 @@ func buildRootFSController(
 	requestObserver objectstore.RequestObserver,
 	portalResolver ctldrootfs.PortalResolver,
 	runtime *ctldrootfs.ContainerdRuntime,
+	observer *ctldrootfs.Observer,
 ) rootFSHandler {
 	store, err := buildRootFSObjectStore(storageCfg, requestObserver)
 	if err != nil {
 		log.Printf("ctld rootfs object store disabled: %v", err)
 	}
-	objectCache := buildRootFSObjectCache(ctx)
+	objectCache := buildRootFSObjectCache(ctx, observer)
 	return ctldrootfs.NewController(ctldrootfs.Config{
 		Runtime:        runtime,
 		Store:          store,
 		PortalResolver: portalResolver,
 		SnapshotDir:    filepath.Join(portalRoot, "rootfs", "prepared"),
 		ObjectCache:    objectCache,
+		Observer:       observer,
 	})
 }
 
-func buildContainerdRuntime() *ctldrootfs.ContainerdRuntime {
+func buildContainerdRuntime(observer *ctldrootfs.Observer) *ctldrootfs.ContainerdRuntime {
 	return ctldrootfs.NewContainerdRuntime(ctldrootfs.ContainerdRuntimeConfig{
 		CRIEndpoint:            criEndpoint,
 		ContainerdEndpoint:     containerdEndpoint,
@@ -608,10 +616,11 @@ func buildContainerdRuntime() *ctldrootfs.ContainerdRuntime {
 		ContainerdHostDataRoot: containerdHostDataRoot,
 		RootFSCacheDir:         filepath.Join(portalRoot, "rootfs"),
 		Namespace:              containerdNamespace,
+		Observer:               observer,
 	})
 }
 
-func buildRootFSObjectCache(ctx context.Context) *ctldrootfs.ObjectCache {
+func buildRootFSObjectCache(ctx context.Context, observer *ctldrootfs.Observer) *ctldrootfs.ObjectCache {
 	maxBytes, err := parseByteQuantity(rootFSObjectCacheMaxBytes)
 	if err != nil {
 		log.Printf("ctld rootfs object cache disabled: %v", err)
@@ -628,6 +637,7 @@ func buildRootFSObjectCache(ctx context.Context) *ctldrootfs.ObjectCache {
 		MinFreeBytes:  minFreeBytes,
 		MaxAge:        rootFSObjectCacheMaxAge,
 		SweepInterval: rootFSObjectCacheSweepInterval,
+		Observer:      observer,
 	})
 	if cache != nil {
 		cache.Start(ctx)

--- a/ctld/internal/ctld/rootfs/containerd_runtime.go
+++ b/ctld/internal/ctld/rootfs/containerd_runtime.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -20,6 +21,7 @@ import (
 	"github.com/containerd/containerd/v2/core/snapshots"
 	crootfs "github.com/containerd/containerd/v2/pkg/rootfs"
 	"github.com/containerd/continuity/fs"
+	"github.com/containerd/errdefs"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
@@ -60,6 +62,7 @@ type ContainerdRuntimeConfig struct {
 	CRIClient              criRuntimeService
 	CRIDialContext         func(ctx context.Context, endpoint string) (*grpc.ClientConn, error)
 	ContainerdClient       containerdClient
+	Observer               *Observer
 }
 
 type ContainerdRuntime struct {
@@ -78,6 +81,7 @@ type ContainerdRuntime struct {
 	criConn                *grpc.ClientConn
 	connectedCRIClient     criRuntimeService
 	containerdClient       containerdClient
+	observer               *Observer
 }
 
 type containerdClient interface {
@@ -139,6 +143,7 @@ func NewContainerdRuntime(cfg ContainerdRuntimeConfig) *ContainerdRuntime {
 		criClient:              cfg.CRIClient,
 		criDialContext:         cfg.CRIDialContext,
 		containerdClient:       cfg.ContainerdClient,
+		observer:               cfg.Observer,
 	}
 }
 
@@ -160,7 +165,11 @@ func (r *ContainerdRuntime) Inspect(ctx context.Context, target ctldapi.RootFSCo
 	return info, nil
 }
 
-func (r *ContainerdRuntime) CreateDiff(ctx context.Context, info ctldapi.RootFSInfo, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+func (r *ContainerdRuntime) CreateDiff(ctx context.Context, info ctldapi.RootFSInfo, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (result ctldapi.RootFSDiffDescriptor, resultReader io.ReadSeekCloser, resultErr error) {
+	started := time.Now()
+	defer func() {
+		r.observer.ObservePhase("save", "diff_create", started, resultErr)
+	}()
 	if strings.TrimSpace(info.SnapshotKey) == "" || strings.TrimSpace(info.Snapshotter) == "" {
 		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("%w: snapshot key and snapshotter are required", ErrBadRequest)
 	}
@@ -207,7 +216,11 @@ func (r *ContainerdRuntime) CreateDiff(ctx context.Context, info ctldapi.RootFSI
 	return rootDesc, closeReadSeekWithFunc{ReadSeekCloser: reader, closeFunc: closeClient}, nil
 }
 
-func (r *ContainerdRuntime) CreateDiffFromBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+func (r *ContainerdRuntime) CreateDiffFromBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (result ctldapi.RootFSDiffDescriptor, resultReader io.ReadSeekCloser, resultErr error) {
+	started := time.Now()
+	defer func() {
+		r.observer.ObservePhase("save", "incremental_diff_create", started, resultErr)
+	}()
 	if strings.TrimSpace(baselineLayerID) == "" {
 		return ctldapi.RootFSDiffDescriptor{}, nil, fmt.Errorf("%w: baseline layer id is required", ErrBadRequest)
 	}
@@ -233,7 +246,11 @@ func (r *ContainerdRuntime) CreateDiffFromBaseline(ctx context.Context, info ctl
 	return writeOverlayUpperDiffFromBaseline(ctx, baselineDir, upperdir, excludedPaths, portalPaths)
 }
 
-func (r *ContainerdRuntime) ApplyDiff(ctx context.Context, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor, reader io.Reader, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, error) {
+func (r *ContainerdRuntime) ApplyDiff(ctx context.Context, info ctldapi.RootFSInfo, desc ctldapi.RootFSDiffDescriptor, reader io.Reader, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (result ctldapi.RootFSDiffDescriptor, resultErr error) {
+	started := time.Now()
+	defer func() {
+		r.observer.ObservePhase("apply", "total", started, resultErr)
+	}()
 	if strings.TrimSpace(info.ContainerID) == "" {
 		return ctldapi.RootFSDiffDescriptor{}, fmt.Errorf("%w: container id is required", ErrBadRequest)
 	}
@@ -243,38 +260,97 @@ func (r *ContainerdRuntime) ApplyDiff(ctx context.Context, info ctldapi.RootFSIn
 	}
 	defer closeClient()
 
+	phaseStarted := time.Now()
 	liveRootFS, err := liveRootFSPath(r.containerdRoot, r.containerdHostRoot, r.namespace, info)
+	r.observer.ObservePhase("apply", "live_rootfs_lookup", phaseStarted, err)
 	if err != nil {
 		return ctldapi.RootFSDiffDescriptor{}, err
 	}
-	filteredDesc, filteredReader, err := filterRootFSDiffTarForApply(desc, reader, excludedPaths, portalPaths)
+	phaseStarted = time.Now()
+	ingestedDesc, stats, err := ingestRootFSDiffForApply(ctx, client.ContentStore(), desc, reader, excludedPaths, portalPaths)
+	r.observer.ObservePhase("apply", "filter_containerd_ingest", phaseStarted, err)
 	if err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, fmt.Errorf("filter rootfs diff: %w", err)
+		return ctldapi.RootFSDiffDescriptor{}, fmt.Errorf("ingest rootfs diff: %w", err)
 	}
-	defer filteredReader.Close()
-	desc = filteredDesc
-	reader = filteredReader
+	r.observer.ObservePhaseDuration("apply", "tar_filter", stats.FilterDuration, nil)
+	r.observer.ObservePhaseDuration("apply", "containerd_ingest", stats.IngestDuration, nil)
+	r.observer.ObserveBytes("apply", "portal", stats.PortalBytes)
+	desc = ingestedDesc
 
 	ociDesc, err := descriptorToOCI(desc)
 	if err != nil {
 		return ctldapi.RootFSDiffDescriptor{}, err
 	}
-	ref := "sandbox0-rootfs-apply-" + strings.ReplaceAll(ociDesc.Digest.String(), ":", "-")
-	if err := content.WriteBlob(ctx, client.ContentStore(), ref, reader, ociDesc); err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, fmt.Errorf("write rootfs diff into containerd content store: %w", err)
-	}
+	phaseStarted = time.Now()
 	applied, err := client.DiffService().Apply(ctx, ociDesc, []mount.Mount{{
 		Type:    "bind",
 		Source:  liveRootFS,
 		Options: []string{"rbind", "rw"},
 	}})
+	r.observer.ObservePhase("apply", "diff_apply", phaseStarted, err)
 	if err != nil {
 		return ctldapi.RootFSDiffDescriptor{}, err
 	}
 	return descriptorFromOCI(applied), nil
 }
 
-func (r *ContainerdRuntime) CaptureBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) error {
+func ingestRootFSDiffForApply(ctx context.Context, store content.Store, desc ctldapi.RootFSDiffDescriptor, reader io.Reader, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, rootFSDiffFilterStats, error) {
+	if !shouldFilterRootFSDiffTar(desc) {
+		ociDesc, err := descriptorToOCI(desc)
+		if err != nil {
+			return ctldapi.RootFSDiffDescriptor{}, rootFSDiffFilterStats{}, err
+		}
+		ref := rootFSApplyIngestRef(desc, excludedPaths, portalPaths)
+		started := time.Now()
+		if err := content.WriteBlob(ctx, store, ref, reader, ociDesc); err != nil {
+			return ctldapi.RootFSDiffDescriptor{}, rootFSDiffFilterStats{}, fmt.Errorf("write rootfs diff into containerd content store: %w", err)
+		}
+		return desc, rootFSDiffFilterStats{InputBytes: desc.Size, OutputBytes: desc.Size, IngestDuration: time.Since(started)}, nil
+	}
+
+	setupStarted := time.Now()
+	writer, err := content.OpenWriter(ctx, store, content.WithRef(rootFSApplyIngestRef(desc, excludedPaths, portalPaths)))
+	if err != nil {
+		return ctldapi.RootFSDiffDescriptor{}, rootFSDiffFilterStats{}, fmt.Errorf("open containerd rootfs content writer: %w", err)
+	}
+	defer writer.Close()
+	if err := writer.Truncate(0); err != nil {
+		return ctldapi.RootFSDiffDescriptor{}, rootFSDiffFilterStats{}, fmt.Errorf("reset containerd rootfs content writer: %w", err)
+	}
+	setupDuration := time.Since(setupStarted)
+
+	filteredDesc, stats, err := writeRootFSDiffTarForApply(writer, desc, reader, excludedPaths, portalPaths)
+	stats.IngestDuration += setupDuration
+	if err != nil {
+		return ctldapi.RootFSDiffDescriptor{}, stats, fmt.Errorf("filter rootfs diff into containerd content store: %w", err)
+	}
+	filteredDigest, err := digest.Parse(filteredDesc.Digest)
+	if err != nil {
+		return ctldapi.RootFSDiffDescriptor{}, stats, fmt.Errorf("parse filtered rootfs digest: %w", err)
+	}
+	commitStarted := time.Now()
+	commitErr := writer.Commit(ctx, filteredDesc.Size, filteredDigest)
+	stats.IngestDuration += time.Since(commitStarted)
+	if commitErr != nil && !errdefs.IsAlreadyExists(commitErr) {
+		return ctldapi.RootFSDiffDescriptor{}, stats, fmt.Errorf("commit rootfs diff to containerd content store: %w", commitErr)
+	}
+	return filteredDesc, stats, nil
+}
+
+func rootFSApplyIngestRef(desc ctldapi.RootFSDiffDescriptor, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) string {
+	portalPaths = filterRootFSPortalPaths(portalPaths, excludedPaths)
+	filter := newRootFSPathFilter(rootFSExcludedPathsWithPortals(excludedPaths, portalPaths))
+	paths := append([]string(nil), filter.excluded...)
+	sort.Strings(paths)
+	sum := sha256.Sum256([]byte(strings.TrimSpace(desc.Digest) + "\x00" + strings.Join(paths, "\x00")))
+	return "sandbox0-rootfs-apply-" + hex.EncodeToString(sum[:])
+}
+
+func (r *ContainerdRuntime) CaptureBaseline(ctx context.Context, info ctldapi.RootFSInfo, baselineLayerID string, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (resultErr error) {
+	started := time.Now()
+	defer func() {
+		r.observer.ObservePhase("apply", "baseline_capture", started, resultErr)
+	}()
 	if strings.TrimSpace(baselineLayerID) == "" {
 		return fmt.Errorf("%w: baseline layer id is required", ErrBadRequest)
 	}
@@ -303,12 +379,18 @@ func (r *ContainerdRuntime) CaptureBaseline(ctx context.Context, info ctldapi.Ro
 			_ = os.RemoveAll(tmp)
 		}
 	}()
+	phaseStarted := time.Now()
 	if err := fs.CopyDir(tmp, upperdir); err != nil {
+		r.observer.ObservePhase("apply", "baseline_copy", phaseStarted, err)
 		return fmt.Errorf("copy rootfs baseline: %w", err)
 	}
+	r.observer.ObservePhase("apply", "baseline_copy", phaseStarted, nil)
+	phaseStarted = time.Now()
 	if err := newRootFSPathFilter(rootFSExcludedPathsWithPortals(excludedPaths, portalPaths)).RemoveAll(tmp); err != nil {
+		r.observer.ObservePhase("apply", "baseline_filter", phaseStarted, err)
 		return fmt.Errorf("filter rootfs baseline: %w", err)
 	}
+	r.observer.ObservePhase("apply", "baseline_filter", phaseStarted, nil)
 	if err := os.RemoveAll(target); err != nil {
 		return fmt.Errorf("replace rootfs baseline: %w", err)
 	}

--- a/ctld/internal/ctld/rootfs/containerd_runtime_test.go
+++ b/ctld/internal/ctld/rootfs/containerd_runtime_test.go
@@ -1,6 +1,8 @@
 package rootfs
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -11,6 +13,10 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/containerd/containerd/v2/core/content"
+	contentlocal "github.com/containerd/containerd/v2/plugins/content/local"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,6 +26,46 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
+
+func TestIngestRootFSDiffForApplyStreamsFilteredLayerIntoContentStore(t *testing.T) {
+	var input bytes.Buffer
+	tarWriter := tar.NewWriter(&input)
+	writeTarEntry(t, tarWriter, "tmp/legacy-download", []byte("ephemeral"), 0o644)
+	writeTarEntry(t, tarWriter, "root/sentinel", []byte("persistent"), 0o644)
+	writeTarEntry(t, tarWriter, "var/tmp/state", []byte("persistent-var-tmp"), 0o644)
+	require.NoError(t, tarWriter.Close())
+
+	inputDigest := digest.FromBytes(input.Bytes())
+	desc := ctldapi.RootFSDiffDescriptor{
+		MediaType: ocispec.MediaTypeImageLayer,
+		Digest:    inputDigest.String(),
+		DiffID:    inputDigest.String(),
+		Size:      int64(input.Len()),
+		ObjectKey: "rootfs/legacy.tar",
+	}
+	store, err := contentlocal.NewStore(t.TempDir())
+	require.NoError(t, err)
+
+	filtered, stats, err := ingestRootFSDiffForApply(context.Background(), store, desc, bytes.NewReader(input.Bytes()), nil, nil)
+	require.NoError(t, err)
+	assert.NotEqual(t, desc.Digest, filtered.Digest)
+	assert.Equal(t, int64(input.Len()), stats.InputBytes)
+	assert.Equal(t, filtered.Size, stats.OutputBytes)
+	assert.Equal(t, int64(len("ephemeral")), stats.ExcludedBytes)
+
+	ociDesc, err := descriptorToOCI(filtered)
+	require.NoError(t, err)
+	blob, err := content.ReadBlob(context.Background(), store, ociDesc)
+	require.NoError(t, err)
+	entries := readTarEntries(t, bytes.NewReader(blob))
+	assert.NotContains(t, entries, "tmp/legacy-download")
+	assert.Contains(t, entries, "root/sentinel")
+	assert.Contains(t, entries, "var/tmp/state")
+
+	filteredAgain, _, err := ingestRootFSDiffForApply(context.Background(), store, desc, bytes.NewReader(input.Bytes()), nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, filtered.Digest, filteredAgain.Digest)
+}
 
 func TestRuntimeFamily(t *testing.T) {
 	tests := []struct {

--- a/ctld/internal/ctld/rootfs/controller.go
+++ b/ctld/internal/ctld/rootfs/controller.go
@@ -43,6 +43,7 @@ type Config struct {
 	PortalResolver   PortalResolver
 	SnapshotDir      string
 	ObjectCache      *ObjectCache
+	Observer         *Observer
 }
 
 type Controller struct {
@@ -52,6 +53,7 @@ type Controller struct {
 	portalResolver   PortalResolver
 	snapshotDir      string
 	objectCache      *ObjectCache
+	observer         *Observer
 }
 
 func NewController(cfg Config) *Controller {
@@ -66,6 +68,7 @@ func NewController(cfg Config) *Controller {
 		portalResolver:   cfg.PortalResolver,
 		snapshotDir:      cfg.SnapshotDir,
 		objectCache:      cfg.ObjectCache,
+		observer:         cfg.Observer,
 	}
 }
 
@@ -108,7 +111,11 @@ func (c *Controller) SaveRootFS(r *http.Request, req ctldapi.SaveRootFSRequest) 
 	return ctldapi.SaveRootFSResponse{Info: published.Info, Descriptor: published.Descriptor}, http.StatusOK
 }
 
-func (c *Controller) PrepareRootFSSnapshot(r *http.Request, req ctldapi.PrepareRootFSSnapshotRequest) (ctldapi.PrepareRootFSSnapshotResponse, int) {
+func (c *Controller) PrepareRootFSSnapshot(r *http.Request, req ctldapi.PrepareRootFSSnapshotRequest) (response ctldapi.PrepareRootFSSnapshotResponse, status int) {
+	started := time.Now()
+	defer func() {
+		c.observer.ObserveOperation("save", req.Target, -1, -1, response.Descriptor.Size, -1, started, status, response.Error)
+	}()
 	if err := validateTarget(req.Target); err != nil {
 		return ctldapi.PrepareRootFSSnapshotResponse{Error: err.Error()}, http.StatusBadRequest
 	}
@@ -175,7 +182,12 @@ func (c *Controller) AbortRootFSSnapshot(_ *http.Request, req ctldapi.AbortRootF
 	return ctldapi.AbortRootFSSnapshotResponse{Aborted: true}, http.StatusOK
 }
 
-func (c *Controller) ApplyRootFS(r *http.Request, req ctldapi.ApplyRootFSRequest) (ctldapi.ApplyRootFSResponse, int) {
+func (c *Controller) ApplyRootFS(r *http.Request, req ctldapi.ApplyRootFSRequest) (response ctldapi.ApplyRootFSResponse, status int) {
+	started := time.Now()
+	chainDepth, inputBytes := rootFSApplyInputStats(req)
+	defer func() {
+		c.observer.ObserveOperation("apply", req.Target, chainDepth, inputBytes, rootFSApplyOutputBytes(response), -1, started, status, response.Error)
+	}()
 	if err := validateTarget(req.Target); err != nil {
 		return ctldapi.ApplyRootFSResponse{Error: err.Error()}, http.StatusBadRequest
 	}
@@ -276,6 +288,32 @@ func (c *Controller) applyDescriptor(ctx context.Context, info ctldapi.RootFSInf
 	}
 	applied.ObjectKey = desc.ObjectKey
 	return applied, nil
+}
+
+func rootFSApplyInputStats(req ctldapi.ApplyRootFSRequest) (int, int64) {
+	if len(req.Layers) == 0 {
+		return 1, req.Descriptor.Size
+	}
+	var bytes int64
+	for _, layer := range req.Layers {
+		if layer.Descriptor.Size > 0 {
+			bytes += layer.Descriptor.Size
+		}
+	}
+	return len(req.Layers), bytes
+}
+
+func rootFSApplyOutputBytes(response ctldapi.ApplyRootFSResponse) int64 {
+	if len(response.Layers) == 0 {
+		return response.Descriptor.Size
+	}
+	var bytes int64
+	for _, layer := range response.Layers {
+		if layer.Descriptor.Size > 0 {
+			bytes += layer.Descriptor.Size
+		}
+	}
+	return bytes
 }
 
 type preparedRootFSSnapshot struct {

--- a/ctld/internal/ctld/rootfs/object_cache.go
+++ b/ctld/internal/ctld/rootfs/object_cache.go
@@ -25,6 +25,7 @@ type ObjectCacheConfig struct {
 	MinFreeBytes  int64
 	MaxAge        time.Duration
 	SweepInterval time.Duration
+	Observer      *Observer
 }
 
 type ObjectCache struct {
@@ -34,6 +35,15 @@ type ObjectCache struct {
 	maxAge        time.Duration
 	sweepInterval time.Duration
 	mu            sync.Mutex
+	validated     map[string]objectCacheFileIdentity
+	observer      *Observer
+}
+
+type objectCacheFileIdentity struct {
+	device      uint64
+	inode       uint64
+	size        int64
+	modTimeNano int64
 }
 
 type objectCacheEntry struct {
@@ -60,6 +70,8 @@ func NewObjectCache(cfg ObjectCacheConfig) *ObjectCache {
 		minFreeBytes:  cfg.MinFreeBytes,
 		maxAge:        cfg.MaxAge,
 		sweepInterval: interval,
+		validated:     make(map[string]objectCacheFileIdentity),
+		observer:      cfg.Observer,
 	}
 }
 
@@ -79,19 +91,30 @@ func (c *ObjectCache) GetOrFetch(ctx context.Context, store objectstore.Store, d
 		reader, err := store.Get(desc.ObjectKey, 0, -1)
 		return reader, false, err
 	}
+	started := time.Now()
 	if reader, ok, err := c.Open(desc); err != nil {
+		c.observer.ObservePhase("apply", "cache_lookup", started, err)
+		c.observer.ObserveCache("error")
 		return nil, false, err
 	} else if ok {
+		c.observer.ObservePhase("apply", "cache_lookup", started, nil)
+		c.observer.ObserveCache("hit")
 		return reader, true, nil
 	}
+	c.observer.ObservePhase("apply", "cache_lookup", started, nil)
+	c.observer.ObserveCache("miss")
+	started = time.Now()
 	reader, err := store.Get(desc.ObjectKey, 0, -1)
 	if err != nil {
+		c.observer.ObservePhase("apply", "object_fetch_cache_fill", started, err)
 		return nil, false, err
 	}
 	defer reader.Close()
 	if err := c.Put(ctx, desc, reader); err != nil {
+		c.observer.ObservePhase("apply", "object_fetch_cache_fill", started, err)
 		return c.fetchUncached(desc, store, err)
 	}
+	c.observer.ObservePhase("apply", "object_fetch_cache_fill", started, nil)
 	cached, ok, err := c.Open(desc)
 	if err != nil {
 		return c.fetchUncached(desc, store, err)
@@ -120,21 +143,30 @@ func (c *ObjectCache) Open(desc ctldapi.RootFSDiffDescriptor) (io.ReadCloser, bo
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if ok, err := c.validateFile(desc, path); err != nil {
-		_ = os.Remove(path)
-		return nil, false, err
-	} else if !ok {
-		return nil, false, nil
-	}
 	file, err := os.Open(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
+			delete(c.validated, path)
 			return nil, false, nil
 		}
 		return nil, false, err
 	}
+	if ok, err := c.validateOpenFile(desc, path, file); err != nil {
+		_ = file.Close()
+		delete(c.validated, path)
+		_ = os.Remove(path)
+		return nil, false, err
+	} else if !ok {
+		_ = file.Close()
+		delete(c.validated, path)
+		_ = os.Remove(path)
+		return nil, false, nil
+	}
 	now := time.Now()
 	_ = os.Chtimes(path, now, now)
+	if info, statErr := file.Stat(); statErr == nil {
+		c.validated[path] = objectCacheIdentity(info)
+	}
 	return file, true, nil
 }
 
@@ -169,6 +201,9 @@ func (c *ObjectCache) PutFile(ctx context.Context, desc ctldapi.RootFSDiffDescri
 				_ = os.Remove(tmpPath)
 			}
 		}()
+		if err := verifyRootFSObjectFile(desc, tmpPath); err != nil {
+			return err
+		}
 		return c.publishTemp(path, tmpPath, &removeTmp)
 	}
 	source, err := os.Open(sourcePath)
@@ -237,6 +272,9 @@ func (c *ObjectCache) publishTemp(path, tmpPath string, removeTmp *bool) error {
 	}
 	now := time.Now()
 	_ = os.Chtimes(path, now, now)
+	if info, err := os.Stat(path); err == nil {
+		c.validated[path] = objectCacheIdentity(info)
+	}
 	return c.sweepLocked()
 }
 
@@ -261,6 +299,7 @@ func (c *ObjectCache) sweepLocked() error {
 		for _, entry := range entries {
 			if now.Sub(entry.modTime) > c.maxAge {
 				_ = os.Remove(entry.path)
+				delete(c.validated, entry.path)
 				continue
 			}
 			kept = append(kept, entry)
@@ -276,6 +315,7 @@ func (c *ObjectCache) sweepLocked() error {
 			break
 		}
 		if err := os.Remove(entry.path); err == nil {
+			delete(c.validated, entry.path)
 			total -= entry.size
 		}
 	}
@@ -297,6 +337,7 @@ func (c *ObjectCache) entriesLocked() ([]objectCacheEntry, int64, error) {
 		}
 		if strings.HasPrefix(entry.Name(), ".") {
 			_ = os.Remove(path)
+			delete(c.validated, path)
 			return nil
 		}
 		info, err := entry.Info()
@@ -329,40 +370,103 @@ func (c *ObjectCache) hasMinFreeLocked() bool {
 	return free >= c.minFreeBytes
 }
 
-func (c *ObjectCache) validateFile(desc ctldapi.RootFSDiffDescriptor, path string) (bool, error) {
-	info, err := os.Stat(path)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return false, nil
+func (c *ObjectCache) validateOpenFile(desc ctldapi.RootFSDiffDescriptor, path string, file *os.File) (valid bool, resultErr error) {
+	var validationStarted time.Time
+	defer func() {
+		if !validationStarted.IsZero() {
+			c.observer.ObservePhase("apply", "cache_validation", validationStarted, resultErr)
 		}
+	}()
+	info, err := file.Stat()
+	if err != nil {
 		return false, err
 	}
 	if !info.Mode().IsRegular() {
-		_ = os.Remove(path)
 		return false, nil
 	}
 	if desc.Size > 0 && info.Size() != desc.Size {
-		_ = os.Remove(path)
 		return false, nil
 	}
-	file, err := os.Open(path)
-	if err != nil {
-		return false, err
+	identity := objectCacheIdentity(info)
+	if validated, ok := c.validated[path]; ok && validated == identity {
+		return true, nil
 	}
-	defer file.Close()
+	validationStarted = time.Now()
 	d, err := godigest.Parse(strings.TrimSpace(desc.Digest))
 	if err != nil {
 		return false, fmt.Errorf("parse rootfs object digest: %w", err)
 	}
 	verifier := d.Verifier()
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return false, err
+	}
 	if _, err := io.Copy(verifier, file); err != nil {
 		return false, err
 	}
+	after, err := file.Stat()
+	if err != nil {
+		return false, err
+	}
+	if objectCacheIdentity(after) != identity {
+		return false, fmt.Errorf("rootfs object changed while validating %s", desc.Digest)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return false, err
+	}
 	if !verifier.Verified() {
-		_ = os.Remove(path)
 		return false, nil
 	}
+	c.validated[path] = identity
 	return true, nil
+}
+
+func verifyRootFSObjectFile(desc ctldapi.RootFSDiffDescriptor, path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("rootfs object is not a regular file")
+	}
+	if desc.Size > 0 && info.Size() != desc.Size {
+		return fmt.Errorf("rootfs object size mismatch: expected %d, got %d", desc.Size, info.Size())
+	}
+	d, err := godigest.Parse(strings.TrimSpace(desc.Digest))
+	if err != nil {
+		return fmt.Errorf("parse rootfs object digest: %w", err)
+	}
+	verifier := d.Verifier()
+	if _, err := io.Copy(verifier, file); err != nil {
+		return err
+	}
+	after, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if objectCacheIdentity(after) != objectCacheIdentity(info) {
+		return fmt.Errorf("rootfs object changed while validating %s", desc.Digest)
+	}
+	if !verifier.Verified() {
+		return fmt.Errorf("rootfs object digest mismatch: expected %s", d.String())
+	}
+	return nil
+}
+
+func objectCacheIdentity(info os.FileInfo) objectCacheFileIdentity {
+	identity := objectCacheFileIdentity{
+		size:        info.Size(),
+		modTimeNano: info.ModTime().UnixNano(),
+	}
+	if stat, ok := info.Sys().(*unix.Stat_t); ok {
+		identity.device = uint64(stat.Dev)
+		identity.inode = stat.Ino
+	}
+	return identity
 }
 
 func (c *ObjectCache) pathForDescriptor(desc ctldapi.RootFSDiffDescriptor) (string, error) {

--- a/ctld/internal/ctld/rootfs/object_cache_test.go
+++ b/ctld/internal/ctld/rootfs/object_cache_test.go
@@ -1,0 +1,98 @@
+package rootfs
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestObjectCacheReusesValidatedFileIdentityAndRevalidatesChanges(t *testing.T) {
+	payload := "rootfs-cache-payload"
+	desc := objectCacheDescriptor("rootfs/cache.tar", payload)
+	cache := NewObjectCache(ObjectCacheConfig{Dir: t.TempDir(), MaxBytes: 1 << 20})
+	require.NoError(t, cache.Put(context.Background(), desc, strings.NewReader(payload)))
+
+	path, err := cache.pathForDescriptor(desc)
+	require.NoError(t, err)
+	cache.mu.Lock()
+	_, validatedOnPut := cache.validated[path]
+	cache.mu.Unlock()
+	assert.True(t, validatedOnPut)
+
+	reader, ok, err := cache.Open(desc)
+	require.NoError(t, err)
+	require.True(t, ok)
+	got, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+	assert.Equal(t, payload, string(got))
+
+	badPayload := strings.Repeat("x", len(payload))
+	require.NoError(t, os.WriteFile(path, []byte(badPayload), 0o600))
+	future := time.Now().Add(time.Second)
+	require.NoError(t, os.Chtimes(path, future, future))
+
+	reader, ok, err = cache.Open(desc)
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Nil(t, reader)
+	_, err = os.Stat(path)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestObjectCacheRevalidatesExistingFileAfterRestart(t *testing.T) {
+	payload := "restart-cache-payload"
+	desc := objectCacheDescriptor("rootfs/restart.tar", payload)
+	cacheDir := t.TempDir()
+	cache := NewObjectCache(ObjectCacheConfig{Dir: cacheDir, MaxBytes: 1 << 20})
+	require.NoError(t, cache.Put(context.Background(), desc, strings.NewReader(payload)))
+
+	path, err := cache.pathForDescriptor(desc)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, []byte(strings.Repeat("z", len(payload))), 0o600))
+
+	restarted := NewObjectCache(ObjectCacheConfig{Dir: cacheDir, MaxBytes: 1 << 20})
+	reader, ok, err := restarted.Open(desc)
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Nil(t, reader)
+}
+
+func TestObjectCachePutFileValidatesBeforePublishing(t *testing.T) {
+	payload := "prepared-rootfs"
+	desc := objectCacheDescriptor("rootfs/prepared.tar", payload)
+	cache := NewObjectCache(ObjectCacheConfig{Dir: t.TempDir(), MaxBytes: 1 << 20})
+	source := t.TempDir() + "/prepared.tar"
+	require.NoError(t, os.WriteFile(source, []byte(strings.Repeat("x", len(payload))), 0o600))
+
+	err := cache.PutFile(context.Background(), desc, source)
+	require.ErrorContains(t, err, "digest mismatch")
+
+	require.NoError(t, os.WriteFile(source, []byte(payload), 0o600))
+	require.NoError(t, cache.PutFile(context.Background(), desc, source))
+	reader, ok, err := cache.Open(desc)
+	require.NoError(t, err)
+	require.True(t, ok)
+	defer reader.Close()
+	got, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, payload, string(got))
+}
+
+func objectCacheDescriptor(objectKey, payload string) ctldapi.RootFSDiffDescriptor {
+	return ctldapi.RootFSDiffDescriptor{
+		MediaType: "application/vnd.oci.image.layer.v1.tar",
+		Digest:    digest.FromString(payload).String(),
+		DiffID:    digest.FromString(payload).String(),
+		Size:      int64(len(payload)),
+		ObjectKey: objectKey,
+	}
+}

--- a/ctld/internal/ctld/rootfs/observer.go
+++ b/ctld/internal/ctld/rootfs/observer.go
@@ -1,0 +1,161 @@
+package rootfs
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	"go.uber.org/zap"
+)
+
+const (
+	rootFSLargeCheckpointBytes  = 512 << 20
+	rootFSSlowOperationDuration = 10 * time.Second
+)
+
+// Observer records node-local rootfs checkpoint phases without adding
+// sandbox identifiers to metric labels.
+type Observer struct {
+	logger            *zap.Logger
+	operationDuration *prometheus.HistogramVec
+	phaseDuration     *prometheus.HistogramVec
+	checkpointBytes   *prometheus.HistogramVec
+	chainDepth        *prometheus.HistogramVec
+	cacheRequests     *prometheus.CounterVec
+}
+
+func NewObserver(registry prometheus.Registerer, logger *zap.Logger) *Observer {
+	observer := &Observer{logger: logger}
+	if registry == nil {
+		return observer
+	}
+	factory := promauto.With(registry)
+	durationBuckets := []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60, 120, 300}
+	byteBuckets := []float64{1 << 10, 1 << 20, 16 << 20, 64 << 20, 256 << 20, 512 << 20, 1 << 30, 2 << 30, 4 << 30}
+	observer.operationDuration = factory.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "ctld_rootfs_operation_duration_seconds",
+		Help:    "Duration of ctld rootfs checkpoint operations",
+		Buckets: durationBuckets,
+	}, []string{"operation", "status"})
+	observer.phaseDuration = factory.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "ctld_rootfs_phase_duration_seconds",
+		Help:    "Duration of ctld rootfs checkpoint phases",
+		Buckets: durationBuckets,
+	}, []string{"operation", "phase", "status"})
+	observer.checkpointBytes = factory.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "ctld_rootfs_checkpoint_bytes",
+		Help:    "Rootfs checkpoint bytes by operation and byte class",
+		Buckets: byteBuckets,
+	}, []string{"operation", "kind"})
+	observer.chainDepth = factory.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "ctld_rootfs_checkpoint_chain_depth",
+		Help:    "Rootfs checkpoint layer chain depth by operation",
+		Buckets: []float64{1, 2, 4, 8, 16, 32, 64},
+	}, []string{"operation"})
+	observer.cacheRequests = factory.NewCounterVec(prometheus.CounterOpts{
+		Name: "ctld_rootfs_object_cache_requests_total",
+		Help: "Rootfs object cache requests by result",
+	}, []string{"result"})
+	return observer
+}
+
+func (o *Observer) ObservePhase(operation, phase string, started time.Time, err error) {
+	if o == nil {
+		return
+	}
+	o.ObservePhaseDuration(operation, phase, time.Since(started), err)
+}
+
+func (o *Observer) ObservePhaseDuration(operation, phase string, duration time.Duration, err error) {
+	if o == nil {
+		return
+	}
+	status := "success"
+	if err != nil {
+		status = "error"
+	}
+	if o.phaseDuration != nil {
+		o.phaseDuration.WithLabelValues(operation, phase, status).Observe(duration.Seconds())
+	}
+	if o.logger != nil {
+		fields := []zap.Field{
+			zap.String("operation", operation),
+			zap.String("phase", phase),
+			zap.String("status", status),
+			zap.Duration("duration", duration),
+		}
+		if err != nil {
+			fields = append(fields, zap.Error(err))
+		}
+		o.logger.Debug("Rootfs checkpoint phase completed", fields...)
+	}
+}
+
+func (o *Observer) ObserveBytes(operation, kind string, bytes int64) {
+	if o == nil || o.checkpointBytes == nil || bytes < 0 {
+		return
+	}
+	o.checkpointBytes.WithLabelValues(operation, kind).Observe(float64(bytes))
+}
+
+func (o *Observer) ObserveCache(result string) {
+	if o != nil && o.cacheRequests != nil {
+		o.cacheRequests.WithLabelValues(result).Inc()
+	}
+}
+
+func (o *Observer) ObserveOperation(operation string, target ctldapi.RootFSContainerRef, chainDepth int, inputBytes, outputBytes, excludedBytes int64, started time.Time, statusCode int, message string) {
+	if o == nil {
+		return
+	}
+	duration := time.Since(started)
+	status := "success"
+	if statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices {
+		status = "error"
+	}
+	if status == "success" && excludedBytes < 0 && inputBytes >= outputBytes && outputBytes >= 0 {
+		excludedBytes = inputBytes - outputBytes
+	}
+	if o.operationDuration != nil {
+		o.operationDuration.WithLabelValues(operation, status).Observe(duration.Seconds())
+	}
+	if o.chainDepth != nil && chainDepth > 0 {
+		o.chainDepth.WithLabelValues(operation).Observe(float64(chainDepth))
+	}
+	o.ObserveBytes(operation, "input", inputBytes)
+	o.ObserveBytes(operation, "output", outputBytes)
+	o.ObserveBytes(operation, "excluded", excludedBytes)
+	if o.logger == nil {
+		return
+	}
+	fields := []zap.Field{
+		zap.String("operation", operation),
+		zap.String("status", status),
+		zap.Duration("duration", duration),
+		zap.String("namespace", target.Namespace),
+		zap.String("pod", target.PodName),
+		zap.String("container", target.ContainerName),
+	}
+	if chainDepth >= 0 {
+		fields = append(fields, zap.Int("chain_depth", chainDepth))
+	}
+	if inputBytes >= 0 {
+		fields = append(fields, zap.Int64("input_bytes", inputBytes))
+	}
+	if outputBytes >= 0 {
+		fields = append(fields, zap.Int64("output_bytes", outputBytes))
+	}
+	if excludedBytes >= 0 {
+		fields = append(fields, zap.Int64("excluded_bytes", excludedBytes))
+	}
+	if message != "" {
+		fields = append(fields, zap.String("error", message))
+	}
+	if duration >= rootFSSlowOperationDuration || inputBytes >= rootFSLargeCheckpointBytes || outputBytes >= rootFSLargeCheckpointBytes {
+		o.logger.Warn("Slow or large rootfs checkpoint operation", fields...)
+		return
+	}
+	o.logger.Info("Rootfs checkpoint operation completed", fields...)
+}

--- a/ctld/internal/ctld/rootfs/observer_test.go
+++ b/ctld/internal/ctld/rootfs/observer_test.go
@@ -1,0 +1,58 @@
+package rootfs
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRootFSObserverRegistersOperationPhaseSizeAndCacheMetrics(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	observer := NewObserver(registry, nil)
+	observer.ObservePhaseDuration("apply", "tar_filter", 25*time.Millisecond, nil)
+	observer.ObserveCache("hit")
+	observer.ObserveOperation("apply", ctldapi.RootFSContainerRef{
+		Namespace:     "tpl-default",
+		PodName:       "sandbox-pod",
+		ContainerName: "procd",
+	}, 2, 2048, 1024, -1, time.Now().Add(-time.Second), http.StatusOK, "")
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+	names := make(map[string]struct{}, len(families))
+	for _, family := range families {
+		names[family.GetName()] = struct{}{}
+	}
+	for _, name := range []string{
+		"ctld_rootfs_operation_duration_seconds",
+		"ctld_rootfs_phase_duration_seconds",
+		"ctld_rootfs_checkpoint_bytes",
+		"ctld_rootfs_checkpoint_chain_depth",
+		"ctld_rootfs_object_cache_requests_total",
+	} {
+		_, ok := names[name]
+		assert.True(t, ok, "metric family %s is registered", name)
+	}
+	for _, family := range families {
+		if family.GetName() != "ctld_rootfs_checkpoint_bytes" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			labels := make(map[string]string, len(metric.GetLabel()))
+			for _, label := range metric.GetLabel() {
+				labels[label.GetName()] = label.GetValue()
+			}
+			if labels["operation"] == "apply" && labels["kind"] == "excluded" {
+				assert.Equal(t, uint64(1), metric.GetHistogram().GetSampleCount())
+				assert.Equal(t, float64(1024), metric.GetHistogram().GetSampleSum())
+				return
+			}
+		}
+	}
+	t.Fatal("excluded checkpoint byte metric not found")
+}

--- a/ctld/internal/ctld/rootfs/overlay_diff.go
+++ b/ctld/internal/ctld/rootfs/overlay_diff.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/core/snapshots"
@@ -23,8 +24,18 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var defaultRootFSSnapshotExcludedPaths = []string{
-	"/procd",
+type rootFSDefaultExcludedPath struct {
+	path           string
+	preserveOpaque bool
+}
+
+// defaultRootFSSnapshotExcludedPaths is the single source of truth for paths
+// that belong to a fresh sandbox runtime instead of its persistent rootfs.
+// preserveOpaque prevents a legacy ancestor whiteout from clearing the clean
+// carrier state for that path during restore.
+var defaultRootFSSnapshotExcludedPaths = []rootFSDefaultExcludedPath{
+	{path: "/procd"},
+	{path: "/tmp", preserveOpaque: true},
 }
 
 func (r *ContainerdRuntime) createOverlayUpperDiff(ctx context.Context, client containerdClient, info ctldapi.RootFSInfo, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, bool, error) {
@@ -323,7 +334,7 @@ func newRootFSPathFilter(extraPaths []string) rootFSPathFilter {
 		}
 	}
 	for _, value := range defaultRootFSSnapshotExcludedPaths {
-		add(value, false)
+		add(value.path, value.preserveOpaque)
 	}
 	for _, value := range extraPaths {
 		add(value, true)
@@ -376,6 +387,9 @@ func (f rootFSPathFilter) ChangeFunc(next fs.ChangeFunc) fs.ChangeFunc {
 
 func (f rootFSPathFilter) AffectsOpaquePreservedPath(dir string) bool {
 	clean := cleanRootFSPath(dir)
+	if clean == "/" {
+		return len(f.opaquePreserve) > 0
+	}
 	for _, preserved := range f.opaquePreserve {
 		if clean == preserved || strings.HasPrefix(preserved, clean+"/") {
 			return true
@@ -465,30 +479,27 @@ func filterRootFSDiffTarForSave(desc ctldapi.RootFSDiffDescriptor, reader io.Rea
 	return appendPortalRootFSToDiff(filteredDesc, filteredReader, portalPaths)
 }
 
-func filterRootFSDiffTarForApply(desc ctldapi.RootFSDiffDescriptor, reader io.Reader, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {
+type rootFSDiffFilterStats struct {
+	InputBytes     int64
+	OutputBytes    int64
+	ExcludedBytes  int64
+	PortalBytes    int64
+	FilterDuration time.Duration
+	IngestDuration time.Duration
+}
+
+func writeRootFSDiffTarForApply(dst io.Writer, desc ctldapi.RootFSDiffDescriptor, reader io.Reader, excludedPaths []string, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, rootFSDiffFilterStats, error) {
 	portalPaths = filterRootFSPortalPaths(portalPaths, excludedPaths)
-	if !shouldFilterRootFSDiffTar(desc) {
-		return desc, noopReadSeekCloser{Reader: reader}, nil
-	}
 	filter := newRootFSPathFilter(rootFSExcludedPathsWithPortals(excludedPaths, portalPaths))
-
-	tmp, err := os.CreateTemp("", "sandbox0-rootfs-apply-filtered-diff-*.tar")
-	if err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, nil, err
-	}
-	removeOnError := true
-	defer func() {
-		if removeOnError {
-			_ = tmp.Close()
-			_ = os.Remove(tmp.Name())
-		}
-	}()
-
+	input := &countingReader{Reader: reader}
+	ingest := &durationWriter{Writer: dst}
+	output := &countingWriter{Writer: ingest}
 	digester := digest.Canonical.Digester()
-	writer := io.MultiWriter(tmp, digester.Hash())
-	tarWriter := tar.NewWriter(writer)
-	tarReader := tar.NewReader(reader)
+	tarWriter := tar.NewWriter(io.MultiWriter(output, digester.Hash()))
+	tarReader := tar.NewReader(input)
 	restored := make(map[string]struct{}, len(portalPaths))
+	stats := rootFSDiffFilterStats{}
+	started := time.Now()
 	for {
 		header, err := tarReader.Next()
 		if err == io.EOF {
@@ -496,50 +507,82 @@ func filterRootFSDiffTarForApply(desc ctldapi.RootFSDiffDescriptor, reader io.Re
 		}
 		if err != nil {
 			_ = tarWriter.Close()
-			return ctldapi.RootFSDiffDescriptor{}, nil, err
+			return ctldapi.RootFSDiffDescriptor{}, stats, err
 		}
 		if portal, rel, ok := matchRootFSPortalHeader(header.Name, portalPaths); ok {
+			stats.PortalBytes += header.Size
 			if err := restoreRootFSPortalHeader(tarReader, header, portal, rel, restored); err != nil {
 				_ = tarWriter.Close()
-				return ctldapi.RootFSDiffDescriptor{}, nil, err
+				return ctldapi.RootFSDiffDescriptor{}, stats, err
 			}
 			continue
 		}
 		if filter.ExcludesTarHeader(header.Name) {
+			stats.ExcludedBytes += header.Size
 			continue
 		}
 
 		headerCopy := *header
 		if err := tarWriter.WriteHeader(&headerCopy); err != nil {
 			_ = tarWriter.Close()
-			return ctldapi.RootFSDiffDescriptor{}, nil, err
+			return ctldapi.RootFSDiffDescriptor{}, stats, err
 		}
 		if header.Size > 0 {
 			if _, err := io.Copy(tarWriter, tarReader); err != nil {
 				_ = tarWriter.Close()
-				return ctldapi.RootFSDiffDescriptor{}, nil, err
+				return ctldapi.RootFSDiffDescriptor{}, stats, err
 			}
 		}
 	}
 	if err := tarWriter.Close(); err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, nil, err
-	}
-	stat, err := tmp.Stat()
-	if err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, nil, err
-	}
-	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
-		return ctldapi.RootFSDiffDescriptor{}, nil, err
+		return ctldapi.RootFSDiffDescriptor{}, stats, err
 	}
 
 	desc.Digest = digester.Digest().String()
 	desc.DiffID = desc.Digest
-	desc.Size = stat.Size()
+	desc.Size = output.Written
 	if strings.TrimSpace(desc.MediaType) == "" {
 		desc.MediaType = ocispec.MediaTypeImageLayer
 	}
-	removeOnError = false
-	return desc, removeOnCloseFile{File: tmp}, nil
+	stats.InputBytes = input.BytesRead
+	stats.OutputBytes = output.Written
+	stats.IngestDuration = ingest.Duration
+	stats.FilterDuration = time.Since(started) - ingest.Duration
+	return desc, stats, nil
+}
+
+type countingReader struct {
+	io.Reader
+	BytesRead int64
+}
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	n, err := r.Reader.Read(p)
+	r.BytesRead += int64(n)
+	return n, err
+}
+
+type countingWriter struct {
+	io.Writer
+	Written int64
+}
+
+type durationWriter struct {
+	io.Writer
+	Duration time.Duration
+}
+
+func (w *durationWriter) Write(p []byte) (int, error) {
+	started := time.Now()
+	n, err := w.Writer.Write(p)
+	w.Duration += time.Since(started)
+	return n, err
+}
+
+func (w *countingWriter) Write(p []byte) (int, error) {
+	n, err := w.Writer.Write(p)
+	w.Written += int64(n)
+	return n, err
 }
 
 func appendPortalRootFSToDiff(desc ctldapi.RootFSDiffDescriptor, reader io.ReadSeekCloser, portalPaths []ctldapi.RootFSPortalPath) (ctldapi.RootFSDiffDescriptor, io.ReadSeekCloser, error) {

--- a/ctld/internal/ctld/rootfs/overlay_diff_test.go
+++ b/ctld/internal/ctld/rootfs/overlay_diff_test.go
@@ -51,6 +51,10 @@ func TestWriteOverlayUpperDiffExcludesRuntimePaths(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(upperdir, "procd", "bin"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(upperdir, "procd", "bin", "procd"), []byte("runtime"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(upperdir, "procd", "bin", "python-runner"), []byte("runtime"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(upperdir, "tmp", "cache"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(upperdir, "tmp", "cache", "download"), []byte("ephemeral"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(upperdir, "var", "tmp"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(upperdir, "var", "tmp", "state"), []byte("persistent"), 0o644))
 	require.NoError(t, os.MkdirAll(filepath.Join(upperdir, strings.TrimPrefix(volumeportal.WebhookStateMountPath, "/"), "webhook-outbox"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(upperdir, strings.TrimPrefix(volumeportal.WebhookStateMountPath, "/"), "webhook-outbox", "evt.json"), []byte("runtime"), 0o644))
 	require.NoError(t, os.MkdirAll(filepath.Join(upperdir, "workspace"), 0o755))
@@ -65,6 +69,11 @@ func TestWriteOverlayUpperDiffExcludesRuntimePaths(t *testing.T) {
 	assert.NotContains(t, entries, "procd/bin/")
 	assert.NotContains(t, entries, "procd/bin/procd")
 	assert.NotContains(t, entries, "procd/bin/python-runner")
+	assert.NotContains(t, entries, "tmp/")
+	assert.NotContains(t, entries, "tmp/cache/")
+	assert.NotContains(t, entries, "tmp/cache/download")
+	assert.Contains(t, entries, "var/tmp/")
+	assert.Contains(t, entries, "var/tmp/state")
 	assert.Contains(t, entries, "var/lib/sandbox0/procd/")
 	assert.Contains(t, entries, "var/lib/sandbox0/procd/webhook-outbox/")
 	assert.Contains(t, entries, "var/lib/sandbox0/procd/webhook-outbox/evt.json")
@@ -268,16 +277,16 @@ func TestFilterRootFSDiffTarForApplyRestoresPortalBacking(t *testing.T) {
 	backing := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(backing, "stale.txt"), []byte("stale"), 0o644))
 
-	desc, reader, err := filterRootFSDiffTarForApply(rootFSDiffDescriptorForTest(), bytes.NewReader(buf.Bytes()), nil, []ctldapi.RootFSPortalPath{{
+	var filtered bytes.Buffer
+	desc, _, err := writeRootFSDiffTarForApply(&filtered, rootFSDiffDescriptorForTest(), bytes.NewReader(buf.Bytes()), nil, []ctldapi.RootFSPortalPath{{
 		PortalName:  "cache",
 		MountPath:   "/workspace/cache",
 		BackingPath: backing,
 	}})
 	require.NoError(t, err)
-	defer reader.Close()
 	require.NotEmpty(t, desc.Digest)
 
-	entries := readTarEntries(t, reader)
+	entries := readTarEntries(t, bytes.NewReader(filtered.Bytes()))
 	assert.Contains(t, entries, "workspace/root.txt")
 	assert.NotContains(t, entries, "workspace/cache/")
 	assert.NotContains(t, entries, "workspace/cache/old.txt")
@@ -291,6 +300,10 @@ func TestFilterRootFSDiffTarExcludesRuntimePaths(t *testing.T) {
 	tarWriter := tar.NewWriter(&buf)
 	writeTarEntry(t, tarWriter, "procd/bin/python-runner", []byte("runtime"), 0o755)
 	writeTarEntry(t, tarWriter, "procd/.wh..wh..opq", nil, 0o000)
+	writeTarEntry(t, tarWriter, "tmp/legacy-download", []byte("ephemeral"), 0o644)
+	writeTarEntry(t, tarWriter, ".wh.tmp", nil, 0o000)
+	writeTarEntry(t, tarWriter, ".wh..wh..opq", nil, 0o000)
+	writeTarEntry(t, tarWriter, "var/tmp/state", []byte("persistent"), 0o644)
 	writeTarEntry(t, tarWriter, "var/lib/sandbox0/procd/webhook-outbox/evt.json", []byte("runtime"), 0o644)
 	writeTarEntry(t, tarWriter, "var/lib/sandbox0/procd/.wh..wh..opq", nil, 0o000)
 	writeTarEntry(t, tarWriter, "workspace/state", []byte("value"), 0o644)
@@ -306,6 +319,10 @@ func TestFilterRootFSDiffTarExcludesRuntimePaths(t *testing.T) {
 	entries := readTarEntries(t, reader)
 	assert.NotContains(t, entries, "procd/bin/python-runner")
 	assert.NotContains(t, entries, "procd/.wh..wh..opq")
+	assert.NotContains(t, entries, "tmp/legacy-download")
+	assert.NotContains(t, entries, ".wh.tmp")
+	assert.NotContains(t, entries, ".wh..wh..opq")
+	assert.Contains(t, entries, "var/tmp/state")
 	assert.Contains(t, entries, "var/lib/sandbox0/procd/webhook-outbox/evt.json")
 	assert.Contains(t, entries, "var/lib/sandbox0/procd/.wh..wh..opq")
 	assert.Contains(t, entries, "workspace/state")
@@ -365,6 +382,11 @@ func TestRootFSPathFilterDoesNotExcludeSimilarPrefixes(t *testing.T) {
 	assert.True(t, filter.Excludes("/workspace/data/file"))
 	assert.False(t, filter.Excludes("/workspace/database/file"))
 	assert.False(t, filter.Excludes("/workspace/data-old/file"))
+	assert.True(t, filter.Excludes("/tmp"))
+	assert.True(t, filter.Excludes("/tmp/cache/file"))
+	assert.False(t, filter.Excludes("/var/tmp/file"))
+	assert.True(t, filter.ExcludesTarHeader(".wh.tmp"))
+	assert.True(t, filter.ExcludesTarHeader(".wh..wh..opq"))
 	assert.True(t, filter.ExcludesTarHeader("workspace/.wh.data"))
 	assert.False(t, filter.ExcludesTarHeader("workspace/.wh.database"))
 	assert.True(t, filter.ExcludesTarHeader("workspace/.wh..wh..opq"))
@@ -374,6 +396,22 @@ func TestRootFSPathFilterDoesNotExcludeSimilarPrefixes(t *testing.T) {
 	assert.True(t, opaque)
 	assert.Equal(t, "/workspace", target)
 	assert.True(t, filter.AffectsOpaquePreservedPath(target))
+}
+
+func TestRootFSPathFilterRemovesEphemeralPathsFromBaseline(t *testing.T) {
+	baseline := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(baseline, "tmp", "cache"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(baseline, "tmp", "cache", "download"), []byte("ephemeral"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(baseline, "var", "tmp"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(baseline, "var", "tmp", "state"), []byte("persistent"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(baseline, "root"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(baseline, "root", "sentinel"), []byte("persistent"), 0o644))
+
+	require.NoError(t, newRootFSPathFilter(nil).RemoveAll(baseline))
+	_, err := os.Stat(filepath.Join(baseline, "tmp"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	assertFileContent(t, filepath.Join(baseline, "var", "tmp", "state"), "persistent")
+	assertFileContent(t, filepath.Join(baseline, "root", "sentinel"), "persistent")
 }
 
 func rootFSDiffDescriptorForTest() ctldapi.RootFSDiffDescriptor {

--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -112,6 +112,21 @@ Resume a sandbox that was paused manually or by TTL expiry.
 
 Mounted Sandbox Volumes are remounted from their durable state.
 
+## Persistent And Ephemeral Paths
+
+The writable rootfs persists across pause and resume except for runtime-owned ephemeral paths:
+
+- `/tmp` is recreated from the clean carrier or template state. Files written there do not survive pause and resume.
+- `/var/tmp` remains part of the persistent rootfs.
+- Other writable rootfs paths, such as `/root` and workspace directories, remain persistent.
+- Mounted Sandbox Volumes keep their independent durable state, including a Volume mounted beneath `/tmp`.
+
+This policy is applied while saving checkpoints, restoring checkpoint layers, and capturing incremental baselines. Sandbox0 also filters `/tmp` from older checkpoint layers during restore. The first restore of a large older checkpoint can still take time because the layer must be read once; the next pause writes a checkpoint without those `/tmp` contents.
+
+<Callout variant="warning">
+Do not use `/tmp` for dependency caches, downloaded tools, or other state that must survive runtime replacement. Store that data under a persistent rootfs path or mount a Sandbox Volume.
+</Callout>
+
 <Endpoint method="POST">
 /api/v1/sandboxes/{'{id}'}/resume
 </Endpoint>

--- a/docs/sandbox/snapshot-restore/page.mdx
+++ b/docs/sandbox/snapshot-restore/page.mdx
@@ -37,6 +37,12 @@ Use [Volumes](/docs/sandbox/volume) when data must be mounted by multiple sandbo
 - `Resume` is required before reading or writing files through sandbox process and file APIs after restore or fork. A sandbox claimed with `snapshot_id` starts running.
 - Deleting a snapshot does not modify any sandbox already claimed or restored from it, and it does not affect forks created from the same rootfs state.
 
+### Rootfs Path Semantics
+
+Snapshots, snapshot claims, restore, and fork use the same persistence boundary as pause and resume. `/tmp` is ephemeral and is not captured or restored, while `/var/tmp` and ordinary writable rootfs paths remain persistent. A Sandbox Volume mounted beneath `/tmp` remains durable because Volume state is managed independently from rootfs checkpoints.
+
+Older snapshot layers are filtered when restored, so legacy `/tmp` entries do not reappear. Reading and filtering a large legacy layer can make its first restore slower; later checkpoints omit that data. See [Pause And Resume](/docs/sandbox/pause-resume#persistent-and-ephemeral-paths) for the complete path policy.
+
 <Callout variant="info">
 The rootfs snapshot API stores snapshot metadata including `name`, `description`, and optional `expires_at`. Delete snapshots explicitly when cleanup workflows no longer need them.
 </Callout>

--- a/docs/self-hosted/observability/page.mdx
+++ b/docs/self-hosted/observability/page.mdx
@@ -26,6 +26,16 @@ For cold-start diagnosis, collect `manager_pod_lifecycle_stage_duration_seconds`
 
 The sandbox boundary is a Kubernetes lifecycle timestamp, not an individual CRI call duration. Collect `kubelet_runtime_operations_duration_seconds{operation_type=~"run_podsandbox|create_container|start_container"}` when you need node-level CRI timing.
 
+For rootfs checkpoint and resume diagnosis, collect these ctld metrics:
+
+- `ctld_rootfs_operation_duration_seconds` for total save and apply latency
+- `ctld_rootfs_phase_duration_seconds` for cache lookup, cache validation, tar filtering, containerd ingest, diff apply, and baseline capture
+- `ctld_rootfs_checkpoint_bytes` for input, output, excluded, and Volume portal byte distributions
+- `ctld_rootfs_checkpoint_chain_depth` for the number of layers replayed by each operation
+- `ctld_rootfs_object_cache_requests_total` for cache hit, miss, and error counts
+
+Manager also records `apply_rootfs_checkpoint`, `bind_volume_portals`, `bind_webhook_state_portal`, `activate_runtime`, and `resume_total` in `manager_sandbox_claim_phase_duration_seconds`. ctld emits a structured warning when a rootfs operation takes at least 10 seconds or handles a checkpoint of at least 512 MiB.
+
 ### Managed Collector
 
 Use `managedCollector` when Sandbox0 should install OpenTelemetry Collectors and export to your OTLP endpoint.

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -22,7 +22,7 @@ const sandboxLifecycleWaitInterval = 100 * time.Millisecond
 // ResumePausedSandboxRuntime creates a new runtime for a paused durable sandbox
 // and restores the latest writable rootfs checkpoint. A terminal runtime first
 // completes crash recovery through the durable pause transaction.
-func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandboxID string) (*Sandbox, error) {
+func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandboxID string) (result *Sandbox, resultErr error) {
 	if s == nil || s.sandboxStore == nil {
 		return nil, k8serrors.NewNotFound(corev1.Resource("pod"), sandboxID)
 	}
@@ -36,6 +36,12 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 	runtimeRecoveryRequested := false
 	claimType := "hot"
 	restoreNeeded := false
+	started := time.Now()
+	defer func() {
+		if restoreNeeded && record != nil {
+			s.observeClaimPhase(record.TemplateID, claimType, "resume_total", started, resultErr)
+		}
+	}()
 	for {
 		pod = nil
 		record = nil
@@ -471,7 +477,9 @@ func (s *SandboxService) finishRestoredSandboxRuntime(ctx context.Context, pod *
 		return pod, err
 	}
 	assignedPodUID := pod.UID
+	phaseStarted := time.Now()
 	pod, err = s.applySandboxRootFSCheckpointWithFallback(ctx, pod, record, template, req, rootFSState, "")
+	s.observeClaimPhase(record.TemplateID, claimType, "apply_rootfs_checkpoint", phaseStarted, err)
 	if err != nil {
 		return pod, err
 	}
@@ -481,13 +489,21 @@ func (s *SandboxService) finishRestoredSandboxRuntime(ctx context.Context, pod *
 			return pod, err
 		}
 	}
-	if _, err := s.bindVolumePortals(ctx, pod, req, template); err != nil {
+	phaseStarted = time.Now()
+	_, err = s.bindVolumePortals(ctx, pod, req, template)
+	s.observeClaimPhase(record.TemplateID, claimType, "bind_volume_portals", phaseStarted, err)
+	if err != nil {
 		return pod, fmt.Errorf("bind volume portals: %w", err)
 	}
-	if err := s.bindWebhookStatePortal(ctx, pod, req); err != nil {
+	phaseStarted = time.Now()
+	err = s.bindWebhookStatePortal(ctx, pod, req)
+	s.observeClaimPhase(record.TemplateID, claimType, "bind_webhook_state_portal", phaseStarted, err)
+	if err != nil {
 		return pod, fmt.Errorf("bind webhook state portal: %w", err)
 	}
+	phaseStarted = time.Now()
 	pod, err = s.activateRuntimeAssignment(ctx, pod, runtimeRevision)
+	s.observeClaimPhase(record.TemplateID, claimType, "activate_runtime", phaseStarted, err)
 	if err != nil {
 		return pod, fmt.Errorf("activate runtime: %w", err)
 	}

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -1025,10 +1025,12 @@ func TestRootFSExcludedPathsForPodUsesBoundClaimMountPaths(t *testing.T) {
 	addRootFSTestVolumePortal(pod, "data", "/workspace/data/")
 	addRootFSTestVolumePortal(pod, "data-duplicate", "/workspace/data")
 	addRootFSTestVolumePortal(pod, "database", "/workspace/database")
+	addRootFSTestVolumePortal(pod, "tmp-volume", "/tmp/sandbox0-volume")
 	addRootFSTestVolumePortal(pod, "ignored-root", "/")
 	setRootFSTestClaimMounts(t, pod, []ClaimMount{
 		{SandboxVolumeID: "vol-1", MountPoint: "/workspace/data/"},
 		{SandboxVolumeID: "vol-2", MountPoint: "/workspace/database"},
+		{SandboxVolumeID: "vol-3", MountPoint: "/tmp/sandbox0-volume"},
 	})
 	pod.Annotations[controller.AnnotationWebhookStateVolumeID] = "webhook-state-vol-1"
 	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
@@ -1046,7 +1048,7 @@ func TestRootFSExcludedPathsForPodUsesBoundClaimMountPaths(t *testing.T) {
 
 	got := rootFSExcludedPathsForPod(pod)
 
-	assert.ElementsMatch(t, []string{"/workspace/data", "/workspace/database", volumeportal.WebhookStateMountPath}, got)
+	assert.ElementsMatch(t, []string{"/workspace/data", "/workspace/database", "/tmp/sandbox0-volume", volumeportal.WebhookStateMountPath}, got)
 }
 
 func TestRootFSExcludedPathsForPodIgnoresUnboundVolumePortals(t *testing.T) {

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -272,6 +272,10 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 					assertSandboxRootFSPersistsAcrossPauseResume(env, session)
 				})
 
+				It("keeps a SandboxVolume mounted beneath ephemeral tmp", func() {
+					assertSandboxVolumeUnderTmpPersistsAcrossPauseResume(env, session)
+				})
+
 				It("snapshots restores and forks sandbox rootfs", func() {
 					assertSandboxRootFSSnapshotRestoreFork(env, session)
 				})
@@ -1392,6 +1396,8 @@ func assertSandboxRootFSPersistsAcrossPauseResume(env *framework.ScenarioEnv, se
 	filePath := rootDir + "/marker.txt"
 	nestedPath := rootDir + "/nested/value.txt"
 	linkPath := rootDir + "/marker.link"
+	tmpPath := "/tmp/" + marker + ".txt"
+	varTmpPath := "/var/tmp/" + marker + ".txt"
 	content := "rootfs checkpoint " + marker
 
 	writeScript := fmt.Sprintf(`set -eu
@@ -1399,6 +1405,8 @@ rm -rf %s
 mkdir -p %s
 printf %%s %s > %s
 printf %%s nested > %s
+printf %%s ephemeral > %s
+printf %%s persistent-var-tmp > %s
 ln -sf %s %s
 chmod 751 %s
 test "$(cat %s)" = %s
@@ -1411,6 +1419,8 @@ test "$(stat -c %%a %s)" = 751
 		shellQuote(content),
 		shellQuote(filePath),
 		shellQuote(nestedPath),
+		shellQuote(tmpPath),
+		shellQuote(varTmpPath),
 		shellQuote(filePath),
 		shellQuote(linkPath),
 		shellQuote(rootDir),
@@ -1452,6 +1462,8 @@ test "$(cat %s)" = %s
 test "$(cat %s)" = nested
 test "$(cat %s)" = %s
 test "$(stat -c %%a %s)" = 751
+test ! -e %s
+test "$(cat %s)" = persistent-var-tmp
 `,
 		shellQuote(filePath),
 		shellQuote(content),
@@ -1459,8 +1471,66 @@ test "$(stat -c %%a %s)" = 751
 		shellQuote(linkPath),
 		shellQuote(content),
 		shellQuote(rootDir),
+		shellQuote(tmpPath),
+		shellQuote(varTmpPath),
 	)
 	_, err = execInSandboxPod(env, templateNamespace, restored.PodName, verifyScript)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func assertSandboxVolumeUnderTmpPersistsAcrossPauseResume(env *framework.ScenarioEnv, session *e2eutils.Session) {
+	volume, status, err := session.CreateSandboxVolume(env.TestCtx.Context, GinkgoT(), apispec.CreateSandboxVolumeRequest{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusCreated))
+	Expect(volume).NotTo(BeNil())
+	volumeID := expectStringPtr(volume.Id, "volume id")
+	DeferCleanup(func() {
+		deleteSandboxVolumeForCleanup(env, session, volumeID)
+	})
+
+	mountPoint := "/tmp/sandbox0-volume"
+	templateID := createVolumePortalTemplate(env, session, mountPoint)
+	template, err := session.GetTemplate(env.TestCtx.Context, GinkgoT(), templateID)
+	Expect(err).NotTo(HaveOccurred())
+	templateNamespace, err := naming.TemplateNamespaceForTeam(expectStringPtr(template.TeamId, "team id"))
+	Expect(err).NotTo(HaveOccurred())
+	claimResp, err := session.ClaimSandboxWithRequest(env.TestCtx.Context, GinkgoT(), apispec.ClaimRequest{
+		Template: &templateID,
+		Mounts: &[]apispec.ClaimMountRequest{{
+			SandboxvolumeId: volumeID,
+			MountPoint:      mountPoint,
+		}},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(claimResp).NotTo(BeNil())
+	sandboxID := claimResp.SandboxId
+	DeferCleanup(func() {
+		_ = session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
+	})
+	sandbox := waitForSandboxPodReadyEventually(env, session, sandboxID, templateNamespace)
+	marker := fmt.Sprintf("tmp-volume-%d", time.Now().UnixNano())
+	volumePath := mountPoint + "/marker.txt"
+	_, err = execInSandboxPod(env, templateNamespace, sandbox.PodName, fmt.Sprintf(
+		"set -eu; printf %%s %s > %s; test \"$(cat %s)\" = %s",
+		shellQuote(marker), shellQuote(volumePath), shellQuote(volumePath), shellQuote(marker),
+	))
+	Expect(err).NotTo(HaveOccurred())
+
+	pauseResp, status, err := session.PauseSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(pauseResp).NotTo(BeNil())
+	waitForSandboxLifecycleStatusEventually(env, session, sandboxID, apispec.SandboxLifecycleStatusPaused)
+	resumeResp, status, err := session.ResumeSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(resumeResp).NotTo(BeNil())
+	Expect(resumeResp.Resumed).To(BeTrue())
+	restored := waitForSandboxPodReadyEventually(env, session, sandboxID, templateNamespace)
+	_, err = execInSandboxPod(env, templateNamespace, restored.PodName, fmt.Sprintf(
+		"set -eu; test \"$(cat %s)\" = %s",
+		shellQuote(volumePath), shellQuote(marker),
+	))
 	Expect(err).NotTo(HaveOccurred())
 }
 
@@ -1631,6 +1701,7 @@ func assertSandboxRootFSSnapshotRestoreFork(env *framework.ScenarioEnv, session 
 	rootDir := "/root/" + marker
 	filePath := rootDir + "/marker.txt"
 	nestedPath := rootDir + "/nested/value.txt"
+	tmpPath := "/tmp/" + marker + ".txt"
 	v1Content := "snapshot v1 " + marker
 	v2Content := "snapshot v2 " + marker
 
@@ -1639,6 +1710,7 @@ rm -rf %s
 mkdir -p %s
 printf %%s %s > %s
 printf %%s nested-v1 > %s
+printf %%s ephemeral-v1 > %s
 test "$(cat %s)" = %s
 test "$(cat %s)" = nested-v1
 `,
@@ -1647,6 +1719,7 @@ test "$(cat %s)" = nested-v1
 		shellQuote(v1Content),
 		shellQuote(filePath),
 		shellQuote(nestedPath),
+		shellQuote(tmpPath),
 		shellQuote(filePath),
 		shellQuote(v1Content),
 		shellQuote(nestedPath),
@@ -1682,12 +1755,14 @@ test "$(cat %s)" = nested-v1
 	writeV2Script := fmt.Sprintf(`set -eu
 printf %%s %s > %s
 printf %%s nested-v2 > %s
+printf %%s ephemeral-v2 > %s
 test "$(cat %s)" = %s
 test "$(cat %s)" = nested-v2
 `,
 		shellQuote(v2Content),
 		shellQuote(filePath),
 		shellQuote(nestedPath),
+		shellQuote(tmpPath),
 		shellQuote(filePath),
 		shellQuote(v2Content),
 		shellQuote(nestedPath),
@@ -1717,10 +1792,12 @@ test "$(cat %s)" = nested-v2
 	verifyV2Script := fmt.Sprintf(`set -eu
 test "$(cat %s)" = %s
 test "$(cat %s)" = nested-v2
+test ! -e %s
 `,
 		shellQuote(filePath),
 		shellQuote(v2Content),
 		shellQuote(nestedPath),
+		shellQuote(tmpPath),
 	)
 	_, err = execInSandboxPod(env, templateNamespace, runningForked.PodName, verifyV2Script)
 	Expect(err).NotTo(HaveOccurred())
@@ -1759,10 +1836,12 @@ test "$(cat %s)" = nested-v2
 	verifyV1Script := fmt.Sprintf(`set -eu
 test "$(cat %s)" = %s
 test "$(cat %s)" = nested-v1
+test ! -e %s
 `,
 		shellQuote(filePath),
 		shellQuote(v1Content),
 		shellQuote(nestedPath),
+		shellQuote(tmpPath),
 	)
 	_, err = execInSandboxPod(env, templateNamespace, source.PodName, verifyV1Script)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Closes #791

## Summary

- centralize the rootfs persistence policy and make `/tmp` ephemeral across checkpoint save, legacy-layer apply, and baseline capture while keeping `/var/tmp` and ordinary rootfs paths persistent
- stream filtered legacy layers directly into containerd instead of materializing a second full tar, and key ingest work by the source digest plus normalized exclusions
- validate cache objects at ingestion, reuse validated device/inode/size/mtime identity on later hits, and revalidate after restart or metadata changes
- add low-cardinality ctld phase/size/cache metrics, manager resume phase metrics, structured slow/large-operation logs, unit/component integration coverage, E2E scenarios, and docs

Sandbox Volumes remain independently durable, including explicit mounts beneath `/tmp`.

## Compatibility

Legacy checkpoints are filtered during restore, so old `/tmp` entries do not reappear. Their first restore still reads and filters the legacy object once. The next pause writes a checkpoint without `/tmp`, which gives subsequent resumes the full size and I/O reduction.

## Validation

### Local

- `make proto manifests apispec`
- `go mod tidy` with no `go.mod` or `go.sum` diff
- `GOFLAGS=-buildvcs=false golangci-lint run ./...` (`v2.5.0`, 0 issues)
- PR Quick Check unit command: all non-E2E/non-integration packages with `-race -count=1`
- billing admission statement coverage: `100.0%`
- `helm lint infra-operator/chart`
- E2E cases package compile check

### Remote kind canary

Validated on the persistent Aliyun Singapore kind environment. For a controlled runc/overlayfs A/B workload containing 256 MiB under `/root` and 256 MiB under `/tmp`:

| Measurement | main | this branch |
| --- | ---: | ---: |
| Checkpoint bytes | 537,106,944 | 268,447,744 after legacy restore/pause |
| Resume | 11.047 s | 6.758 s for the legacy checkpoint |
| Later resumes | — | 5.542 s, 5.526 s |

The branch completed three consecutive resumes with `/root` and `/var/tmp` intact and `/tmp` absent. The rewritten checkpoint was about 50% smaller for this 50/50 workload. The remote disk did not have enough safe headroom for a full main/branch 1.5 GiB A/B, so the controlled comparison was sized down while retaining the same path ratio.

Additional remote checks passed for snapshot restore, fork, and a Sandbox Volume mounted at `/tmp/sandbox0-volume`.

Over the three measured branch resumes, manager recorded 17.709 s total (`5.903 s` average) and 13.206 s in rootfs apply (`4.402 s` average). ctld recorded 1,074,006,016 input bytes, 805,336,576 output bytes, three cache hits and one initial miss. After cache identities were established, a same-process resume added about 0.34 ms across four cache lookups and did not add any full validation pass.

The environment was returned to `gvisor-rootfs`, all test sandboxes were deleted, and the ECS was stopped after validation.

## Release note

`/tmp` is now ephemeral sandbox rootfs state: files written there do not survive pause/resume, snapshot restore, or fork. `/var/tmp`, `/root`, other writable rootfs paths, and Sandbox Volumes remain persistent. Move caches or tools that must survive runtime replacement out of `/tmp`, or mount a Sandbox Volume there.
