### PR TITLE
Fix WebSocket routing and provision new teams transactionally

### DIFF
--- a/global-gateway/pkg/http/server.go
+++ b/global-gateway/pkg/http/server.go
@@ -58,6 +58,21 @@ type regionDirectory interface {
 	GetRegion(ctx context.Context, regionID string) (*tenantdir.Region, error)
 }
 
+type serverOptions struct {
+	teamCreationHook identity.TeamCreationHook
+}
+
+// ServerOption configures optional global-gateway integrations.
+type ServerOption func(*serverOptions)
+
+// WithTeamCreationHook extends all team creation transactions in the global
+// identity repository.
+func WithTeamCreationHook(hook identity.TeamCreationHook) ServerOption {
+	return func(options *serverOptions) {
+		options.teamCreationHook = hook
+	}
+}
+
 const regionRouteCacheTTL = 8 * time.Hour
 const regionRouteCacheMaxEntries = 256
 
@@ -67,6 +82,7 @@ func NewServer(
 	pool *pgxpool.Pool,
 	logger *zap.Logger,
 	obsProvider *observability.Provider,
+	opts ...ServerOption,
 ) (*Server, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("config is required")
@@ -78,7 +94,15 @@ func NewServer(
 	gin.SetMode(gin.ReleaseMode)
 	router := gin.New()
 
-	identityRepo := identity.NewRepository(pool)
+	var options serverOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+	identityOptions := make([]identity.RepositoryOption, 0, 1)
+	if options.teamCreationHook != nil {
+		identityOptions = append(identityOptions, identity.WithTeamCreationHook(options.teamCreationHook))
+	}
+	identityRepo := identity.NewRepository(pool, identityOptions...)
 	regionRepo := tenantdir.NewRepository(pool)
 	jwtIssuer, err := authn.NewIssuerFromConfig(cfg.JWTIssuer, cfg.JWTSecret, cfg.JWTPrivateKeyPEM, cfg.JWTPublicKeyPEM, cfg.JWTPrivateKeyFile, cfg.JWTPublicKeyFile, cfg.JWTAccessTokenTTL.Duration, cfg.JWTRefreshTokenTTL.Duration)
 	if err != nil {

--- a/pkg/gateway/identity/repository.go
+++ b/pkg/gateway/identity/repository.go
@@ -34,12 +34,28 @@ var (
 
 // Repository provides database access for identity and tenancy data.
 type Repository struct {
-	pool *pgxpool.Pool
+	pool             *pgxpool.Pool
+	teamCreationHook TeamCreationHook
+}
+
+// RepositoryOption configures optional identity repository behavior.
+type RepositoryOption func(*Repository)
+
+// WithTeamCreationHook adds transactional and post-commit work to every team
+// creation path.
+func WithTeamCreationHook(hook TeamCreationHook) RepositoryOption {
+	return func(repository *Repository) {
+		repository.teamCreationHook = hook
+	}
 }
 
 // NewRepository creates a new database repository.
-func NewRepository(pool *pgxpool.Pool) *Repository {
-	return &Repository{pool: pool}
+func NewRepository(pool *pgxpool.Pool, opts ...RepositoryOption) *Repository {
+	repository := &Repository{pool: pool}
+	for _, opt := range opts {
+		opt(repository)
+	}
+	return repository
 }
 
 // Pool returns the underlying connection pool.

--- a/pkg/gateway/identity/team_repository.go
+++ b/pkg/gateway/identity/team_repository.go
@@ -10,9 +10,41 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
+// TeamCreationHook extends every repository-owned team creation transaction.
+// BeforeTeamCreateCommit must only perform transactional database work. The
+// post-commit callback is synchronous but best effort so external delivery
+// failures cannot make an already-committed team appear to have failed.
+type TeamCreationHook interface {
+	BeforeTeamCreateCommit(ctx context.Context, tx pgx.Tx, team *Team) error
+	AfterTeamCreateCommit(ctx context.Context, team *Team)
+}
+
 // CreateTeam creates a new team.
 func (r *Repository) CreateTeam(ctx context.Context, team *Team) error {
-	return insertTeam(ctx, r.pool, team)
+	if r.teamCreationHook == nil {
+		return insertTeam(ctx, r.pool, team)
+	}
+	tx, err := r.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin create team: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	createdTeam := *team
+	if err := insertTeam(ctx, tx, &createdTeam); err != nil {
+		return err
+	}
+	if err := r.teamCreationHook.BeforeTeamCreateCommit(ctx, tx, &createdTeam); err != nil {
+		return fmt.Errorf("provision new team: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit create team: %w", err)
+	}
+	*team = createdTeam
+	r.teamCreationHook.AfterTeamCreateCommit(ctx, &createdTeam)
+	return nil
 }
 
 // CreateTeamWithMember creates a team and its initial member in one transaction.
@@ -35,12 +67,20 @@ func (r *Repository) CreateTeamWithMember(ctx context.Context, team *Team, membe
 	if err := insertTeamMember(ctx, tx, &createdMember); err != nil {
 		return err
 	}
+	if r.teamCreationHook != nil {
+		if err := r.teamCreationHook.BeforeTeamCreateCommit(ctx, tx, &createdTeam); err != nil {
+			return fmt.Errorf("provision new team: %w", err)
+		}
+	}
 
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("commit create team with member: %w", err)
 	}
 	*team = createdTeam
 	*member = createdMember
+	if r.teamCreationHook != nil {
+		r.teamCreationHook.AfterTeamCreateCommit(ctx, &createdTeam)
+	}
 	return nil
 }
 

--- a/pkg/gateway/identity/team_repository_test.go
+++ b/pkg/gateway/identity/team_repository_test.go
@@ -2,11 +2,30 @@ package identity
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
 	gatewaymigrations "github.com/sandbox0-ai/sandbox0/pkg/gateway/migrations"
 	"github.com/sandbox0-ai/sandbox0/pkg/migrate"
 )
+
+type testTeamCreationHook struct {
+	before func(context.Context, pgx.Tx, *Team) error
+	after  func(context.Context, *Team)
+}
+
+func (h testTeamCreationHook) BeforeTeamCreateCommit(
+	ctx context.Context,
+	tx pgx.Tx,
+	team *Team,
+) error {
+	return h.before(ctx, tx, team)
+}
+
+func (h testTeamCreationHook) AfterTeamCreateCommit(ctx context.Context, team *Team) {
+	h.after(ctx, team)
+}
 
 func TestTeamRepositoryAllowsDuplicateNamesAndSlugs(t *testing.T) {
 	pool, _ := newGatewayIdentityTestPool(t)
@@ -112,6 +131,82 @@ func TestTeamRepositoryCreateTeamWithMemberIsAtomic(t *testing.T) {
 	}
 	if rolledBackCount != 0 {
 		t.Fatalf("rolled back team count = %d, want 0", rolledBackCount)
+	}
+}
+
+func TestTeamCreationHookCoversRepositoryCreationPaths(t *testing.T) {
+	pool, _ := newGatewayIdentityTestPool(t)
+	if pool == nil {
+		return
+	}
+
+	ctx := context.Background()
+	var beforeIDs []string
+	var afterIDs []string
+	wantFailure := errors.New("provisioning failed")
+	hook := testTeamCreationHook{
+		before: func(ctx context.Context, tx pgx.Tx, team *Team) error {
+			if team.Name == "Rejected Team" {
+				return wantFailure
+			}
+			var exists bool
+			if err := tx.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM teams WHERE id = $1)`, team.ID).
+				Scan(&exists); err != nil {
+				return err
+			}
+			if !exists {
+				return errors.New("team is not visible inside its creation transaction")
+			}
+			beforeIDs = append(beforeIDs, team.ID)
+			return nil
+		},
+		after: func(ctx context.Context, team *Team) {
+			var exists bool
+			if err := pool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM teams WHERE id = $1)`, team.ID).
+				Scan(&exists); err != nil || !exists {
+				t.Errorf("team is not committed before post-commit hook: exists=%t err=%v", exists, err)
+			}
+			afterIDs = append(afterIDs, team.ID)
+		},
+	}
+	repo := NewRepository(pool, WithTeamCreationHook(hook))
+
+	owner := &User{Email: "team-hook-owner@example.com", Name: "Hook Owner"}
+	if err := repo.CreateUser(ctx, owner); err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	ownerID := owner.ID
+	direct := &Team{Name: "Direct Team", OwnerID: &ownerID}
+	if err := repo.CreateTeam(ctx, direct); err != nil {
+		t.Fatalf("create direct team: %v", err)
+	}
+
+	withMember := &Team{Name: "Member Team", OwnerID: &ownerID}
+	member := &TeamMember{UserID: owner.ID, Role: "admin"}
+	if err := repo.CreateTeamWithMember(ctx, withMember, member); err != nil {
+		t.Fatalf("create team with member: %v", err)
+	}
+
+	registered := &User{Email: "team-hook-register@example.com", Name: "Registered"}
+	if _, _, err := repo.CreateUserWithInitialTeam(ctx, registered, "Initial Team", nil); err != nil {
+		t.Fatalf("create user with initial team: %v", err)
+	}
+
+	if len(beforeIDs) != 3 || len(afterIDs) != 3 {
+		t.Fatalf("team hook calls = before %d, after %d, want 3 each", len(beforeIDs), len(afterIDs))
+	}
+
+	rejected := &Team{Name: "Rejected Team", OwnerID: &ownerID}
+	if err := repo.CreateTeam(ctx, rejected); !errors.Is(err, wantFailure) {
+		t.Fatalf("create rejected team error = %v, want %v", err, wantFailure)
+	}
+	var rejectedCount int
+	if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM teams WHERE name = 'Rejected Team'`).
+		Scan(&rejectedCount); err != nil {
+		t.Fatalf("count rejected teams: %v", err)
+	}
+	if rejectedCount != 0 || len(afterIDs) != 3 {
+		t.Fatalf("rejected team state = rows %d, after calls %d", rejectedCount, len(afterIDs))
 	}
 }
 

--- a/pkg/gateway/identity/user_repository.go
+++ b/pkg/gateway/identity/user_repository.go
@@ -78,9 +78,17 @@ func (r *Repository) CreateUserWithInitialTeam(ctx context.Context, user *User, 
 	if err != nil {
 		return nil, nil, fmt.Errorf("insert team member: %w", err)
 	}
+	if r.teamCreationHook != nil {
+		if err = r.teamCreationHook.BeforeTeamCreateCommit(ctx, tx, team); err != nil {
+			return nil, nil, fmt.Errorf("provision initial team: %w", err)
+		}
+	}
 
 	if err = tx.Commit(ctx); err != nil {
 		return nil, nil, fmt.Errorf("commit tx: %w", err)
+	}
+	if r.teamCreationHook != nil {
+		r.teamCreationHook.AfterTeamCreateCommit(ctx, team)
 	}
 	return team, member, nil
 }

--- a/pkg/proxy/websocket.go
+++ b/pkg/proxy/websocket.go
@@ -140,9 +140,10 @@ func isWebSocketUpgrade(r *http.Request) bool {
 
 func dialWebSocketUpstream(ctx context.Context, targetURL *url.URL) (net.Conn, error) {
 	dialer := &net.Dialer{}
+	address := websocketUpstreamAddress(targetURL)
 	switch strings.ToLower(targetURL.Scheme) {
 	case "https", "wss":
-		rawConn, err := dialer.DialContext(ctx, "tcp", targetURL.Host)
+		rawConn, err := dialer.DialContext(ctx, "tcp", address)
 		if err != nil {
 			return nil, err
 		}
@@ -155,8 +156,21 @@ func dialWebSocketUpstream(ctx context.Context, targetURL *url.URL) (net.Conn, e
 		}
 		return tlsConn, nil
 	default:
-		return dialer.DialContext(ctx, "tcp", targetURL.Host)
+		return dialer.DialContext(ctx, "tcp", address)
 	}
+}
+
+func websocketUpstreamAddress(targetURL *url.URL) string {
+	port := targetURL.Port()
+	if port == "" {
+		switch strings.ToLower(targetURL.Scheme) {
+		case "https", "wss":
+			port = "443"
+		default:
+			port = "80"
+		}
+	}
+	return net.JoinHostPort(targetURL.Hostname(), port)
 }
 
 func writeUpstreamHandshake(conn net.Conn, req *http.Request) error {

--- a/pkg/proxy/websocket_test.go
+++ b/pkg/proxy/websocket_test.go
@@ -73,3 +73,28 @@ func TestWebSocketProxyRewritesUntrustedForwardedHeaders(t *testing.T) {
 		t.Fatal("timed out waiting for upstream headers")
 	}
 }
+
+func TestWebSocketUpstreamAddressAddsDefaultPort(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		target string
+		want   string
+	}{
+		{name: "http", target: "http://region.example", want: "region.example:80"},
+		{name: "https", target: "https://region.example", want: "region.example:443"},
+		{name: "ws", target: "ws://region.example", want: "region.example:80"},
+		{name: "wss", target: "wss://region.example", want: "region.example:443"},
+		{name: "explicit port", target: "https://region.example:8443", want: "region.example:8443"},
+		{name: "IPv6", target: "https://[2001:db8::1]", want: "[2001:db8::1]:443"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			targetURL, err := url.Parse(test.target)
+			if err != nil {
+				t.Fatalf("parse target URL: %v", err)
+			}
+			if got := websocketUpstreamAddress(targetURL); got != test.want {
+				t.Fatalf("websocketUpstreamAddress() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- Add default TCP ports when the WebSocket proxy targets an HTTP(S) URL without an explicit port.
- Add an optional identity repository team-creation hook.
- Run the hook inside all repository-owned team creation transactions and synchronously after commit.
- Expose the hook through global-gateway construction so hosted extensions can atomically provision related state.

## Why

Production global-gateway WebSocket requests to `https://ali-ue1.sandbox0.ai` failed because the raw dial used a host without port `443`. Separately, fail-closed billing admission requires every new team to persist its initial account and outbox state in the same transaction as team creation, including registration-created teams.

The open-source hook is optional; self-hosted and regional deployments keep their current behavior when no hook is configured.

## Validation

- `go test ./pkg/proxy ./global-gateway/pkg/http`
- `go test ./pkg/gateway/identity ./global-gateway/pkg/http`
- PostgreSQL integration: `TestTeamCreationHookCoversRepositoryCreationPaths`
- `go test ./...` passed for all unit/integration packages reached locally; the kind-backed e2e suite could not start because `kind` is not installed in this environment.
