### PR TITLE
Add headed browser runtime to coding-agent template

### DIFF
--- a/docs/use-cases/coding-agents/page.mdx
+++ b/docs/use-cases/coding-agents/page.mdx
@@ -2,7 +2,7 @@
 
 Run Codex, Claude Code, OpenCode, or Pi inside a Sandbox0 sandbox when you want an isolated, persistent workspace with supervised process recovery, replayable I/O, and an agent-controllable browser.
 
-The builtin `coding-agent` template installs all four native CLIs, the official Playwright CLI, Chromium, and Docker. It declares `/workspace` as its writable mount point.
+The builtin `coding-agent` template installs all four native CLIs, the official Playwright CLI, Chromium, a lightweight headed-browser runtime (Xvfb, Openbox, and x11vnc), and Docker. It declares `/workspace` as its writable mount point.
 
 ## Why Supervised Sessions?
 
@@ -38,7 +38,7 @@ Docker images, containers, layers, and volumes under `/var/lib/docker` are ephem
 
 ## Use The Shared Browser
 
-The template installs the official `playwright-cli` command and its bundled Agent Skill. Chromium is stored in the image instead of downloaded into each claimed sandbox. Browser sessions use Playwright's official daemon and Dashboard; Sandbox0 does not add another browser-control protocol.
+The template installs the official `playwright-cli` command and its bundled Agent Skill. Chromium is stored in the image instead of downloaded into each claimed sandbox. The redundant Chromium headless-shell payload is omitted; Playwright uses the full bundled browser for both headless and headed sessions. Browser sessions use Playwright's official daemon and Dashboard; Sandbox0 does not add another browser-control protocol.
 
 Install the bundled official Skill into a claimed workspace before asking an Agent Skills-compatible coding agent to use the browser:
 
@@ -53,7 +53,11 @@ playwright-cli open http://127.0.0.1:3000 --browser chromium --persistent
 playwright-cli show --host=127.0.0.1 --port=9324
 ```
 
-The coding-agent container runs privileged inside the enclosing Sandbox0 runtime so it can host a sandbox-local Docker daemon. The template also disables Chromium's process sandbox and relies on the Sandbox0 runtime boundary for isolation. The Dashboard has no Sandbox0 user authentication of its own. Keep it on sandbox loopback unless an authenticated application proxies both its HTTP and WebSocket traffic.
+The coding-agent container runs privileged inside the enclosing Sandbox0 runtime so it can host a sandbox-local Docker daemon. The managed Playwright CLI flow disables Chromium's process sandbox and relies on the Sandbox0 runtime boundary for isolation; the unprivileged headed-browser flow uses Chromium's configured setuid sandbox helper. The Dashboard has no Sandbox0 user authentication of its own. Keep it on sandbox loopback unless an authenticated application proxies both its HTTP and WebSocket traffic.
+
+Applications that need exclusive human takeover can use the same template without exposing a CDP endpoint. Stop the Playwright daemon, launch the bundled browser as the unprivileged `sandbox-browser` user on Xvfb, bind x11vnc to loopback, and proxy its stream through an authenticated AppService. Return control by stopping the headed browser before Playwright reopens the same workspace-backed profile. Keep the owner in one application-level record; any file used to block the supported agent command should be treated only as a derived guard.
+
+The public template contains Chrome for Testing, not the proprietary Google Chrome stable binary. An operator may extend a private image with another browser after reviewing its license and deployment requirements. Browser ownership inside one privileged coding-agent sandbox is a cooperative application boundary: a root process can bypass wrappers or launch another browser, so use a separate Sandbox or more strongly isolated component when the browser owner is adversarial.
 
 <Callout variant="warning">
 The examples grant the selected coding agent broad control inside its sandbox. Keep model credentials narrow, restrict network policy for production workloads, and do not mount a developer home directory or host Docker socket into the sandbox.

--- a/docs/use-cases/page.mdx
+++ b/docs/use-cases/page.mdx
@@ -46,7 +46,7 @@ Operators can pin images, tune pools, or remove a template by setting `Sandbox0I
 
 | Template | Image |
 |----------|-------|
-| `coding-agent` | `sandbox0ai/otemplates:coding-agent-v0.2.0` |
+| `coding-agent` | `sandbox0ai/otemplates:coding-agent-v0.3.0` |
 | `openclaw` | `ghcr.io/openclaw/openclaw:latest` |
 | `hermes` | `nousresearch/hermes-agent:latest` |
 | `browser` | `ghcr.io/steel-dev/steel-browser:latest` |

--- a/infra-operator/chart/samples/multi-cluster/data-plane.yaml
+++ b/infra-operator/chart/samples/multi-cluster/data-plane.yaml
@@ -109,9 +109,9 @@ spec:
         minIdle: 0
         maxIdle: 2
     - templateId: coding-agent
