### PR TITLE
Enable Docker in the coding-agent template

### DIFF
--- a/docs/sandbox/docker-in-sandbox/page.mdx
+++ b/docs/sandbox/docker-in-sandbox/page.mdx
@@ -11,7 +11,7 @@ Typical uses:
 `/var/lib/docker` is ephemeral. Images, containers, layers, and Docker volumes are discarded when the sandbox is deleted. Store source code and durable outputs in Sandbox volumes instead.
 
 <Callout variant="info">
-The built-in `default` template provides Docker binaries and writable Docker state, but it does not start `dockerd` before the sandbox is claimed. The examples below start Docker in a Sandbox0 Cloud-compatible mode before running containers.
+The built-in `default` and `coding-agent` templates provide Docker binaries and writable Docker state, but they do not start `dockerd` before the sandbox is claimed. The examples below use `default`; claim `coding-agent` instead when the same sandbox also needs the bundled coding agents and browser tooling.
 </Callout>
 
 <Callout variant="warning">
@@ -502,7 +502,7 @@ For projects that require kind, run that part of the workflow in a VM, a CI runn
 - If you run against an environment where Docker port publishing works, `-p hostPort:containerPort` is also fine. The Cloud examples use `--network=host` because it avoids relying on Docker bridge/NAT.
 - Use Sandbox Services when a containerized HTTP service needs to be reachable from outside the sandbox.
 - Docker state is not durable. Use Sandbox Volumes for source, generated files, or database dumps that must survive sandbox cleanup.
-- Docker state uses the default template's ephemeral storage limit. Hosted default sandboxes keep the standard `500m` CPU and `2Gi` memory baseline, so large builds should request larger sandbox resources.
+- Docker state uses the selected template's ephemeral storage limit. Hosted `default` sandboxes provide `500m` CPU, `2Gi` memory, and `8Gi` ephemeral storage; `coding-agent` provides 1 CPU, `4Gi` memory, and `16Gi` ephemeral storage.
 - Pulling images can take longer than a single synchronous command request. Start long Docker setup commands asynchronously, then poll readiness with short commands.
 - kind and similar nested Kubernetes tools require cgroup namespace and networking support beyond ordinary Docker builds. Use a VM or CI runner when those kernel features are not available.
 - Long-running containers count against the sandbox resource limits. Stop containers when a test run finishes if the sandbox will stay alive.

--- a/docs/use-cases/coding-agents/page.mdx
+++ b/docs/use-cases/coding-agents/page.mdx
@@ -2,7 +2,7 @@
 
 Run Codex, Claude Code, OpenCode, or Pi inside a Sandbox0 sandbox when you want an isolated, persistent workspace with supervised process recovery, replayable I/O, and an agent-controllable browser.
 
-The builtin `coding-agent` template installs all four native CLIs, the official Playwright CLI, and Chromium. It declares `/workspace` as its writable mount point.
+The builtin `coding-agent` template installs all four native CLIs, the official Playwright CLI, Chromium, and Docker. It declares `/workspace` as its writable mount point.
 
 ## Why Supervised Sessions?
 
@@ -30,6 +30,12 @@ The template sets both the container's operating-system `HOME` and every supervi
 | OpenCode | `opencode acp --cwd /workspace` | Agent Client Protocol over nd-JSON |
 | Pi | `pi --mode rpc` | Pi RPC over JSONL |
 
+## Use Docker
+
+The template supports a sandbox-local Docker daemon for builds, test databases, and other service containers. Docker does not start automatically; follow [Docker in Sandbox](/docs/sandbox/docker-in-sandbox) to start it in the Sandbox0 Cloud-compatible mode. In Cloud sandboxes, run service containers with `--network=host` and connect to them from the coding agent at `127.0.0.1:<port>`.
+
+Docker images, containers, layers, and volumes under `/var/lib/docker` are ephemeral. Keep repositories and durable outputs in the `/workspace` Sandbox Volume.
+
 ## Use The Shared Browser
 
 The template installs the official `playwright-cli` command and its bundled Agent Skill. Chromium is stored in the image instead of downloaded into each claimed sandbox. Browser sessions use Playwright's official daemon and Dashboard; Sandbox0 does not add another browser-control protocol.