-      image: sandbox0ai/otemplates:coding-agent-v0.2.0
+      image: sandbox0ai/otemplates:coding-agent-v0.3.0
       displayName: Coding Agents
-      description: Builtin coding-agent template with Docker, Codex, Claude Code, OpenCode, Pi, and Playwright CLI installed by infra-operator.
+      description: Builtin coding-agent template with Docker, Codex, Claude Code, OpenCode, Pi, Playwright CLI, and headed browser runtime installed by infra-operator.
       pool:
         minIdle: 0
         maxIdle: 2

--- a/infra-operator/chart/samples/single-cluster/fullmode-gke-gvisor.yaml
+++ b/infra-operator/chart/samples/single-cluster/fullmode-gke-gvisor.yaml
@@ -67,9 +67,9 @@ spec:
         minIdle: 0
         maxIdle: 2
     - templateId: coding-agent
-      image: sandbox0ai/otemplates:coding-agent-v0.2.0
+      image: sandbox0ai/otemplates:coding-agent-v0.3.0
       displayName: Coding Agents
-      description: Builtin coding-agent template with Docker, Codex, Claude Code, OpenCode, Pi, and Playwright CLI installed by infra-operator.
+      description: Builtin coding-agent template with Docker, Codex, Claude Code, OpenCode, Pi, Playwright CLI, and headed browser runtime installed by infra-operator.
       pool:
         minIdle: 0
         maxIdle: 2

--- a/infra-operator/chart/samples/single-cluster/fullmode.yaml
+++ b/infra-operator/chart/samples/single-cluster/fullmode.yaml
@@ -137,9 +137,9 @@ spec:
         minIdle: 0
         maxIdle: 2
     - templateId: coding-agent
-      image: sandbox0ai/otemplates:coding-agent-v0.2.0
+      image: sandbox0ai/otemplates:coding-agent-v0.3.0
       displayName: Coding Agents
-      description: Builtin coding-agent template with Docker, Codex, Claude Code, OpenCode, Pi, and Playwright CLI installed by infra-operator.
+      description: Builtin coding-agent template with Docker, Codex, Claude Code, OpenCode, Pi, Playwright CLI, and headed browser runtime installed by infra-operator.
       pool:
         minIdle: 0
         maxIdle: 2

--- a/manager/procd/Dockerfile.coding-agent
+++ b/manager/procd/Dockerfile.coding-agent
@@ -15,15 +15,17 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright \
     PLAYWRIGHT_MCP_BROWSER=chromium \
     PLAYWRIGHT_MCP_ISOLATED=false \
-    PLAYWRIGHT_MCP_SANDBOX=false
+    PLAYWRIGHT_MCP_SANDBOX=false \
+    SANDPI_BROWSER_USER=sandbox-browser
 
 # Claude Code and Pi require Node.js 22. Pi currently requires Node.js 22.19+
 # specifically, so fail the build if the repository ever resolves an older 22.x.
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
+  && apt-get install -y --no-install-recommends ca-certificates curl gnupg openbox x11vnc xvfb \
   && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
   && apt-get install -y --no-install-recommends nodejs \
   && node -e 'const [major, minor] = process.versions.node.split(".").map(Number); if (major < 22 || (major === 22 && minor < 19)) process.exit(1)' \
+  && useradd --create-home --home-dir /home/sandbox-browser --shell /bin/bash "$SANDPI_BROWSER_USER" \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/coding-agents
@@ -33,7 +35,7 @@ COPY manager/procd/coding-agents/THIRD_PARTY.md ./
 
 RUN npm ci --omit=dev \
   && for agent in codex claude opencode pi playwright-cli; do ln -sf "/opt/coding-agents/node_modules/.bin/$agent" "/usr/local/bin/$agent"; done \
-  && playwright-cli install-browser chromium --with-deps \
+  && ./node_modules/.bin/playwright install chromium --with-deps --no-shell \
   && test -f /opt/coding-agents/node_modules/playwright-core/lib/tools/cli-client/skill/SKILL.md \
   && codex --version \
   && claude --version \
@@ -41,6 +43,14 @@ RUN npm ci --omit=dev \
   && pi --version \
   && playwright-cli --version \
   && npm cache clean --force
+
+# Chrome for Testing ships its process-sandbox helper without the setuid bit.
+# Human-owned headed sessions run as sandbox-browser, so configure the helper
+# explicitly instead of weakening those sessions with --no-sandbox.
+RUN chrome_sandbox="$(find /opt/ms-playwright -type f -path '*/chrome-linux*/chrome_sandbox' | head -n 1)" \
+  && test -n "$chrome_sandbox" \
+  && chown root:root "$chrome_sandbox" \
+  && chmod 4755 "$chrome_sandbox"
 
 RUN mkdir -p /workspace
 