@@ -47,7 +53,7 @@ playwright-cli open http://127.0.0.1:3000 --browser chromium --persistent
 playwright-cli show --host=127.0.0.1 --port=9324
 ```
 
-The coding-agent container runs as root, so the template disables Chromium's process sandbox and relies on the enclosing Sandbox0 runtime isolation. The Dashboard has no Sandbox0 user authentication of its own. Keep it on sandbox loopback unless an authenticated application proxies both its HTTP and WebSocket traffic.
+The coding-agent container runs privileged inside the enclosing Sandbox0 runtime so it can host a sandbox-local Docker daemon. The template also disables Chromium's process sandbox and relies on the Sandbox0 runtime boundary for isolation. The Dashboard has no Sandbox0 user authentication of its own. Keep it on sandbox loopback unless an authenticated application proxies both its HTTP and WebSocket traffic.
 
 <Callout variant="warning">
 The examples grant the selected coding agent broad control inside its sandbox. Keep model credentials narrow, restrict network policy for production workloads, and do not mount a developer home directory or host Docker socket into the sandbox.

--- a/infra-operator/chart/samples/multi-cluster/data-plane.yaml
+++ b/infra-operator/chart/samples/multi-cluster/data-plane.yaml
@@ -111,7 +111,7 @@ spec:
     - templateId: coding-agent
       image: sandbox0ai/otemplates:coding-agent-v0.2.0
       displayName: Coding Agents
-      description: Builtin coding-agent template with Codex, Claude Code, OpenCode, Pi, and Playwright CLI installed by infra-operator.
+      description: Builtin coding-agent template with Docker, Codex, Claude Code, OpenCode, Pi, and Playwright CLI installed by infra-operator.
       pool:
         minIdle: 0
         maxIdle: 2

--- a/infra-operator/chart/samples/single-cluster/fullmode-gke-gvisor.yaml
+++ b/infra-operator/chart/samples/single-cluster/fullmode-gke-gvisor.yaml
@@ -69,7 +69,7 @@ spec:
     - templateId: coding-agent
       image: sandbox0ai/otemplates:coding-agent-v0.2.0
       displayName: Coding Agents
-      description: Builtin coding-agent template with Codex, Claude Code, OpenCode, Pi, and Playwright CLI installed by infra-operator.
+      description: Builtin coding-agent template with Docker, Codex, Claude Code, OpenCode, Pi, and Playwright CLI installed by infra-operator.
       pool:
         minIdle: 0
         maxIdle: 2

--- a/infra-operator/chart/samples/single-cluster/fullmode.yaml
+++ b/infra-operator/chart/samples/single-cluster/fullmode.yaml
@@ -139,7 +139,7 @@ spec:
     - templateId: coding-agent
       image: sandbox0ai/otemplates:coding-agent-v0.2.0
       displayName: Coding Agents
-      description: Builtin coding-agent template with Codex, Claude Code, OpenCode, Pi, and Playwright CLI installed by infra-operator.
+      description: Builtin coding-agent template with Docker, Codex, Claude Code, OpenCode, Pi, and Playwright CLI installed by infra-operator.
       pool:
         minIdle: 0
         maxIdle: 2

--- a/infra-operator/internal/controller/pkg/common/builtin_templates.go
+++ b/infra-operator/internal/controller/pkg/common/builtin_templates.go
@@ -189,7 +189,7 @@ func BuildBuiltinTemplateSpec(templateID string, builtin infrav1alpha1.BuiltinTe
 func codingAgentTemplateSpec() templatev1alpha1.SandboxTemplateSpec {
 	runAsRoot := int64(0)
 	runAsNonRoot := false
-	return templatev1alpha1.SandboxTemplateSpec{
+	spec := templatev1alpha1.SandboxTemplateSpec{
 		DisplayName: template.CodingAgentTemplateDisplayName,
 		Description: template.CodingAgentTemplateDescription,
 		MainContainer: templatev1alpha1.ContainerSpec{
@@ -226,6 +226,8 @@ func codingAgentTemplateSpec() templatev1alpha1.SandboxTemplateSpec {
 			Mode: templatev1alpha1.NetworkModeAllowAll,
 		},
 	}
+	applyDockerRuntime(&spec)
+	return spec
 }
 
 func defaultBuiltinTemplateSpec(templateID string) templatev1alpha1.SandboxTemplateSpec {
@@ -254,21 +256,27 @@ func defaultBuiltinTemplateSpec(templateID string) templatev1alpha1.SandboxTempl
 			Name:      template.DefaultTemplateWorkspaceName,
 			MountPath: template.DefaultTemplateWorkspaceMount,
 		}}
-		spec.MainContainer.SecurityContext = &templatev1alpha1.SecurityContext{
-			Privileged:               BoolPtr(true),
-			AllowPrivilegeEscalation: BoolPtr(true),
-		}
-		sizeLimit := resource.MustParse(template.DefaultTemplateDockerRootSize)
-		spec.Pod = &templatev1alpha1.PodSpecOverride{
-			EmptyDirMounts: []templatev1alpha1.EmptyDirMountSpec{
-				{
-					MountPath: template.DefaultTemplateDockerRoot,
-					SizeLimit: &sizeLimit,
-				},
-			},
-		}
+		applyDockerRuntime(&spec)
 	}
 	return spec
+}
+
+// applyDockerRuntime enables a sandbox-local Docker daemon and keeps its state outside the root filesystem.
+func applyDockerRuntime(spec *templatev1alpha1.SandboxTemplateSpec) {
+	if spec.MainContainer.SecurityContext == nil {
+		spec.MainContainer.SecurityContext = &templatev1alpha1.SecurityContext{}
+	}
+	spec.MainContainer.SecurityContext.Privileged = BoolPtr(true)
+	spec.MainContainer.SecurityContext.AllowPrivilegeEscalation = BoolPtr(true)
+
+	if spec.Pod == nil {
+		spec.Pod = &templatev1alpha1.PodSpecOverride{}
+	}
+	dockerRootSize := spec.MainContainer.Resources.EphemeralStorage.DeepCopy()
+	spec.Pod.EmptyDirMounts = append(spec.Pod.EmptyDirMounts, templatev1alpha1.EmptyDirMountSpec{
+		MountPath: template.DockerDataRootMount,
+		SizeLimit: &dockerRootSize,
+	})
 }
 
 func openClawTemplateSpec() templatev1alpha1.SandboxTemplateSpec {

--- a/infra-operator/internal/controller/pkg/common/builtin_templates_test.go
+++ b/infra-operator/internal/controller/pkg/common/builtin_templates_test.go
@@ -38,22 +38,7 @@ func TestBuildBuiltinTemplateSpecUsesDefaultPreset(t *testing.T) {
 	if mount.Name != template.DefaultTemplateWorkspaceName || mount.MountPath != template.DefaultTemplateWorkspaceMount || mount.ReadOnly {
 		t.Fatalf("volumeMounts[0] = %#v, want writable %s at %s", mount, template.DefaultTemplateWorkspaceName, template.DefaultTemplateWorkspaceMount)
 	}
-	if spec.MainContainer.SecurityContext == nil || spec.MainContainer.SecurityContext.Privileged == nil || !*spec.MainContainer.SecurityContext.Privileged {
-		t.Fatalf("expected privileged security context, got %#v", spec.MainContainer.SecurityContext)
-	}
-	if spec.MainContainer.SecurityContext.AllowPrivilegeEscalation == nil || !*spec.MainContainer.SecurityContext.AllowPrivilegeEscalation {
-		t.Fatalf("expected allowPrivilegeEscalation=true, got %#v", spec.MainContainer.SecurityContext)
-	}
-	if spec.Pod == nil || len(spec.Pod.EmptyDirMounts) != 1 {
-		t.Fatalf("expected one emptyDir mount, got %#v", spec.Pod)
-	}
-	dockerRoot := spec.Pod.EmptyDirMounts[0]
-	if dockerRoot.MountPath != template.DefaultTemplateDockerRoot {
-		t.Fatalf("emptyDir mount path = %q, want %q", dockerRoot.MountPath, template.DefaultTemplateDockerRoot)
-	}
-	if dockerRoot.SizeLimit == nil || dockerRoot.SizeLimit.Cmp(resource.MustParse(template.DefaultTemplateDockerRootSize)) != 0 {
-		t.Fatalf("emptyDir sizeLimit = %#v, want %s", dockerRoot.SizeLimit, template.DefaultTemplateDockerRootSize)
-	}
+	assertDockerRuntimeShape(t, spec, template.DefaultTemplateEphemeralStorage)
 }
 
 func TestBuildBuiltinTemplateSpecDoesNotAddDefaultRuntimeShapeToGenericPreset(t *testing.T) {
@@ -100,11 +85,9 @@ func TestBuildBuiltinTemplateSpecUsesCodingAgentPreset(t *testing.T) {
 	}
 	security := spec.MainContainer.SecurityContext
 	if security == nil || security.RunAsUser == nil || *security.RunAsUser != 0 || security.RunAsNonRoot == nil || *security.RunAsNonRoot {
-		t.Fatalf("securityContext = %#v, want root without privileged mode", security)
+		t.Fatalf("securityContext = %#v, want root", security)
 	}
-	if security.Privileged != nil || security.AllowPrivilegeEscalation != nil {
-		t.Fatalf("securityContext = %#v, want no privileged settings", security)
-	}
+	assertDockerRuntimeShape(t, spec, template.CodingAgentEphemeralStorage)
 	for key, want := range map[string]string{
 		"DISABLE_AUTOUPDATER":         "1",
 		"HOME":                        template.DefaultTemplateWorkspaceMount,
@@ -121,6 +104,27 @@ func TestBuildBuiltinTemplateSpecUsesCodingAgentPreset(t *testing.T) {
 	}
 	if spec.Network == nil || spec.Network.Mode != templatev1alpha1.NetworkModeAllowAll {
 		t.Fatalf("network = %#v, want allow-all", spec.Network)
+	}
+}
+
+func assertDockerRuntimeShape(t *testing.T, spec templatev1alpha1.SandboxTemplateSpec, wantSize string) {
+	t.Helper()
+	security := spec.MainContainer.SecurityContext
+	if security == nil || security.Privileged == nil || !*security.Privileged {
+		t.Fatalf("expected privileged security context, got %#v", security)
+	}
+	if security.AllowPrivilegeEscalation == nil || !*security.AllowPrivilegeEscalation {
+		t.Fatalf("expected allowPrivilegeEscalation=true, got %#v", security)
+	}
+	if spec.Pod == nil || len(spec.Pod.EmptyDirMounts) != 1 {
+		t.Fatalf("expected one Docker emptyDir mount, got %#v", spec.Pod)
+	}
+	dockerRoot := spec.Pod.EmptyDirMounts[0]
+	if dockerRoot.MountPath != template.DockerDataRootMount {
+		t.Fatalf("emptyDir mount path = %q, want %q", dockerRoot.MountPath, template.DockerDataRootMount)
+	}
+	if dockerRoot.SizeLimit == nil || dockerRoot.SizeLimit.Cmp(resource.MustParse(wantSize)) != 0 {
+		t.Fatalf("emptyDir sizeLimit = %#v, want %s", dockerRoot.SizeLimit, wantSize)
 	}
 }
 

--- a/pkg/template/defaults.go
+++ b/pkg/template/defaults.go
@@ -13,13 +13,12 @@ const (
 	DefaultTemplateMaxIdle          = int32(5)
 	DefaultTemplateWorkspaceName    = "workspace"
 	DefaultTemplateWorkspaceMount   = "/workspace"
-	DefaultTemplateDockerRoot       = "/var/lib/docker"
-	DefaultTemplateDockerRootSize   = v1alpha1.DefaultSandboxEphemeralStorage
+	DockerDataRootMount             = "/var/lib/docker"
 
 	CodingAgentTemplateID          = "coding-agent"
 	CodingAgentTemplateImage       = "sandbox0ai/otemplates:coding-agent-v0.2.0"
 	CodingAgentTemplateDisplayName = "Coding Agents"
-	CodingAgentTemplateDescription = "Builtin coding-agent template with Codex, Claude Code, OpenCode, Pi, and Playwright CLI installed by infra-operator."
+	CodingAgentTemplateDescription = "Builtin coding-agent template with Docker, Codex, Claude Code, OpenCode, Pi, and Playwright CLI installed by infra-operator."
 	CodingAgentCPU                 = "1"
 	CodingAgentMemory              = "4Gi"
 	CodingAgentEphemeralStorage    = "16Gi"


### PR DESCRIPTION
## Summary

- share one Docker runtime configuration between the default and coding-agent built-in templates
- run coding-agent with the required privilege settings and a 16 GiB emptyDir mounted at /var/lib/docker
- document daemon startup, persistence, and Sandbox0 Cloud networking constraints

## Why

The coding-agent image already inherits the Docker CLI and daemon binaries from the default image, but its effective SandboxTemplate did not enable privilege escalation or provide dedicated writable Docker state. As a result, Docker was present but unsupported at runtime.

This change derives the Docker data-root size from each template's existing ephemeral-storage request, so the default template remains at 8 GiB and coding-agent receives 16 GiB without maintaining a second capacity value.

## Behavior and impact

The coding-agent preset can now start a sandbox-local Docker daemon and perform ordinary Docker build/run workflows. Docker state remains sandbox-ephemeral; durable project data should stay under /workspace.

On Sandbox0 Cloud, containers that need to expose services to the agent should use host networking and bind to localhost as documented. Nested Kubernetes workloads such as kind or k3d remain subject to gVisor cgroup-namespace limitations and are not claimed as part of this change.

## Validation

- make proto manifests apispec (no unexpected generated changes)
- go mod tidy (no module changes)
- helm lint infra-operator/chart
- golangci-lint run ./...
- full non-e2e/non-integration Go test suite with -race
- pkg/gateway/admission coverage: 100%
- generated the website docs registry and compiled both changed MDX pages
- remote gVisor environment:
  - verified the rendered SandboxTemplate and actual Pod security context and 16 GiB /var/lib/docker emptyDir
  - started Docker 29.1.3 with the vfs storage driver
  - passed docker build and docker run
  - served and fetched an HTTP endpoint through Docker host networking on sandbox localhost