--- a/manager/procd/coding-agents/THIRD_PARTY.md
+++ b/manager/procd/coding-agents/THIRD_PARTY.md
@@ -9,5 +9,6 @@ The `coding-agent` template installs these pinned third-party packages:
 | `opencode-ai` | `1.17.18` | MIT |
 | `@earendil-works/pi-coding-agent` | `0.80.6` | MIT |
 | `@playwright/cli` | `0.1.17` | Apache-2.0 |
+| `ws` | `8.21.0` | MIT |
 
 This inventory does not replace the license and notice files distributed in each npm package. Review the current upstream terms before publishing a derived image, especially for packages that do not use an open-source license.

--- a/manager/procd/coding-agents/package-lock.json
+++ b/manager/procd/coding-agents/package-lock.json
@@ -13,7 +13,8 @@
         "@earendil-works/pi-coding-agent": "0.80.6",
         "@openai/codex": "0.144.1",
         "@playwright/cli": "0.1.17",
-        "opencode-ai": "1.17.18"
+        "opencode-ai": "1.17.18",
+        "ws": "8.21.0"
       }
     },
     "node_modules/@anthropic-ai/claude-code": {
@@ -2354,6 +2355,27 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     }
   }

--- a/manager/procd/coding-agents/package.json
+++ b/manager/procd/coding-agents/package.json
@@ -9,6 +9,7 @@
     "@earendil-works/pi-coding-agent": "0.80.6",
     "@openai/codex": "0.144.1",
     "@playwright/cli": "0.1.17",
-    "opencode-ai": "1.17.18"
+    "opencode-ai": "1.17.18",
+    "ws": "8.21.0"
   }
 }

--- a/pkg/template/defaults.go
+++ b/pkg/template/defaults.go
@@ -16,9 +16,9 @@ const (
 	DockerDataRootMount             = "/var/lib/docker"
 
 	CodingAgentTemplateID          = "coding-agent"
-	CodingAgentTemplateImage       = "sandbox0ai/otemplates:coding-agent-v0.2.0"
+	CodingAgentTemplateImage       = "sandbox0ai/otemplates:coding-agent-v0.3.0"
 	CodingAgentTemplateDisplayName = "Coding Agents"
-	CodingAgentTemplateDescription = "Builtin coding-agent template with Docker, Codex, Claude Code, OpenCode, Pi, and Playwright CLI installed by infra-operator."
+	CodingAgentTemplateDescription = "Builtin coding-agent template with Docker, Codex, Claude Code, OpenCode, Pi, Playwright CLI, and headed browser runtime installed by infra-operator."
 	CodingAgentCPU                 = "1"
 	CodingAgentMemory              = "4Gi"
 	CodingAgentEphemeralStorage    = "16Gi"


### PR DESCRIPTION
## What changed

- add Xvfb, Openbox, x11vnc, and an unprivileged `sandbox-browser` account to the builtin coding-agent image
- install the full Playwright Chromium payload without the redundant headless shell and configure Chromium's setuid sandbox helper for headed sessions
- add the pinned `ws` runtime dependency used by authenticated application-level VNC bridges
- move the builtin coding-agent template and deployment samples from `coding-agent-v0.2.0` to `coding-agent-v0.3.0`
- document the cooperative ownership boundary, public Chrome for Testing default, and private stable-browser extension point

## Why

Sandpi Environment Browser V2 needs a real headed browser path for exclusive human takeover. During takeover, applications can stop Playwright, run Chromium as an unprivileged user without CDP, expose x11vnc only on sandbox loopback, and later return the same persistent profile to the agent.

The previous coding-agent image contained only the Playwright-oriented browser runtime, so it could not provide that human-owned transport without installing packages during claim or startup.

## Impact

The extra OS packages are baked into the template image so sandbox claims do not install them at runtime. Omitting Playwright's separate headless-shell payload avoids carrying two Chromium executables. Browser ownership remains a cooperative application boundary inside the privileged coding-agent sandbox; adversarial isolation still requires a separate Sandbox or component.

`sandbox0ai/otemplates:coding-agent-v0.3.0` must be built and published before this default image reference is rolled out.

## Validation

- `go test ./pkg/template/... ./infra-operator/internal/controller/pkg/common/...`
- `npm install --package-lock-only --ignore-scripts --dry-run` with no lockfile drift
- built the coding-agent image on the remote Aliyun kind environment
- deployed Sandbox0Infra to Ready and claimed the template under `gvisor-rootfs`
- verified the headed Chrome process runs as `sandbox-browser`, has no remote-debugging or automation flags, and uses a mode-4755 root-owned sandbox helper
- measured a 3.85 s remote claim and about 21 s cold headed-browser/VNC readiness; the installed Chromium payload was about 412 MB
