### PR TITLE
perf(procd): make session journal resume history-independent

### DIFF
--- a/manager/procd/pkg/session/journal.go
+++ b/manager/procd/pkg/session/journal.go
@@ -10,20 +10,16 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"sync"
 	"time"
-)
-
-const (
-	journalCompactionMinStaleBytes int64 = 1 << 20
-	journalCompactionMaxStaleBytes int64 = 64 << 20
 )
 
 type journalSubscriber struct {
 	ch chan Event
 }
 
-// journalEntry is the compact in-memory index for one persisted event.
+// journalEntry is the compact on-disk index for one legacy JSONL event.
 type journalEntry struct {
 	seq            int64
 	offset         int64
@@ -31,197 +27,712 @@ type journalEntry struct {
 	occurredAtNano int64
 }
 
+type journalBacklogFormat uint8
+
+const (
+	journalBacklogLegacy journalBacklogFormat = iota + 1
+	journalBacklogSegment
+)
+
+type journalBacklogSource struct {
+	format  journalBacklogFormat
+	file    *os.File
+	path    string
+	entries []journalEntry
+	next    int
+	offset  int64
+	end     int64
+}
+
 // EventBacklog streams a stable journal snapshot without retaining event
 // payloads in the procd heap.
 type EventBacklog struct {
-	file    *os.File
-	entries []journalEntry
-	next    int
-	closed  bool
+	mu         sync.Mutex
+	sources    []journalBacklogSource
+	nextSource int
+	after      int64
+	head       int64
+	remaining  int
+	release    func()
+	closed     bool
 }
 
 // Next returns the next retained event in the snapshot.
 func (b *EventBacklog) Next() (Event, bool, error) {
-	if b == nil || b.closed || b.next >= len(b.entries) {
+	if b == nil {
 		return Event{}, false, nil
 	}
-	event, err := readJournalEvent(b.file, b.entries[b.next])
-	if err != nil {
-		return Event{}, false, err
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed || b.remaining == 0 {
+		return Event{}, false, nil
 	}
-	b.next++
-	return event, true, nil
+	for b.nextSource < len(b.sources) {
+		source := &b.sources[b.nextSource]
+		switch source.format {
+		case journalBacklogLegacy:
+			for source.next < len(source.entries) {
+				entry := source.entries[source.next]
+				source.next++
+				if entry.seq <= b.after || entry.seq < b.head {
+					continue
+				}
+				event, err := readLegacyJournalEvent(source.file, entry)
+				if err != nil {
+					return Event{}, false, err
+				}
+				b.consumeOne()
+				return event, true, nil
+			}
+		case journalBacklogSegment:
+			for source.offset < source.end {
+				meta, err := readJournalFrameMeta(source.file, source.offset, source.end)
+				if err != nil {
+					return Event{}, false, fmt.Errorf("read journal backlog metadata: %w", err)
+				}
+				source.offset += meta.frameSize
+				if meta.seq <= b.after || meta.seq < b.head {
+					continue
+				}
+				event, err := readJournalFrame(source.file, meta)
+				if err != nil {
+					return Event{}, false, err
+				}
+				b.consumeOne()
+				return event, true, nil
+			}
+		default:
+			return Event{}, false, errors.New("event journal snapshot has an invalid source")
+		}
+		b.nextSource++
+	}
+	return Event{}, false, nil
 }
 
-// Close releases the snapshot file descriptor.
+func (b *EventBacklog) consumeOne() {
+	if b.remaining > 0 {
+		b.remaining--
+	}
+}
+
+// Close releases snapshot file descriptors and segment deletion pins.
 func (b *EventBacklog) Close() error {
-	if b == nil || b.closed {
+	if b == nil {
+		return nil
+	}
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
 		return nil
 	}
 	b.closed = true
-	if b.file == nil {
-		return nil
+	var closeErr error
+	for i := range b.sources {
+		if b.sources[i].file != nil {
+			closeErr = errors.Join(closeErr, b.sources[i].file.Close())
+		}
 	}
-	return b.file.Close()
+	release := b.release
+	b.release = nil
+	b.mu.Unlock()
+	if release != nil {
+		release()
+	}
+	return closeErr
+}
+
+// JournalStats exposes bounded format-level diagnostics without session event
+// payloads. It is intended for activation logs and tests.
+type JournalStats struct {
+	FormatVersion      int
+	SealedSegments     int
+	ActiveBytes        int64
+	ActiveEvents       int
+	RetainedBytes      int64
+	RetainedBytesKnown bool
+	LegacyDeferred     bool
 }
 
 // Journal is a bounded, cursor-addressable event log with live subscriptions.
-// Event payloads stay on disk; memory contains only a compact offset index and
-// bounded subscriber channels.
+// V2 stores immutable sealed segments plus one bounded active tail. Legacy
+// JSONL is immutable and indexed lazily, keeping session activation independent
+// of retained history size.
 type Journal struct {
-	mu          sync.Mutex
-	path        string
-	file        *os.File
-	fileSize    int64
-	retention   EventRetentionSpec
-	entries     []journalEntry
-	totalBytes  int64
-	nextSeq     int64
-	subscribers map[uint64]*journalSubscriber
-	nextSubID   uint64
-	closed      bool
+	mu sync.Mutex
+
+	legacyPath   string
+	dir          string
+	manifestPath string
+	manifest     journalManifest
+
+	activeFile         *os.File
+	activeSize         int64
+	activeLogicalBytes int64
+	activeEntries      []journalRecordMeta
+
+	retention     EventRetentionSpec
+	retainedBytes int64
+	retainedKnown bool
+	headSeq       int64
+	nextSeq       int64
+
+	legacyOnce    sync.Once
+	legacyLoadErr error
+	legacyEntries []journalEntry
+	legacyLoaded  bool
+
+	headCacheSource string
+	headCache       []journalRecordMeta
+	headCacheIndex  int
+
+	subscribers   map[uint64]*journalSubscriber
+	nextSubID     uint64
+	pins          map[string]int
+	pendingDelete map[string]struct{}
+	dirty         bool
+	fatalErr      error
+	closed        bool
 }
 
-func OpenJournal(path string, retention EventRetentionSpec, lastSeq int64) (*Journal, error) {
+type recoveredJournalFile struct {
+	name    string
+	file    *os.File
+	entries []journalRecordMeta
+	size    int64
+	sealed  bool
+	meta    journalSegmentMeta
+}
+
+// OpenJournal opens or upgrades a session event journal. The persisted cursor
+// is a sequence floor; segment files remain the journal authority.
+func OpenJournal(path string, retention EventRetentionSpec, cursor EventCursor) (*Journal, error) {
 	retention = normalizeSpec(SessionSpec{EventRetention: retention}).EventRetention
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return nil, fmt.Errorf("create event journal directory: %w", err)
 	}
-	entries, validBytes, err := loadJournal(path)
+	dir := journalDirectoryForPath(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create segmented journal directory: %w", err)
+	}
+	manifestPath := journalManifestPath(path)
+	manifest, err := readJournalManifest(manifestPath)
+	manifestExists := err == nil
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	if !manifestExists {
+		manifest = journalManifest{
+			Version:              journalFormatVersion,
+			SegmentTargetBytes:   normalizedJournalSegmentTarget(retention, 0),
+			HeadSeq:              positiveSequence(cursor.Earliest),
+			NextSeq:              maxInt64(1, cursor.Latest+1),
+			RetainedLogicalBytes: 0,
+			ActiveDataEnd:        segmentHeaderSize,
+		}
+		legacy, inspectErr := inspectLegacyJournal(path, cursor)
+		if inspectErr != nil {
+			return nil, inspectErr
+		}
+		manifest.Legacy = legacy
+		if legacy != nil {
+			manifest.NextSeq = maxInt64(manifest.NextSeq, legacy.LatestSeq+1)
+			manifest.RetainedLogicalBytes = -1
+		}
+	}
+	if manifest.SegmentTargetBytes <= 0 {
+		manifest.SegmentTargetBytes = normalizedJournalSegmentTarget(retention, 0)
+	}
+
+	recovered, active, recoveryChanged, err := recoverJournalLayout(dir, manifest, manifestExists)
 	if err != nil {
 		return nil, err
 	}
-	if info, statErr := os.Stat(path); statErr == nil && info.Size() > validBytes {
-		if err := os.Truncate(path, validBytes); err != nil {
-			return nil, fmt.Errorf("truncate incomplete event journal tail: %w", err)
+	closeActive := true
+	defer func() {
+		if closeActive && active != nil && active.file != nil {
+			_ = active.file.Close()
 		}
-	} else if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
-		return nil, fmt.Errorf("stat event journal: %w", statErr)
+	}()
+
+	originalActive := manifest.ActiveFile
+	originalHead := manifest.HeadSeq
+	manifest.Segments = recovered
+	manifest.ActiveFile = active.name
+	activeLogical := journalRecordLogicalBytes(active.entries)
+	latest := maxInt64(cursor.Latest, segmentMetaLatest(recovered), latestRecordSequence(active.entries))
+	if manifest.Legacy != nil {
+		latest = maxInt64(latest, manifest.Legacy.LatestSeq)
 	}
-	latest := lastSeq
-	var total int64
-	for _, entry := range entries {
-		if entry.seq > latest {
-			latest = entry.seq
-		}
-		total += entry.size
+	manifest.NextSeq = maxInt64(1, manifest.NextSeq, latest+1)
+	head := maxInt64(positiveSequence(manifest.HeadSeq), positiveSequence(cursor.Earliest))
+	if first := firstJournalSequence(manifest.Legacy, recovered, active.entries); first > 0 && head < first {
+		head = first
 	}
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)
-	if err != nil {
-		return nil, fmt.Errorf("open event journal: %w", err)
+	if head <= 0 {
+		head = 1
+	}
+
+	retained, retainedKnown := retainedBytesFromManifest(
+		manifest,
+		originalActive,
+		originalHead,
+		head,
+		activeLogical,
+		recoveryChanged,
+	)
+	if !retainedKnown && manifest.Legacy == nil {
+		retained, retainedKnown = retainedBytesWithoutSegmentScan(head, recovered, active.entries)
 	}
 	journal := &Journal{
-		path:        path,
-		file:        file,
-		fileSize:    validBytes,
-		retention:   retention,
-		entries:     entries,
-		totalBytes:  total,
-		nextSeq:     latest + 1,
-		subscribers: map[uint64]*journalSubscriber{},
+		legacyPath:         path,
+		dir:                dir,
+		manifestPath:       manifestPath,
+		manifest:           manifest,
+		activeFile:         active.file,
+		activeSize:         active.size,
+		activeLogicalBytes: activeLogical,
+		activeEntries:      active.entries,
+		retention:          retention,
+		retainedBytes:      retained,
+		retainedKnown:      retainedKnown,
+		headSeq:            head,
+		nextSeq:            manifest.NextSeq,
+		subscribers:        map[uint64]*journalSubscriber{},
+		pins:               map[string]int{},
+		pendingDelete:      map[string]struct{}{},
+		dirty:              !manifestExists || recoveryChanged || originalHead != head,
 	}
-	if journal.nextSeq <= 0 {
-		journal.nextSeq = 1
-	}
-	if journal.trimLocked(time.Now()) {
-		if err := journal.compactLocked(); err != nil {
-			_ = journal.file.Close()
+	closeActive = false
+	if journal.dirty {
+		if err := journal.checkpointLocked(); err != nil {
+			_ = journal.activeFile.Close()
 			return nil, err
 		}
 	}
 	return journal, nil
 }
 
-func loadJournal(path string) ([]journalEntry, int64, error) {
-	file, err := os.Open(path)
+// recoverJournalLayout keeps the normal resume path constant-sized and expands
+// to a directory reconciliation only when the manifest's active tail is sealed
+// or missing, which are crash-window states.
+func recoverJournalLayout(dir string, manifest journalManifest, requireManifestFiles bool) ([]journalSegmentMeta, *recoveredJournalFile, bool, error) {
+	// The normal activation path trusts the atomically published manifest and
+	// opens only the bounded active tail. A sealed active file identifies the
+	// narrow crash window between sealing a segment and publishing its successor;
+	// only that recovery path enumerates segment footers.
+	if requireManifestFiles {
+		activePath := filepath.Join(dir, manifest.ActiveFile)
+		file, err := os.OpenFile(activePath, os.O_RDWR|os.O_APPEND, 0)
+		if err == nil {
+			if err := validateJournalSegmentHeader(file); err != nil {
+				_ = file.Close()
+				return nil, nil, false, fmt.Errorf("validate active journal segment %s: %w", manifest.ActiveFile, err)
+			}
+			_, sealed, footerErr := readJournalSegmentFooter(file)
+			if footerErr != nil {
+				_ = file.Close()
+				return nil, nil, false, fmt.Errorf("read active journal segment %s footer: %w", manifest.ActiveFile, footerErr)
+			}
+			if !sealed {
+				before, statErr := file.Stat()
+				if statErr != nil {
+					_ = file.Close()
+					return nil, nil, false, fmt.Errorf("stat active journal segment %s: %w", manifest.ActiveFile, statErr)
+				}
+				entries, size, scanErr := scanActiveJournalSegment(file)
+				if scanErr != nil {
+					_ = file.Close()
+					return nil, nil, false, fmt.Errorf("recover active journal segment %s: %w", manifest.ActiveFile, scanErr)
+				}
+				return append([]journalSegmentMeta(nil), manifest.Segments...), &recoveredJournalFile{
+					name: manifest.ActiveFile, file: file, entries: entries, size: size,
+				}, before.Size() != size, nil
+			}
+			_ = file.Close()
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, nil, false, fmt.Errorf("open active journal segment %s: %w", manifest.ActiveFile, err)
+		}
+	}
+
+	dirEntries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("read segmented journal directory: %w", err)
+	}
+	files := make([]*recoveredJournalFile, 0)
+	seen := make(map[string]struct{})
+	for _, entry := range dirEntries {
+		if entry.IsDir() || !filepath.IsLocal(entry.Name()) || filepath.Ext(entry.Name()) != ".sjr" {
+			continue
+		}
+		if err := validateJournalFileName(entry.Name()); err != nil {
+			return nil, nil, false, err
+		}
+		file, err := os.OpenFile(filepath.Join(dir, entry.Name()), os.O_RDWR|os.O_APPEND, 0)
+		if err != nil {
+			return nil, nil, false, fmt.Errorf("open journal segment %s: %w", entry.Name(), err)
+		}
+		item := &recoveredJournalFile{name: entry.Name(), file: file}
+		if err := validateJournalSegmentHeader(file); err != nil {
+			_ = file.Close()
+			return nil, nil, false, fmt.Errorf("validate journal segment %s: %w", entry.Name(), err)
+		}
+		footer, sealed, footerErr := readJournalSegmentFooter(file)
+		if footerErr != nil {
+			_ = file.Close()
+			return nil, nil, false, fmt.Errorf("read journal segment %s footer: %w", entry.Name(), footerErr)
+		}
+		if sealed {
+			if footer.File != "" && footer.File != entry.Name() {
+				_ = file.Close()
+				return nil, nil, false, fmt.Errorf("journal segment %s footer names %s", entry.Name(), footer.File)
+			}
+			footer.File = entry.Name()
+			item.sealed = true
+			item.meta = footer
+			_ = file.Close()
+			item.file = nil
+		} else {
+			entries, size, scanErr := scanActiveJournalSegment(file)
+			if scanErr != nil {
+				_ = file.Close()
+				return nil, nil, false, fmt.Errorf("recover journal segment %s: %w", entry.Name(), scanErr)
+			}
+			item.entries = entries
+			item.size = size
+		}
+		files = append(files, item)
+		seen[entry.Name()] = struct{}{}
+	}
+	if requireManifestFiles {
+		for _, segment := range manifest.Segments {
+			if segment.LastSeq < manifest.HeadSeq {
+				continue
+			}
+			if _, ok := seen[segment.File]; !ok {
+				closeRecoveredFiles(files)
+				return nil, nil, false, fmt.Errorf("journal segment %s referenced by the manifest is missing", segment.File)
+			}
+		}
+		if manifest.ActiveFile != "" {
+			if _, ok := seen[manifest.ActiveFile]; !ok {
+				closeRecoveredFiles(files)
+				return nil, nil, false, fmt.Errorf("active journal segment %s is missing", manifest.ActiveFile)
+			}
+		}
+	}
+
+	changed := false
+	unsealed := make([]*recoveredJournalFile, 0)
+	segments := make([]journalSegmentMeta, 0)
+	for _, item := range files {
+		if item.sealed {
+			if item.meta.LastSeq >= manifest.HeadSeq || manifest.HeadSeq <= 0 {
+				segments = append(segments, item.meta)
+			} else {
+				if err := os.Remove(filepath.Join(dir, item.name)); err != nil && !errors.Is(err, os.ErrNotExist) {
+					closeRecoveredFiles(files)
+					return nil, nil, false, fmt.Errorf("remove expired journal segment %s: %w", item.name, err)
+				}
+				changed = true
+			}
+			continue
+		}
+		unsealed = append(unsealed, item)
+	}
+	sort.Slice(unsealed, func(i, k int) bool {
+		iLatest := latestRecordSequence(unsealed[i].entries)
+		kLatest := latestRecordSequence(unsealed[k].entries)
+		if iLatest == kLatest {
+			if unsealed[i].name == manifest.ActiveFile {
+				return false
+			}
+			if unsealed[k].name == manifest.ActiveFile {
+				return true
+			}
+			return unsealed[i].name < unsealed[k].name
+		}
+		return iLatest < kLatest
+	})
+	var active *recoveredJournalFile
+	if len(unsealed) > 0 {
+		active = unsealed[len(unsealed)-1]
+	}
+	for _, item := range unsealed {
+		if item == active {
+			continue
+		}
+		if len(item.entries) > 0 {
+			meta := segmentMetaFromEntries(item.name, item.entries, item.size)
+			if err := writeJournalSegmentFooter(item.file, meta); err != nil {
+				closeRecoveredFiles(files)
+				return nil, nil, false, fmt.Errorf("seal recovered journal segment %s: %w", item.name, err)
+			}
+			segments = append(segments, meta)
+		}
+		_ = item.file.Close()
+		item.file = nil
+		changed = true
+	}
+	if active == nil {
+		name, file, createErr := createJournalSegment(dir)
+		if createErr != nil {
+			closeRecoveredFiles(files)
+			return nil, nil, false, createErr
+		}
+		active = &recoveredJournalFile{name: name, file: file, size: segmentHeaderSize}
+		changed = true
+	}
+	if active.name != manifest.ActiveFile {
+		changed = true
+	}
+	sort.Slice(segments, func(i, k int) bool { return segments[i].FirstSeq < segments[k].FirstSeq })
+	previous := int64(0)
+	for _, segment := range segments {
+		if segment.EventCount <= 0 || segment.FirstSeq <= 0 || segment.LastSeq < segment.FirstSeq {
+			closeRecoveredFiles(files)
+			return nil, nil, false, fmt.Errorf("journal segment %s has invalid sequence metadata", segment.File)
+		}
+		if previous > 0 && segment.FirstSeq <= previous {
+			closeRecoveredFiles(files)
+			return nil, nil, false, fmt.Errorf("journal segment %s overlaps sequence %d", segment.File, previous)
+		}
+		previous = segment.LastSeq
+	}
+	if len(active.entries) > 0 && previous > 0 && active.entries[0].seq <= previous {
+		closeRecoveredFiles(files)
+		return nil, nil, false, fmt.Errorf("active journal segment %s overlaps sealed history", active.name)
+	}
+	return segments, active, changed || !sameSegmentLayout(manifest.Segments, segments), nil
+}
+
+func closeRecoveredFiles(files []*recoveredJournalFile) {
+	for _, file := range files {
+		if file.file != nil {
+			_ = file.file.Close()
+		}
+	}
+}
+
+func sameSegmentLayout(left, right []journalSegmentMeta) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i].File != right[i].File || left[i].FirstSeq != right[i].FirstSeq || left[i].LastSeq != right[i].LastSeq || left[i].DataEnd != right[i].DataEnd {
+			return false
+		}
+	}
+	return true
+}
+
+// inspectLegacyJournal reads only the final JSONL record boundary and sequence.
+// It deliberately does not construct the legacy offset index during resume.
+func inspectLegacyJournal(path string, cursor EventCursor) (*journalLegacyMeta, error) {
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
 	if errors.Is(err, os.ErrNotExist) {
-		return nil, 0, nil
+		return nil, nil
 	}
 	if err != nil {
-		return nil, 0, fmt.Errorf("open event journal for replay: %w", err)
+		return nil, fmt.Errorf("open legacy event journal: %w", err)
 	}
 	defer file.Close()
-
-	reader := bufio.NewReaderSize(file, 64*1024)
-	var entries []journalEntry
-	var previous int64
-	var validBytes int64
-	for {
-		offset := validBytes
-		line, readErr := reader.ReadBytes('\n')
-		complete := bytes.HasSuffix(line, []byte{'\n'})
-		if len(bytes.TrimSpace(line)) > 0 {
-			if readErr == io.EOF && !complete {
-				break
-			}
-			var event Event
-			if err := json.Unmarshal(bytes.TrimSpace(line), &event); err != nil {
-				return nil, 0, fmt.Errorf("decode event journal: %w", err)
-			}
-			if event.Seq <= previous {
-				return nil, 0, fmt.Errorf("event journal sequence %d is not greater than %d", event.Seq, previous)
-			}
-			previous = event.Seq
-			entries = append(entries, journalEntry{
-				seq:            event.Seq,
-				offset:         offset,
-				size:           int64(len(line)),
-				occurredAtNano: event.OccurredAt.UnixNano(),
-			})
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat legacy event journal: %w", err)
+	}
+	validBytes, lastLineStart, err := legacyValidTail(file, info.Size())
+	if err != nil {
+		return nil, err
+	}
+	if validBytes < info.Size() {
+		if err := file.Truncate(validBytes); err != nil {
+			return nil, fmt.Errorf("truncate incomplete legacy journal tail: %w", err)
 		}
-		if complete {
-			validBytes += int64(len(line))
-		}
-		if readErr != nil {
-			if errors.Is(readErr, io.EOF) {
-				break
-			}
-			return nil, 0, fmt.Errorf("read event journal: %w", readErr)
+		if err := file.Sync(); err != nil {
+			return nil, fmt.Errorf("sync truncated legacy journal: %w", err)
 		}
 	}
-	return entries, validBytes, nil
+	if validBytes == 0 {
+		return nil, nil
+	}
+	latest := cursor.Latest
+	prefixSize := validBytes - lastLineStart
+	if prefixSize > 4096 {
+		prefixSize = 4096
+	}
+	prefix := make([]byte, int(prefixSize))
+	if _, err := file.ReadAt(prefix, lastLineStart); err != nil && !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("read legacy journal tail: %w", err)
+	}
+	if seq, seqErr := legacySequenceFromPrefix(prefix); seqErr == nil {
+		latest = maxInt64(latest, seq)
+	} else if latest <= 0 {
+		return nil, seqErr
+	}
+	earliest := positiveSequence(cursor.Earliest)
+	if earliest <= 0 {
+		earliest = 1
+	}
+	return &journalLegacyMeta{
+		File:                 filepath.Base(path),
+		IndexFile:            journalLegacyIndexName,
+		ValidBytes:           validBytes,
+		EarliestSeq:          earliest,
+		LatestSeq:            latest,
+		RetainedLogicalBytes: -1,
+	}, nil
+}
+
+func legacyValidTail(file *os.File, size int64) (int64, int64, error) {
+	if size <= 0 {
+		return 0, 0, nil
+	}
+	last := []byte{0}
+	if _, err := file.ReadAt(last, size-1); err != nil {
+		return 0, 0, fmt.Errorf("read legacy journal suffix: %w", err)
+	}
+	valid := size
+	if last[0] != '\n' {
+		newline, err := findPreviousNewline(file, size)
+		if err != nil {
+			return 0, 0, err
+		}
+		valid = newline + 1
+	}
+	if valid == 0 {
+		return 0, 0, nil
+	}
+	previous, err := findPreviousNewline(file, valid-1)
+	if err != nil {
+		return 0, 0, err
+	}
+	return valid, previous + 1, nil
+}
+
+func findPreviousNewline(file *os.File, before int64) (int64, error) {
+	const blockSize = int64(64 << 10)
+	for end := before; end > 0; {
+		start := end - blockSize
+		if start < 0 {
+			start = 0
+		}
+		buf := make([]byte, int(end-start))
+		if _, err := file.ReadAt(buf, start); err != nil && !errors.Is(err, io.EOF) {
+			return -1, fmt.Errorf("scan legacy journal tail: %w", err)
+		}
+		if index := bytes.LastIndexByte(buf, '\n'); index >= 0 {
+			return start + int64(index), nil
+		}
+		end = start
+	}
+	return -1, nil
+}
+
+func legacySequenceFromPrefix(prefix []byte) (int64, error) {
+	marker := []byte(`"seq":`)
+	index := bytes.Index(prefix, marker)
+	if index < 0 {
+		return 0, errors.New("legacy journal tail does not contain a sequence")
+	}
+	start := index + len(marker)
+	end := start
+	for end < len(prefix) && prefix[end] >= '0' && prefix[end] <= '9' {
+		end++
+	}
+	if end == start {
+		return 0, errors.New("legacy journal tail sequence is invalid")
+	}
+	seq, err := strconv.ParseInt(string(prefix[start:end]), 10, 64)
+	if err != nil || seq <= 0 {
+		return 0, errors.New("legacy journal tail sequence is invalid")
+	}
+	return seq, nil
+}
+
+func retainedBytesFromManifest(manifest journalManifest, originalActive string, originalHead, head, activeLogical int64, recoveryChanged bool) (int64, bool) {
+	if recoveryChanged || manifest.RetainedLogicalBytes < 0 || originalHead != head || originalActive == "" || originalActive != manifest.ActiveFile {
+		return 0, false
+	}
+	delta := activeLogical - manifest.ActiveLogicalBytes
+	if delta < 0 || manifest.RetainedLogicalBytes+delta < 0 {
+		return 0, false
+	}
+	return manifest.RetainedLogicalBytes + delta, true
+}
+
+func retainedBytesWithoutSegmentScan(head int64, segments []journalSegmentMeta, active []journalRecordMeta) (int64, bool) {
+	total := int64(0)
+	for _, segment := range segments {
+		switch {
+		case segment.LastSeq < head:
+			continue
+		case segment.FirstSeq >= head:
+			total += segment.LogicalBytes
+		default:
+			return 0, false
+		}
+	}
+	for _, entry := range active {
+		if entry.seq >= head {
+			total += entry.logicalSize
+		}
+	}
+	return total, true
 }
 
 func (j *Journal) Append(event Event) (Event, error) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
-	if j.closed {
-		return Event{}, errors.New("event journal is closed")
+	if err := j.writableErrorLocked(); err != nil {
+		return Event{}, err
 	}
 	event.Seq = j.nextSeq
 	if event.OccurredAt.IsZero() {
 		event.OccurredAt = time.Now().UTC()
 	}
-	line, err := json.Marshal(event)
+	frame, meta, err := encodeJournalFrame(event)
 	if err != nil {
-		return Event{}, fmt.Errorf("encode event: %w", err)
+		return Event{}, err
 	}
-	line = append(line, '\n')
-	offset := j.fileSize
-	written, err := j.file.Write(line)
-	if err != nil || written != len(line) {
-		writeErr := err
+	if len(j.activeEntries) > 0 && j.activeSize+int64(len(frame)) > j.manifest.SegmentTargetBytes {
+		if err := j.sealActiveLocked(); err != nil {
+			return Event{}, err
+		}
+	}
+	offset := j.activeSize
+	written, writeErr := j.activeFile.Write(frame)
+	if writeErr != nil || written != len(frame) {
 		if writeErr == nil {
 			writeErr = io.ErrShortWrite
 		}
-		if truncateErr := j.file.Truncate(offset); truncateErr != nil {
-			return Event{}, errors.Join(fmt.Errorf("append event journal: %w", writeErr), fmt.Errorf("rollback partial event journal append: %w", truncateErr))
+		if truncateErr := j.activeFile.Truncate(offset); truncateErr != nil {
+			j.fatalErr = errors.Join(writeErr, truncateErr)
+			return Event{}, fmt.Errorf("append segmented event journal: %w", j.fatalErr)
 		}
-		return Event{}, fmt.Errorf("append event journal: %w", writeErr)
+		return Event{}, fmt.Errorf("append segmented event journal: %w", writeErr)
 	}
-	size := int64(len(line))
-	j.fileSize += size
+	meta.offset = offset
+	j.activeSize += meta.frameSize
+	j.activeLogicalBytes += meta.logicalSize
+	j.activeEntries = append(j.activeEntries, meta)
 	j.nextSeq++
-	j.entries = append(j.entries, journalEntry{
-		seq:            event.Seq,
-		offset:         offset,
-		size:           size,
-		occurredAtNano: event.OccurredAt.UnixNano(),
-	})
-	j.totalBytes += size
-	if j.trimLocked(event.OccurredAt) {
-		if err := j.maybeCompactLocked(); err != nil {
-			return event, err
+	j.manifest.NextSeq = j.nextSeq
+	if j.retainedKnown {
+		j.retainedBytes += meta.logicalSize
+	}
+	if j.headCacheSource == j.manifest.ActiveFile {
+		j.headCache = append(j.headCache, meta)
+	}
+	j.dirty = true
+	if j.retainedKnown {
+		changed, trimErr := j.trimLocked(time.Now())
+		if trimErr != nil {
+			return event, trimErr
+		}
+		if changed && j.hasExpiredFilesLocked() {
+			if err := j.checkpointLocked(); err != nil {
+				return event, err
+			}
 		}
 	}
 	for id, subscriber := range j.subscribers {
@@ -236,13 +747,21 @@ func (j *Journal) Append(event Event) (Event, error) {
 }
 
 func (j *Journal) Read(after int64, limit int) (EventPage, error) {
-	j.mu.Lock()
-	if j.closed {
-		j.mu.Unlock()
-		return EventPage{}, errors.New("event journal is closed")
+	if err := j.ensureRetentionKnown(); err != nil {
+		return EventPage{}, err
 	}
-	if j.trimLocked(time.Now()) {
-		if err := j.maybeCompactLocked(); err != nil {
+	j.mu.Lock()
+	if err := j.readableErrorLocked(); err != nil {
+		j.mu.Unlock()
+		return EventPage{}, err
+	}
+	changed, err := j.trimLocked(time.Now())
+	if err != nil {
+		j.mu.Unlock()
+		return EventPage{}, err
+	}
+	if changed {
+		if err := j.checkpointLocked(); err != nil {
 			j.mu.Unlock()
 			return EventPage{}, err
 		}
@@ -261,8 +780,7 @@ func (j *Journal) Read(after int64, limit int) (EventPage, error) {
 		return EventPage{}, err
 	}
 	defer backlog.Close()
-
-	events := make([]Event, 0, len(backlog.entries))
+	events := make([]Event, 0, min(limit, 1000))
 	for {
 		event, ok, err := backlog.Next()
 		if err != nil {
@@ -277,13 +795,20 @@ func (j *Journal) Read(after int64, limit int) (EventPage, error) {
 }
 
 func (j *Journal) Subscribe(after int64) (*EventBacklog, <-chan Event, func(), EventCursor, error) {
+	if err := j.ensureRetentionKnown(); err != nil {
+		return nil, nil, nil, EventCursor{}, err
+	}
 	j.mu.Lock()
 	defer j.mu.Unlock()
-	if j.closed {
-		return nil, nil, nil, EventCursor{}, errors.New("event journal is closed")
+	if err := j.readableErrorLocked(); err != nil {
+		return nil, nil, nil, EventCursor{}, err
 	}
-	if j.trimLocked(time.Now()) {
-		if err := j.maybeCompactLocked(); err != nil {
+	changed, err := j.trimLocked(time.Now())
+	if err != nil {
+		return nil, nil, nil, EventCursor{}, err
+	}
+	if changed {
+		if err := j.checkpointLocked(); err != nil {
 			return nil, nil, nil, EventCursor{}, err
 		}
 	}
@@ -320,34 +845,68 @@ func (j *Journal) Cursor() EventCursor {
 	return j.cursorLocked()
 }
 
+func (j *Journal) Stats() JournalStats {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return JournalStats{
+		FormatVersion:      journalFormatVersion,
+		SealedSegments:     len(j.manifest.Segments),
+		ActiveBytes:        j.activeSize,
+		ActiveEvents:       len(j.activeEntries),
+		RetainedBytes:      j.retainedBytes,
+		RetainedBytesKnown: j.retainedKnown,
+		LegacyDeferred:     j.manifest.Legacy != nil && !j.legacyLoaded,
+	}
+}
+
 func (j *Journal) SetRetention(retention EventRetentionSpec) error {
 	retention = normalizeSpec(SessionSpec{EventRetention: retention}).EventRetention
+	if err := j.ensureRetentionKnown(); err != nil {
+		return err
+	}
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	j.retention = retention
-	if !j.trimLocked(time.Now()) {
-		return nil
+	changed, err := j.trimLocked(time.Now())
+	if err != nil {
+		return err
 	}
-	return j.compactLocked()
+	if !changed {
+		return j.cleanupOrphanSegmentsLocked()
+	}
+	return errors.Join(j.checkpointLocked(), j.cleanupOrphanSegmentsLocked())
 }
 
 // Prune applies time- and size-based retention without requiring a new event.
 func (j *Journal) Prune(now time.Time) error {
+	if err := j.ensureRetentionKnown(); err != nil {
+		return err
+	}
 	j.mu.Lock()
 	defer j.mu.Unlock()
-	if j.closed || !j.trimLocked(now) {
+	if j.closed {
 		return nil
 	}
-	return j.maybeCompactLocked()
+	changed, err := j.trimLocked(now)
+	if err != nil {
+		return err
+	}
+	if changed {
+		err = j.checkpointLocked()
+	}
+	return errors.Join(err, j.cleanupOrphanSegmentsLocked())
 }
 
 func (j *Journal) Flush() error {
 	j.mu.Lock()
 	defer j.mu.Unlock()
-	if j.closed || j.file == nil {
+	if j.closed || j.activeFile == nil {
 		return nil
 	}
-	return j.file.Sync()
+	if err := j.activeFile.Sync(); err != nil {
+		return err
+	}
+	return j.checkpointLocked()
 }
 
 func (j *Journal) Close() error {
@@ -361,58 +920,509 @@ func (j *Journal) Close() error {
 		close(subscriber.ch)
 		delete(j.subscribers, id)
 	}
-	if j.file == nil {
+	var result error
+	if j.activeFile != nil {
+		result = errors.Join(result, j.activeFile.Sync())
+		result = errors.Join(result, j.checkpointLocked())
+		result = errors.Join(result, j.activeFile.Close())
+		j.activeFile = nil
+	}
+	return result
+}
+
+// sealActiveLocked publishes an immutable footer before atomically switching
+// the manifest to a freshly synced active segment.
+func (j *Journal) sealActiveLocked() error {
+	meta := segmentMetaFromEntries(j.manifest.ActiveFile, j.activeEntries, j.activeSize)
+	if meta.EventCount == 0 {
 		return nil
 	}
-	if err := j.file.Sync(); err != nil {
-		_ = j.file.Close()
+	if err := writeJournalSegmentFooter(j.activeFile, meta); err != nil {
+		j.fatalErr = err
 		return err
 	}
-	return j.file.Close()
+	if err := j.activeFile.Close(); err != nil {
+		j.fatalErr = err
+		return err
+	}
+	name, file, err := createJournalSegment(j.dir)
+	if err != nil {
+		j.fatalErr = err
+		return err
+	}
+	j.manifest.Segments = append(j.manifest.Segments, meta)
+	sort.Slice(j.manifest.Segments, func(i, k int) bool { return j.manifest.Segments[i].FirstSeq < j.manifest.Segments[k].FirstSeq })
+	j.manifest.ActiveFile = name
+	j.activeFile = file
+	j.activeSize = segmentHeaderSize
+	j.activeLogicalBytes = 0
+	j.activeEntries = nil
+	j.headCacheSource = ""
+	j.headCache = nil
+	j.headCacheIndex = 0
+	j.dirty = true
+	if err := j.checkpointLocked(); err != nil {
+		j.fatalErr = err
+		return err
+	}
+	return nil
+}
+
+// checkpointLocked advances the durable logical head before deleting whole
+// expired files. A crash can therefore leak an orphan but cannot resurrect it.
+func (j *Journal) checkpointLocked() error {
+	next := j.manifest
+	next.HeadSeq = j.headSeq
+	next.NextSeq = j.nextSeq
+	next.ActiveFile = j.manifest.ActiveFile
+	next.ActiveDataEnd = j.activeSize
+	next.ActiveLogicalBytes = j.activeLogicalBytes
+	if j.retainedKnown {
+		next.RetainedLogicalBytes = j.retainedBytes
+	} else {
+		next.RetainedLogicalBytes = -1
+	}
+	kept := make([]journalSegmentMeta, 0, len(j.manifest.Segments))
+	deletePaths := make([]string, 0)
+	for _, segment := range j.manifest.Segments {
+		if segment.LastSeq < j.headSeq {
+			deletePaths = append(deletePaths, filepath.Join(j.dir, segment.File))
+			continue
+		}
+		kept = append(kept, segment)
+	}
+	next.Segments = kept
+	if next.Legacy != nil && next.Legacy.LatestSeq < j.headSeq {
+		deletePaths = append(deletePaths, j.legacyPath)
+		if next.Legacy.IndexFile != "" {
+			deletePaths = append(deletePaths, filepath.Join(j.dir, next.Legacy.IndexFile))
+		}
+		next.Legacy = nil
+	}
+	if err := writeJournalManifest(j.manifestPath, &next); err != nil {
+		return err
+	}
+	j.manifest = next
+	if next.Legacy == nil {
+		j.legacyEntries = nil
+	}
+	j.dirty = false
+	var deleteErr error
+	for _, path := range deletePaths {
+		deleteErr = errors.Join(deleteErr, j.removeOrDeferLocked(path))
+	}
+	return deleteErr
 }
 
 func (j *Journal) openBacklogLocked(after int64, limit int) (*EventBacklog, error) {
-	start := sort.Search(len(j.entries), func(i int) bool {
-		return j.entries[i].seq > after
-	})
-	end := len(j.entries)
-	if limit > 0 && end-start > limit {
-		end = start + limit
+	backlog := &EventBacklog{after: after, head: j.headSeq, remaining: -1}
+	if limit > 0 {
+		backlog.remaining = limit
 	}
-	entries := append([]journalEntry(nil), j.entries[start:end]...)
-	if len(entries) == 0 {
-		return &EventBacklog{}, nil
+	pinned := make([]string, 0)
+	addSource := func(source journalBacklogSource) error {
+		file, err := os.Open(source.path)
+		if err != nil {
+			return err
+		}
+		source.file = file
+		j.pins[source.path]++
+		pinned = append(pinned, source.path)
+		backlog.sources = append(backlog.sources, source)
+		return nil
 	}
-	file, err := os.Open(j.path)
-	if err != nil {
-		return nil, fmt.Errorf("open event journal snapshot: %w", err)
+	rollback := func() {
+		for i := range backlog.sources {
+			_ = backlog.sources[i].file.Close()
+		}
+		for _, path := range pinned {
+			j.pins[path]--
+			if j.pins[path] == 0 {
+				delete(j.pins, path)
+			}
+		}
 	}
-	return &EventBacklog{file: file, entries: entries}, nil
+	if j.manifest.Legacy != nil && j.legacyLoaded && j.manifest.Legacy.LatestSeq > after && j.manifest.Legacy.LatestSeq >= j.headSeq {
+		start := sort.Search(len(j.legacyEntries), func(i int) bool { return j.legacyEntries[i].seq > after && j.legacyEntries[i].seq >= j.headSeq })
+		if start < len(j.legacyEntries) {
+			entries := append([]journalEntry(nil), j.legacyEntries[start:]...)
+			if err := addSource(journalBacklogSource{format: journalBacklogLegacy, path: j.legacyPath, entries: entries}); err != nil {
+				rollback()
+				return nil, fmt.Errorf("open legacy journal snapshot: %w", err)
+			}
+		}
+	}
+	for _, segment := range j.manifest.Segments {
+		if segment.LastSeq <= after || segment.LastSeq < j.headSeq {
+			continue
+		}
+		startSeq := maxInt64(after+1, j.headSeq)
+		offset := journalSegmentStartOffset(segment, startSeq)
+		path := filepath.Join(j.dir, segment.File)
+		if err := addSource(journalBacklogSource{format: journalBacklogSegment, path: path, offset: offset, end: segment.DataEnd}); err != nil {
+			rollback()
+			return nil, fmt.Errorf("open journal segment snapshot: %w", err)
+		}
+	}
+	if len(j.activeEntries) > 0 && j.activeEntries[len(j.activeEntries)-1].seq > after && j.activeEntries[len(j.activeEntries)-1].seq >= j.headSeq {
+		path := filepath.Join(j.dir, j.manifest.ActiveFile)
+		if err := addSource(journalBacklogSource{format: journalBacklogSegment, path: path, offset: segmentHeaderSize, end: j.activeSize}); err != nil {
+			rollback()
+			return nil, fmt.Errorf("open active journal snapshot: %w", err)
+		}
+	}
+	backlog.release = func() { j.releasePins(pinned) }
+	return backlog, nil
 }
 
-func readJournalEvent(file *os.File, entry journalEntry) (Event, error) {
+func (j *Journal) releasePins(paths []string) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	for _, path := range paths {
+		j.pins[path]--
+		if j.pins[path] > 0 {
+			continue
+		}
+		delete(j.pins, path)
+		if _, pending := j.pendingDelete[path]; pending {
+			_ = os.Remove(path)
+			delete(j.pendingDelete, path)
+		}
+	}
+}
+
+func (j *Journal) removeOrDeferLocked(path string) error {
+	if j.pins[path] > 0 {
+		j.pendingDelete[path] = struct{}{}
+		return nil
+	}
+	err := os.Remove(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+func (j *Journal) cleanupOrphanSegmentsLocked() error {
+	entries, err := os.ReadDir(j.dir)
+	if err != nil {
+		return fmt.Errorf("read journal directory for orphan cleanup: %w", err)
+	}
+	live := make(map[string]struct{}, len(j.manifest.Segments)+1)
+	live[j.manifest.ActiveFile] = struct{}{}
+	for _, segment := range j.manifest.Segments {
+		live[segment.File] = struct{}{}
+	}
+	var cleanupErr error
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || filepath.Ext(name) != ".sjr" {
+			continue
+		}
+		if _, ok := live[name]; ok {
+			continue
+		}
+		if err := validateJournalFileName(name); err != nil {
+			continue
+		}
+		path := filepath.Join(j.dir, name)
+		cleanupErr = errors.Join(cleanupErr, j.removeOrDeferLocked(path))
+	}
+	return cleanupErr
+}
+
+func readLegacyJournalEvent(file *os.File, entry journalEntry) (Event, error) {
 	if file == nil {
-		return Event{}, errors.New("event journal snapshot is closed")
+		return Event{}, errors.New("legacy event journal snapshot is closed")
 	}
 	if entry.size <= 0 || entry.size > int64(maxInt()) {
-		return Event{}, fmt.Errorf("invalid event journal record size %d", entry.size)
+		return Event{}, fmt.Errorf("invalid legacy event journal record size %d", entry.size)
 	}
 	line := make([]byte, int(entry.size))
 	if _, err := file.ReadAt(line, entry.offset); err != nil {
-		return Event{}, fmt.Errorf("read event journal record: %w", err)
+		return Event{}, fmt.Errorf("read legacy event journal record: %w", err)
 	}
 	var event Event
 	if err := json.Unmarshal(bytes.TrimSpace(line), &event); err != nil {
-		return Event{}, fmt.Errorf("decode event journal record: %w", err)
+		return Event{}, fmt.Errorf("decode legacy event journal record: %w", err)
 	}
 	if event.Seq != entry.seq {
-		return Event{}, fmt.Errorf("event journal record sequence %d does not match index %d", event.Seq, entry.seq)
+		return Event{}, fmt.Errorf("legacy event journal sequence %d does not match index %d", event.Seq, entry.seq)
 	}
 	return event, nil
 }
 
-func maxInt() int {
-	return int(^uint(0) >> 1)
+// ensureRetentionKnown performs deferred legacy indexing and, at most, scans
+// frame headers in the one sealed segment containing the retained head.
+func (j *Journal) ensureRetentionKnown() error {
+	if err := j.ensureLegacyLoaded(); err != nil {
+		return err
+	}
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.retainedKnown || j.closed {
+		return nil
+	}
+	total, err := j.computeRetainedBytesLocked()
+	if err != nil {
+		return err
+	}
+	j.retainedBytes = total
+	j.retainedKnown = true
+	j.dirty = true
+	return nil
+}
+
+func (j *Journal) ensureLegacyLoaded() error {
+	j.mu.Lock()
+	hasLegacy := j.manifest.Legacy != nil
+	j.mu.Unlock()
+	if !hasLegacy {
+		return nil
+	}
+	j.legacyOnce.Do(func() {
+		j.mu.Lock()
+		legacy := *j.manifest.Legacy
+		j.mu.Unlock()
+		indexPath := filepath.Join(j.dir, legacy.IndexFile)
+		entries, err := readLegacyJournalIndex(indexPath, legacy.ValidBytes)
+		if err != nil {
+			entries, _, err = loadLegacyJournal(j.legacyPath, legacy.ValidBytes)
+			if err == nil {
+				err = writeLegacyJournalIndex(indexPath, legacy.ValidBytes, entries)
+			}
+		}
+		if err != nil {
+			j.legacyLoadErr = err
+			return
+		}
+		j.mu.Lock()
+		j.legacyEntries = entries
+		j.legacyLoaded = true
+		if len(entries) > 0 && j.manifest.Legacy != nil {
+			updated := *j.manifest.Legacy
+			updated.EarliestSeq = entries[0].seq
+			updated.LatestSeq = entries[len(entries)-1].seq
+			var retained int64
+			for _, entry := range entries {
+				if entry.seq >= j.headSeq {
+					retained += entry.size
+				}
+			}
+			updated.RetainedLogicalBytes = retained
+			j.manifest.Legacy = &updated
+		}
+		j.mu.Unlock()
+	})
+	return j.legacyLoadErr
+}
+
+func loadLegacyJournal(path string, validLimit int64) ([]journalEntry, int64, error) {
+	file, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, 0, nil
+	}
+	if err != nil {
+		return nil, 0, fmt.Errorf("open legacy event journal for replay: %w", err)
+	}
+	defer file.Close()
+	reader := bufio.NewReaderSize(io.LimitReader(file, validLimit), 64*1024)
+	var entries []journalEntry
+	var previous int64
+	var validBytes int64
+	for validBytes < validLimit {
+		offset := validBytes
+		line, readErr := reader.ReadBytes('\n')
+		complete := bytes.HasSuffix(line, []byte{'\n'})
+		if len(bytes.TrimSpace(line)) > 0 {
+			if readErr == io.EOF && !complete {
+				break
+			}
+			var event Event
+			if err := json.Unmarshal(bytes.TrimSpace(line), &event); err != nil {
+				return nil, 0, fmt.Errorf("decode legacy event journal: %w", err)
+			}
+			if event.Seq <= previous {
+				return nil, 0, fmt.Errorf("legacy event journal sequence %d is not greater than %d", event.Seq, previous)
+			}
+			previous = event.Seq
+			entries = append(entries, journalEntry{seq: event.Seq, offset: offset, size: int64(len(line)), occurredAtNano: event.OccurredAt.UnixNano()})
+		}
+		if complete {
+			validBytes += int64(len(line))
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				break
+			}
+			return nil, 0, fmt.Errorf("read legacy event journal: %w", readErr)
+		}
+	}
+	if validBytes != validLimit {
+		return nil, validBytes, fmt.Errorf("legacy event journal index ended at %d, want %d", validBytes, validLimit)
+	}
+	return entries, validBytes, nil
+}
+
+func (j *Journal) computeRetainedBytesLocked() (int64, error) {
+	total := int64(0)
+	if j.manifest.Legacy != nil {
+		if !j.legacyLoaded {
+			return 0, errors.New("legacy event journal is not indexed")
+		}
+		for _, entry := range j.legacyEntries {
+			if entry.seq >= j.headSeq {
+				total += entry.size
+			}
+		}
+	}
+	for _, segment := range j.manifest.Segments {
+		switch {
+		case segment.LastSeq < j.headSeq:
+			continue
+		case segment.FirstSeq >= j.headSeq:
+			total += segment.LogicalBytes
+		default:
+			file, err := os.Open(filepath.Join(j.dir, segment.File))
+			if err != nil {
+				return 0, err
+			}
+			entries, scanErr := scanJournalSegmentMetadata(file, journalSegmentStartOffset(segment, j.headSeq), segment.DataEnd)
+			closeErr := file.Close()
+			if scanErr != nil || closeErr != nil {
+				return 0, errors.Join(scanErr, closeErr)
+			}
+			for _, entry := range entries {
+				if entry.seq >= j.headSeq {
+					total += entry.logicalSize
+				}
+			}
+		}
+	}
+	for _, entry := range j.activeEntries {
+		if entry.seq >= j.headSeq {
+			total += entry.logicalSize
+		}
+	}
+	return total, nil
+}
+
+func (j *Journal) trimLocked(now time.Time) (bool, error) {
+	if !j.retainedKnown {
+		return false, nil
+	}
+	changed := false
+	if j.retention.MaxAgeSeconds > 0 {
+		cutoff := now.Add(-time.Duration(j.retention.MaxAgeSeconds) * time.Second).UnixNano()
+		for {
+			entry, ok, err := j.peekHeadLocked()
+			if err != nil {
+				return changed, err
+			}
+			if !ok || entry.occurredAtNano >= cutoff {
+				break
+			}
+			j.advanceHeadLocked(entry)
+			changed = true
+		}
+	}
+	if j.retention.MaxBytes > 0 {
+		for j.retainedBytes > j.retention.MaxBytes {
+			entry, ok, err := j.peekHeadLocked()
+			if err != nil {
+				return changed, err
+			}
+			if !ok {
+				j.retainedBytes = 0
+				break
+			}
+			j.advanceHeadLocked(entry)
+			changed = true
+		}
+	}
+	if changed {
+		j.dirty = true
+	}
+	return changed, nil
+}
+
+func (j *Journal) peekHeadLocked() (journalRecordMeta, bool, error) {
+	for {
+		if j.headCacheIndex < len(j.headCache) {
+			entry := j.headCache[j.headCacheIndex]
+			if entry.seq >= j.headSeq {
+				if entry.seq > j.headSeq {
+					j.headSeq = entry.seq
+				}
+				return entry, true, nil
+			}
+			j.headCacheIndex++
+			continue
+		}
+		j.headCacheSource = ""
+		j.headCache = nil
+		j.headCacheIndex = 0
+		if j.manifest.Legacy != nil && j.legacyLoaded && j.headSeq <= j.manifest.Legacy.LatestSeq {
+			start := sort.Search(len(j.legacyEntries), func(i int) bool { return j.legacyEntries[i].seq >= j.headSeq })
+			if start < len(j.legacyEntries) {
+				j.headCacheSource = "legacy"
+				j.headCache = make([]journalRecordMeta, 0, len(j.legacyEntries)-start)
+				for _, entry := range j.legacyEntries[start:] {
+					j.headCache = append(j.headCache, journalRecordMeta{seq: entry.seq, offset: entry.offset, frameSize: entry.size, payloadSize: entry.size, logicalSize: entry.size, occurredAtNano: entry.occurredAtNano})
+				}
+				continue
+			}
+		}
+		loaded := false
+		for _, segment := range j.manifest.Segments {
+			if segment.LastSeq < j.headSeq {
+				continue
+			}
+			file, err := os.Open(filepath.Join(j.dir, segment.File))
+			if err != nil {
+				return journalRecordMeta{}, false, err
+			}
+			entries, scanErr := scanJournalSegmentMetadata(file, journalSegmentStartOffset(segment, j.headSeq), segment.DataEnd)
+			closeErr := file.Close()
+			if scanErr != nil || closeErr != nil {
+				return journalRecordMeta{}, false, errors.Join(scanErr, closeErr)
+			}
+			start := sort.Search(len(entries), func(i int) bool { return entries[i].seq >= j.headSeq })
+			j.headCacheSource = segment.File
+			j.headCache = entries[start:]
+			loaded = true
+			break
+		}
+		if loaded {
+			continue
+		}
+		start := sort.Search(len(j.activeEntries), func(i int) bool { return j.activeEntries[i].seq >= j.headSeq })
+		if start < len(j.activeEntries) {
+			j.headCacheSource = j.manifest.ActiveFile
+			j.headCache = append([]journalRecordMeta(nil), j.activeEntries[start:]...)
+			continue
+		}
+		j.headSeq = j.nextSeq
+		return journalRecordMeta{}, false, nil
+	}
+}
+
+func (j *Journal) advanceHeadLocked(entry journalRecordMeta) {
+	j.retainedBytes -= entry.logicalSize
+	if j.retainedBytes < 0 {
+		j.retainedBytes = 0
+	}
+	j.headSeq = entry.seq + 1
+	j.headCacheIndex++
+}
+
+func (j *Journal) hasExpiredFilesLocked() bool {
+	for _, segment := range j.manifest.Segments {
+		if segment.LastSeq < j.headSeq {
+			return true
+		}
+	}
+	return j.manifest.Legacy != nil && j.manifest.Legacy.LatestSeq < j.headSeq
 }
 
 func (j *Journal) validateCursorLocked(after int64) error {
@@ -431,115 +1441,74 @@ func (j *Journal) validateCursorLocked(after int64) error {
 
 func (j *Journal) cursorLocked() EventCursor {
 	latest := j.nextSeq - 1
-	if latest < 0 {
-		latest = 0
+	if latest <= 0 {
+		return EventCursor{}
 	}
-	earliest := int64(0)
-	if len(j.entries) > 0 {
-		earliest = j.entries[0].seq
-	} else if latest > 0 {
-		// No event is retained, so the next sequence is the lower bound of the
-		// retained window. A client can resume only after the current latest.
+	earliest := j.headSeq
+	if earliest <= 0 {
+		earliest = 1
+	}
+	if earliest > latest {
 		earliest = j.nextSeq
 	}
 	return EventCursor{Earliest: earliest, Latest: latest}
 }
 
-func (j *Journal) trimLocked(now time.Time) bool {
-	removed := 0
-	if j.retention.MaxAgeSeconds > 0 {
-		cutoff := now.Add(-time.Duration(j.retention.MaxAgeSeconds) * time.Second).UnixNano()
-		for removed < len(j.entries) && j.entries[removed].occurredAtNano < cutoff {
-			j.totalBytes -= j.entries[removed].size
-			removed++
-		}
-	}
-	if j.retention.MaxBytes > 0 {
-		for removed < len(j.entries) && j.totalBytes > j.retention.MaxBytes {
-			j.totalBytes -= j.entries[removed].size
-			removed++
-		}
-	}
-	if removed == 0 {
-		return false
-	}
-	j.entries = j.entries[removed:]
-	return true
-}
-
-func (j *Journal) maybeCompactLocked() error {
-	staleBytes := j.staleBytesLocked()
-	if staleBytes == 0 {
-		return nil
-	}
-	retainedBytes := j.fileSize - staleBytes
-	threshold := j.retention.MaxBytes / 4
-	if threshold < journalCompactionMinStaleBytes {
-		threshold = journalCompactionMinStaleBytes
-	}
-	if threshold > journalCompactionMaxStaleBytes {
-		threshold = journalCompactionMaxStaleBytes
-	}
-	if staleBytes < threshold && staleBytes < retainedBytes {
-		return nil
-	}
-	return j.compactLocked()
-}
-
-func (j *Journal) staleBytesLocked() int64 {
-	if len(j.entries) == 0 {
-		return j.fileSize
-	}
-	return j.entries[0].offset
-}
-
-func (j *Journal) compactLocked() error {
-	start := j.staleBytesLocked()
-	if start == 0 {
-		return nil
-	}
-	retainedBytes := j.fileSize - start
-	tmp, err := os.CreateTemp(filepath.Dir(j.path), ".events-*.tmp")
-	if err != nil {
-		return fmt.Errorf("create compacted event journal: %w", err)
-	}
-	tmpPath := tmp.Name()
-	defer os.Remove(tmpPath)
-	if err := tmp.Chmod(0o600); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("chmod compacted event journal: %w", err)
-	}
-	if retainedBytes > 0 {
-		if _, err := io.CopyN(tmp, io.NewSectionReader(j.file, start, retainedBytes), retainedBytes); err != nil {
-			_ = tmp.Close()
-			return fmt.Errorf("copy compacted event journal: %w", err)
-		}
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("sync compacted event journal: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("close compacted event journal: %w", err)
-	}
-	if err := j.file.Close(); err != nil {
-		return fmt.Errorf("close event journal before compaction: %w", err)
-	}
-	if err := os.Rename(tmpPath, j.path); err != nil {
-		file, reopenErr := os.OpenFile(j.path, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)
-		if reopenErr == nil {
-			j.file = file
-		}
-		return errors.Join(fmt.Errorf("replace compacted event journal: %w", err), reopenErr)
-	}
-	file, err := os.OpenFile(j.path, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)
-	if err != nil {
-		return fmt.Errorf("reopen compacted event journal: %w", err)
-	}
-	j.file = file
-	j.fileSize = retainedBytes
-	for i := range j.entries {
-		j.entries[i].offset -= start
+func (j *Journal) readableErrorLocked() error {
+	if j.closed {
+		return errors.New("event journal is closed")
 	}
 	return nil
+}
+
+func (j *Journal) writableErrorLocked() error {
+	if err := j.readableErrorLocked(); err != nil {
+		return err
+	}
+	if j.fatalErr != nil {
+		return fmt.Errorf("event journal requires recovery: %w", j.fatalErr)
+	}
+	return nil
+}
+
+func journalRecordLogicalBytes(entries []journalRecordMeta) int64 {
+	var total int64
+	for _, entry := range entries {
+		total += entry.logicalSize
+	}
+	return total
+}
+
+func latestRecordSequence(entries []journalRecordMeta) int64 {
+	if len(entries) == 0 {
+		return 0
+	}
+	return entries[len(entries)-1].seq
+}
+
+func firstJournalSequence(legacy *journalLegacyMeta, segments []journalSegmentMeta, active []journalRecordMeta) int64 {
+	first := int64(0)
+	if legacy != nil && legacy.EarliestSeq > 0 {
+		first = legacy.EarliestSeq
+	}
+	for _, segment := range segments {
+		if segment.FirstSeq > 0 && (first == 0 || segment.FirstSeq < first) {
+			first = segment.FirstSeq
+		}
+	}
+	if len(active) > 0 && (first == 0 || active[0].seq < first) {
+		first = active[0].seq
+	}
+	return first
+}
+
+func positiveSequence(value int64) int64 {
+	if value > 0 {
+		return value
+	}
+	return 0
+}
+
+func maxInt() int {
+	return int(^uint(0) >> 1)
 }

--- a/manager/procd/pkg/session/journal_benchmark_test.go
+++ b/manager/procd/pkg/session/journal_benchmark_test.go
@@ -1,0 +1,131 @@
+package session
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+var journalBenchmarkSizes = []struct {
+	name string
+	size int64
+}{
+	{name: "regular-1MiB", size: 1 << 20},
+	{name: "large-64MiB", size: 64 << 20},
+	{name: "huge-256MiB", size: 256 << 20},
+}
+
+func BenchmarkJournalResumeV2(b *testing.B) {
+	for _, size := range journalBenchmarkSizes {
+		b.Run(size.name, func(b *testing.B) {
+			path, cursor, stats := buildV2BenchmarkJournal(b, size.size)
+			b.ReportMetric(float64(stats.ActiveBytes), "active_bytes")
+			b.ReportMetric(float64(stats.SealedSegments), "sealed_segments")
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				journal, err := OpenJournal(path, benchmarkRetention(size.size), cursor)
+				if err != nil {
+					b.Fatal(err)
+				}
+				b.StopTimer()
+				if err := journal.Close(); err != nil {
+					b.Fatal(err)
+				}
+				b.StartTimer()
+			}
+		})
+	}
+}
+
+// BenchmarkLegacyJournalFullScan records the activation cost that v1 paid on
+// every resume. V2 keeps this work off the activation path and performs it only
+// when legacy history is first queried or pruned.
+func BenchmarkLegacyJournalFullScan(b *testing.B) {
+	for _, size := range journalBenchmarkSizes {
+		b.Run(size.name, func(b *testing.B) {
+			path, validBytes := buildLegacyBenchmarkJournal(b, size.size)
+			b.ReportMetric(float64(validBytes), "journal_bytes")
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				entries, indexedBytes, err := loadLegacyJournal(path, validBytes)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if indexedBytes != validBytes || len(entries) == 0 {
+					b.Fatalf("indexed (%d, %d), want %d bytes", len(entries), indexedBytes, validBytes)
+				}
+			}
+		})
+	}
+}
+
+func buildV2BenchmarkJournal(b *testing.B, targetBytes int64) (string, EventCursor, JournalStats) {
+	b.Helper()
+	path := filepath.Join(b.TempDir(), "events.jsonl")
+	journal, err := OpenJournal(path, benchmarkRetention(targetBytes), EventCursor{})
+	if err != nil {
+		b.Fatal(err)
+	}
+	payload := strings.Repeat("x", 32<<10)
+	count := int(targetBytes/int64(len(payload))) + 1
+	for i := 0; i < count; i++ {
+		if _, err := journal.Append(Event{SessionID: "ses-benchmark", Type: "output", DataBase64: payload}); err != nil {
+			b.Fatal(err)
+		}
+	}
+	cursor := journal.Cursor()
+	stats := journal.Stats()
+	if err := journal.Close(); err != nil {
+		b.Fatal(err)
+	}
+	return path, cursor, stats
+}
+
+func buildLegacyBenchmarkJournal(b *testing.B, targetBytes int64) (string, int64) {
+	b.Helper()
+	path := filepath.Join(b.TempDir(), "events.jsonl")
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		b.Fatal(err)
+	}
+	writer := bufio.NewWriterSize(file, 1<<20)
+	payload := strings.Repeat("x", 32<<10)
+	written := int64(0)
+	for seq := int64(1); written < targetBytes; seq++ {
+		line, err := json.Marshal(Event{
+			Seq:        seq,
+			SessionID:  "ses-benchmark",
+			Type:       "output",
+			DataBase64: payload,
+			OccurredAt: time.Now().UTC(),
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+		line = append(line, '\n')
+		if _, err := writer.Write(line); err != nil {
+			b.Fatal(err)
+		}
+		written += int64(len(line))
+	}
+	if err := writer.Flush(); err != nil {
+		b.Fatal(err)
+	}
+	if err := file.Sync(); err != nil {
+		b.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		b.Fatal(err)
+	}
+	return path, written
+}
+
+func benchmarkRetention(size int64) EventRetentionSpec {
+	return EventRetentionSpec{MaxBytes: size + 64<<20, MaxAgeSeconds: 24 * 60 * 60}
+}

--- a/manager/procd/pkg/session/journal_segment.go
+++ b/manager/procd/pkg/session/journal_segment.go
@@ -1,0 +1,664 @@
+package session
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+
+	"github.com/google/uuid"
+)
+
+const (
+	journalFormatVersion        = 2
+	journalDirectoryName        = "journal-v2"
+	journalManifestName         = "manifest.json"
+	journalLegacyIndexName      = "legacy.idx"
+	defaultJournalSegmentBytes  = int64(4 << 20)
+	minimumJournalSegmentBytes  = int64(64 << 10)
+	segmentHeaderSize           = int64(16)
+	segmentFrameHeaderSize      = int64(32)
+	segmentFooterPrefixSize     = int64(8)
+	segmentFooterTrailerSize    = int64(20)
+	segmentSparseIndexStride    = 64
+	maximumJournalFramePayload  = int64(64 << 20)
+	maximumJournalFooterPayload = int64(16 << 20)
+	legacyIndexHeaderSize       = int64(32)
+	legacyIndexEntrySize        = int64(32)
+)
+
+var (
+	segmentHeaderMagic = [8]byte{'S', '0', 'J', 'S', 'E', 'G', '2', '\n'}
+	segmentFooterMagic = [8]byte{'S', '0', 'J', 'E', 'N', 'D', '2', '\n'}
+	legacyIndexMagic   = [8]byte{'S', '0', 'J', 'I', 'D', 'X', '2', '\n'}
+	journalCRCTable    = crc32.MakeTable(crc32.Castagnoli)
+)
+
+// A segment starts with segmentHeaderMagic, followed by independently
+// checksummed frames. Sealing appends segmentFooterMagic, JSON metadata, a
+// metadata checksum, and the magic again. DataEnd excludes the footer so
+// snapshot readers never interpret index bytes as events.
+
+type journalSparseEntry struct {
+	Seq            int64 `json:"seq"`
+	Offset         int64 `json:"offset"`
+	OccurredAtNano int64 `json:"occurred_at_nano"`
+	LogicalBefore  int64 `json:"logical_before"`
+}
+
+type journalSegmentMeta struct {
+	File            string               `json:"file"`
+	FirstSeq        int64                `json:"first_seq"`
+	LastSeq         int64                `json:"last_seq"`
+	FirstOccurredAt int64                `json:"first_occurred_at_nano"`
+	LastOccurredAt  int64                `json:"last_occurred_at_nano"`
+	DataEnd         int64                `json:"data_end"`
+	LogicalBytes    int64                `json:"logical_bytes"`
+	EventCount      int64                `json:"event_count"`
+	Sparse          []journalSparseEntry `json:"sparse,omitempty"`
+}
+
+type journalLegacyMeta struct {
+	File                 string `json:"file"`
+	IndexFile            string `json:"index_file,omitempty"`
+	ValidBytes           int64  `json:"valid_bytes"`
+	EarliestSeq          int64  `json:"earliest_seq"`
+	LatestSeq            int64  `json:"latest_seq"`
+	RetainedLogicalBytes int64  `json:"retained_logical_bytes"`
+}
+
+type journalManifest struct {
+	Version              int                  `json:"version"`
+	Generation           int64                `json:"generation"`
+	SegmentTargetBytes   int64                `json:"segment_target_bytes"`
+	HeadSeq              int64                `json:"head_seq"`
+	NextSeq              int64                `json:"next_seq"`
+	RetainedLogicalBytes int64                `json:"retained_logical_bytes"`
+	Segments             []journalSegmentMeta `json:"segments,omitempty"`
+	ActiveFile           string               `json:"active_file"`
+	ActiveDataEnd        int64                `json:"active_data_end"`
+	ActiveLogicalBytes   int64                `json:"active_logical_bytes"`
+	Legacy               *journalLegacyMeta   `json:"legacy,omitempty"`
+}
+
+type journalRecordMeta struct {
+	seq            int64
+	offset         int64
+	frameSize      int64
+	payloadSize    int64
+	logicalSize    int64
+	occurredAtNano int64
+}
+
+func normalizedJournalSegmentTarget(retention EventRetentionSpec, requested int64) int64 {
+	if requested <= 0 {
+		requested = defaultJournalSegmentBytes
+	}
+	if retention.MaxBytes > 0 && retention.MaxBytes < requested {
+		requested = retention.MaxBytes
+	}
+	if requested < minimumJournalSegmentBytes {
+		requested = minimumJournalSegmentBytes
+	}
+	return requested
+}
+
+func journalDirectoryForPath(path string) string {
+	return filepath.Join(filepath.Dir(path), journalDirectoryName)
+}
+
+func journalManifestPath(path string) string {
+	return filepath.Join(journalDirectoryForPath(path), journalManifestName)
+}
+
+func validateJournalFileName(name string) error {
+	if name == "" || filepath.Base(name) != name || !strings.HasPrefix(name, "seg-") || !strings.HasSuffix(name, ".sjr") {
+		return fmt.Errorf("invalid journal segment file %q", name)
+	}
+	return nil
+}
+
+func createJournalSegment(dir string) (string, *os.File, error) {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", nil, fmt.Errorf("create journal directory: %w", err)
+	}
+	name := "seg-" + uuid.NewString() + ".sjr"
+	path := filepath.Join(dir, name)
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_RDWR|os.O_APPEND, 0o600)
+	if err != nil {
+		return "", nil, fmt.Errorf("create journal segment: %w", err)
+	}
+	header := make([]byte, segmentHeaderSize)
+	copy(header, segmentHeaderMagic[:])
+	binary.LittleEndian.PutUint32(header[8:12], journalFormatVersion)
+	if _, err := file.Write(header); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return "", nil, fmt.Errorf("write journal segment header: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return "", nil, fmt.Errorf("sync journal segment header: %w", err)
+	}
+	return name, file, nil
+}
+
+func validateJournalSegmentHeader(file *os.File) error {
+	header := make([]byte, segmentHeaderSize)
+	if _, err := file.ReadAt(header, 0); err != nil {
+		return fmt.Errorf("read journal segment header: %w", err)
+	}
+	if string(header[:8]) != string(segmentHeaderMagic[:]) {
+		return errors.New("journal segment header magic is invalid")
+	}
+	if version := binary.LittleEndian.Uint32(header[8:12]); version != journalFormatVersion {
+		return fmt.Errorf("journal segment version %d is unsupported", version)
+	}
+	return nil
+}
+
+func encodeJournalFrame(event Event) ([]byte, journalRecordMeta, error) {
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return nil, journalRecordMeta{}, fmt.Errorf("encode event: %w", err)
+	}
+	if int64(len(payload)) > maximumJournalFramePayload {
+		return nil, journalRecordMeta{}, fmt.Errorf("event payload is %d bytes, limit is %d", len(payload), maximumJournalFramePayload)
+	}
+	header := make([]byte, segmentFrameHeaderSize)
+	binary.LittleEndian.PutUint32(header[0:4], uint32(len(payload)))
+	binary.LittleEndian.PutUint64(header[8:16], uint64(event.Seq))
+	binary.LittleEndian.PutUint64(header[16:24], uint64(event.OccurredAt.UnixNano()))
+	logicalSize := int64(len(payload) + 1)
+	binary.LittleEndian.PutUint64(header[24:32], uint64(logicalSize))
+	checksum := crc32.New(journalCRCTable)
+	_, _ = checksum.Write(header[:4])
+	_, _ = checksum.Write(header[8:])
+	_, _ = checksum.Write(payload)
+	binary.LittleEndian.PutUint32(header[4:8], checksum.Sum32())
+	frame := make([]byte, 0, len(header)+len(payload))
+	frame = append(frame, header...)
+	frame = append(frame, payload...)
+	return frame, journalRecordMeta{
+		seq:            event.Seq,
+		frameSize:      int64(len(frame)),
+		payloadSize:    int64(len(payload)),
+		logicalSize:    logicalSize,
+		occurredAtNano: event.OccurredAt.UnixNano(),
+	}, nil
+}
+
+func readJournalFrameMeta(file *os.File, offset, end int64) (journalRecordMeta, error) {
+	if offset < segmentHeaderSize || end-offset < segmentFrameHeaderSize {
+		return journalRecordMeta{}, io.ErrUnexpectedEOF
+	}
+	header := make([]byte, segmentFrameHeaderSize)
+	if _, err := file.ReadAt(header, offset); err != nil {
+		return journalRecordMeta{}, err
+	}
+	payloadSize := int64(binary.LittleEndian.Uint32(header[0:4]))
+	if payloadSize < 0 || payloadSize > maximumJournalFramePayload {
+		return journalRecordMeta{}, fmt.Errorf("invalid journal frame payload size %d", payloadSize)
+	}
+	frameSize := segmentFrameHeaderSize + payloadSize
+	if frameSize > end-offset {
+		return journalRecordMeta{}, io.ErrUnexpectedEOF
+	}
+	seq := int64(binary.LittleEndian.Uint64(header[8:16]))
+	logicalSize := int64(binary.LittleEndian.Uint64(header[24:32]))
+	if seq <= 0 || logicalSize <= 0 {
+		return journalRecordMeta{}, errors.New("journal frame metadata is invalid")
+	}
+	return journalRecordMeta{
+		seq:            seq,
+		offset:         offset,
+		frameSize:      frameSize,
+		payloadSize:    payloadSize,
+		logicalSize:    logicalSize,
+		occurredAtNano: int64(binary.LittleEndian.Uint64(header[16:24])),
+	}, nil
+}
+
+func readJournalFrame(file *os.File, meta journalRecordMeta) (Event, error) {
+	if meta.payloadSize < 0 || meta.payloadSize > maximumJournalFramePayload {
+		return Event{}, fmt.Errorf("invalid journal frame payload size %d", meta.payloadSize)
+	}
+	header := make([]byte, segmentFrameHeaderSize)
+	if _, err := file.ReadAt(header, meta.offset); err != nil {
+		return Event{}, fmt.Errorf("read journal frame header: %w", err)
+	}
+	payload := make([]byte, int(meta.payloadSize))
+	if _, err := file.ReadAt(payload, meta.offset+segmentFrameHeaderSize); err != nil {
+		return Event{}, fmt.Errorf("read journal frame payload: %w", err)
+	}
+	checksum := crc32.New(journalCRCTable)
+	_, _ = checksum.Write(header[:4])
+	_, _ = checksum.Write(header[8:])
+	_, _ = checksum.Write(payload)
+	if got, want := checksum.Sum32(), binary.LittleEndian.Uint32(header[4:8]); got != want {
+		return Event{}, fmt.Errorf("journal frame checksum %08x does not match %08x", got, want)
+	}
+	var event Event
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return Event{}, fmt.Errorf("decode journal frame: %w", err)
+	}
+	if event.Seq != meta.seq {
+		return Event{}, fmt.Errorf("journal frame sequence %d does not match index %d", event.Seq, meta.seq)
+	}
+	return event, nil
+}
+
+func verifyJournalFrame(file *os.File, meta journalRecordMeta, scratch []byte) error {
+	header := make([]byte, segmentFrameHeaderSize)
+	if _, err := file.ReadAt(header, meta.offset); err != nil {
+		return fmt.Errorf("read journal frame header: %w", err)
+	}
+	checksum := crc32.New(journalCRCTable)
+	_, _ = checksum.Write(header[:4])
+	_, _ = checksum.Write(header[8:])
+	if len(scratch) == 0 {
+		scratch = make([]byte, 64<<10)
+	}
+	readOffset := meta.offset + segmentFrameHeaderSize
+	remaining := meta.payloadSize
+	for remaining > 0 {
+		chunkSize := int64(len(scratch))
+		if chunkSize > remaining {
+			chunkSize = remaining
+		}
+		chunk := scratch[:int(chunkSize)]
+		if _, err := file.ReadAt(chunk, readOffset); err != nil {
+			return fmt.Errorf("checksum journal frame payload: %w", err)
+		}
+		_, _ = checksum.Write(chunk)
+		readOffset += chunkSize
+		remaining -= chunkSize
+	}
+	if got, want := checksum.Sum32(), binary.LittleEndian.Uint32(header[4:8]); got != want {
+		return fmt.Errorf("journal frame checksum %08x does not match %08x", got, want)
+	}
+	return nil
+}
+
+func scanActiveJournalSegment(file *os.File) ([]journalRecordMeta, int64, error) {
+	if err := validateJournalSegmentHeader(file); err != nil {
+		return nil, 0, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return nil, 0, fmt.Errorf("stat active journal segment: %w", err)
+	}
+	end := info.Size()
+	offset := segmentHeaderSize
+	entries := make([]journalRecordMeta, 0)
+	checksumScratch := make([]byte, 64<<10)
+	previous := int64(0)
+	for offset < end {
+		if end-offset >= segmentFooterPrefixSize {
+			prefix := make([]byte, segmentFooterPrefixSize)
+			if _, err := file.ReadAt(prefix, offset); err != nil {
+				return nil, 0, fmt.Errorf("read active journal tail prefix: %w", err)
+			}
+			if string(prefix) == string(segmentFooterMagic[:]) {
+				break
+			}
+		}
+		meta, metaErr := readJournalFrameMeta(file, offset, end)
+		if metaErr != nil {
+			break
+		}
+		if meta.seq <= previous {
+			return nil, 0, fmt.Errorf("journal sequence %d is not greater than %d", meta.seq, previous)
+		}
+		if err := verifyJournalFrame(file, meta, checksumScratch); err != nil {
+			if offset+meta.frameSize == end {
+				break
+			}
+			return nil, 0, fmt.Errorf("verify active journal frame at offset %d: %w", offset, err)
+		}
+		entries = append(entries, meta)
+		previous = meta.seq
+		offset += meta.frameSize
+	}
+	if offset < end {
+		if err := file.Truncate(offset); err != nil {
+			return nil, 0, fmt.Errorf("truncate incomplete active journal tail: %w", err)
+		}
+	}
+	return entries, offset, nil
+}
+
+func segmentMetaFromEntries(file string, entries []journalRecordMeta, dataEnd int64) journalSegmentMeta {
+	meta := journalSegmentMeta{File: file, DataEnd: dataEnd, EventCount: int64(len(entries))}
+	if len(entries) == 0 {
+		return meta
+	}
+	meta.FirstSeq = entries[0].seq
+	meta.LastSeq = entries[len(entries)-1].seq
+	meta.FirstOccurredAt = entries[0].occurredAtNano
+	meta.LastOccurredAt = entries[len(entries)-1].occurredAtNano
+	logicalBefore := int64(0)
+	for i, entry := range entries {
+		if i%segmentSparseIndexStride == 0 {
+			meta.Sparse = append(meta.Sparse, journalSparseEntry{
+				Seq:            entry.seq,
+				Offset:         entry.offset,
+				OccurredAtNano: entry.occurredAtNano,
+				LogicalBefore:  logicalBefore,
+			})
+		}
+		logicalBefore += entry.logicalSize
+	}
+	meta.LogicalBytes = logicalBefore
+	return meta
+}
+
+func writeJournalSegmentFooter(file *os.File, meta journalSegmentMeta) error {
+	payload, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("encode journal segment footer: %w", err)
+	}
+	trailer := make([]byte, segmentFooterTrailerSize)
+	binary.LittleEndian.PutUint64(trailer[0:8], uint64(len(payload)))
+	binary.LittleEndian.PutUint32(trailer[8:12], crc32.Checksum(payload, journalCRCTable))
+	copy(trailer[12:20], segmentFooterMagic[:])
+	if _, err := file.Write(segmentFooterMagic[:]); err != nil {
+		return fmt.Errorf("write journal segment footer prefix: %w", err)
+	}
+	if _, err := file.Write(payload); err != nil {
+		return fmt.Errorf("write journal segment footer: %w", err)
+	}
+	if _, err := file.Write(trailer); err != nil {
+		return fmt.Errorf("write journal segment footer trailer: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("sync sealed journal segment: %w", err)
+	}
+	return nil
+}
+
+func readJournalSegmentFooter(file *os.File) (journalSegmentMeta, bool, error) {
+	info, err := file.Stat()
+	if err != nil {
+		return journalSegmentMeta{}, false, err
+	}
+	if info.Size() < segmentHeaderSize+segmentFooterPrefixSize+segmentFooterTrailerSize {
+		return journalSegmentMeta{}, false, nil
+	}
+	trailer := make([]byte, segmentFooterTrailerSize)
+	if _, err := file.ReadAt(trailer, info.Size()-segmentFooterTrailerSize); err != nil {
+		return journalSegmentMeta{}, false, err
+	}
+	if string(trailer[12:20]) != string(segmentFooterMagic[:]) {
+		return journalSegmentMeta{}, false, nil
+	}
+	payloadSize := int64(binary.LittleEndian.Uint64(trailer[0:8]))
+	footerOffset := info.Size() - segmentFooterTrailerSize - payloadSize - segmentFooterPrefixSize
+	if payloadSize <= 0 || payloadSize > maximumJournalFooterPayload || footerOffset < segmentHeaderSize {
+		return journalSegmentMeta{}, false, errors.New("journal segment footer size is invalid")
+	}
+	prefix := make([]byte, segmentFooterPrefixSize)
+	if _, err := file.ReadAt(prefix, footerOffset); err != nil {
+		return journalSegmentMeta{}, false, err
+	}
+	if string(prefix) != string(segmentFooterMagic[:]) {
+		return journalSegmentMeta{}, false, errors.New("journal segment footer prefix is invalid")
+	}
+	payload := make([]byte, int(payloadSize))
+	if _, err := file.ReadAt(payload, footerOffset+segmentFooterPrefixSize); err != nil {
+		return journalSegmentMeta{}, false, err
+	}
+	if got, want := crc32.Checksum(payload, journalCRCTable), binary.LittleEndian.Uint32(trailer[8:12]); got != want {
+		return journalSegmentMeta{}, false, fmt.Errorf("journal segment footer checksum %08x does not match %08x", got, want)
+	}
+	var meta journalSegmentMeta
+	if err := json.Unmarshal(payload, &meta); err != nil {
+		return journalSegmentMeta{}, false, fmt.Errorf("decode journal segment footer: %w", err)
+	}
+	if meta.DataEnd != footerOffset {
+		return journalSegmentMeta{}, false, fmt.Errorf("journal segment data end %d does not match footer offset %d", meta.DataEnd, footerOffset)
+	}
+	return meta, true, nil
+}
+
+func journalSegmentStartOffset(meta journalSegmentMeta, seq int64) int64 {
+	offset := segmentHeaderSize
+	index := sort.Search(len(meta.Sparse), func(i int) bool { return meta.Sparse[i].Seq > seq })
+	if index > 0 {
+		offset = meta.Sparse[index-1].Offset
+	}
+	return offset
+}
+
+func scanJournalSegmentMetadata(file *os.File, start, end int64) ([]journalRecordMeta, error) {
+	entries := make([]journalRecordMeta, 0)
+	offset := start
+	for offset < end {
+		meta, err := readJournalFrameMeta(file, offset, end)
+		if err != nil {
+			return nil, fmt.Errorf("scan journal segment metadata at offset %d: %w", offset, err)
+		}
+		entries = append(entries, meta)
+		offset += meta.frameSize
+	}
+	if offset != end {
+		return nil, fmt.Errorf("journal segment metadata ended at %d, want %d", offset, end)
+	}
+	return entries, nil
+}
+
+func readJournalManifest(path string) (journalManifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return journalManifest{}, err
+	}
+	var manifest journalManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return journalManifest{}, fmt.Errorf("decode journal manifest: %w", err)
+	}
+	if manifest.Version != journalFormatVersion {
+		return journalManifest{}, fmt.Errorf("journal manifest version %d is unsupported", manifest.Version)
+	}
+	if manifest.NextSeq <= 0 {
+		manifest.NextSeq = 1
+	}
+	if manifest.SegmentTargetBytes <= 0 {
+		manifest.SegmentTargetBytes = defaultJournalSegmentBytes
+	}
+	if err := validateJournalFileName(manifest.ActiveFile); err != nil {
+		return journalManifest{}, err
+	}
+	for i := range manifest.Segments {
+		if err := validateJournalFileName(manifest.Segments[i].File); err != nil {
+			return journalManifest{}, err
+		}
+		segment := manifest.Segments[i]
+		if segment.EventCount <= 0 || segment.FirstSeq <= 0 || segment.LastSeq < segment.FirstSeq || segment.DataEnd < segmentHeaderSize || segment.LogicalBytes <= 0 {
+			return journalManifest{}, fmt.Errorf("journal segment %s metadata is invalid", segment.File)
+		}
+		previousOffset := int64(0)
+		for _, sparse := range segment.Sparse {
+			if sparse.Seq < segment.FirstSeq || sparse.Seq > segment.LastSeq || sparse.Offset < segmentHeaderSize || sparse.Offset >= segment.DataEnd || sparse.Offset <= previousOffset {
+				return journalManifest{}, fmt.Errorf("journal segment %s sparse index is invalid", segment.File)
+			}
+			previousOffset = sparse.Offset
+		}
+	}
+	if manifest.Legacy != nil {
+		if filepath.Base(manifest.Legacy.File) != manifest.Legacy.File || manifest.Legacy.ValidBytes <= 0 || manifest.Legacy.EarliestSeq <= 0 || manifest.Legacy.LatestSeq < manifest.Legacy.EarliestSeq {
+			return journalManifest{}, errors.New("legacy journal manifest metadata is invalid")
+		}
+		if manifest.Legacy.IndexFile == "" {
+			manifest.Legacy.IndexFile = journalLegacyIndexName
+		}
+		if filepath.Base(manifest.Legacy.IndexFile) != manifest.Legacy.IndexFile {
+			return journalManifest{}, errors.New("legacy journal index file is invalid")
+		}
+	}
+	sort.Slice(manifest.Segments, func(i, k int) bool { return manifest.Segments[i].FirstSeq < manifest.Segments[k].FirstSeq })
+	return manifest, nil
+}
+
+func writeJournalManifest(path string, manifest *journalManifest) error {
+	if manifest == nil {
+		return errors.New("journal manifest is required")
+	}
+	manifest.Version = journalFormatVersion
+	manifest.Generation++
+	payload, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode journal manifest: %w", err)
+	}
+	payload = append(payload, '\n')
+	if err := writeFileAtomic(path, payload, 0o600); err != nil {
+		return fmt.Errorf("persist journal manifest: %w", err)
+	}
+	// Reopening and syncing the renamed file flushes the S0FS WAL entry that
+	// made the manifest visible. The directory sync below supplies the normal
+	// POSIX rename durability guarantee; S0FS reports that operation unsupported.
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("reopen journal manifest: %w", err)
+	}
+	syncErr := file.Sync()
+	closeErr := file.Close()
+	if syncErr != nil || closeErr != nil {
+		return errors.Join(syncErr, closeErr)
+	}
+	directory, err := os.Open(filepath.Dir(path))
+	if err != nil {
+		return fmt.Errorf("open journal directory for sync: %w", err)
+	}
+	directorySyncErr := directory.Sync()
+	directoryCloseErr := directory.Close()
+	if directorySyncErr != nil && !errors.Is(directorySyncErr, syscall.ENOSYS) && !errors.Is(directorySyncErr, syscall.EINVAL) {
+		return errors.Join(directorySyncErr, directoryCloseErr)
+	}
+	if directoryCloseErr != nil {
+		return directoryCloseErr
+	}
+	return nil
+}
+
+func writeLegacyJournalIndex(path string, validBytes int64, entries []journalEntry) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".legacy-index-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	header := make([]byte, legacyIndexHeaderSize)
+	copy(header[:8], legacyIndexMagic[:])
+	binary.LittleEndian.PutUint32(header[8:12], journalFormatVersion)
+	binary.LittleEndian.PutUint64(header[16:24], uint64(validBytes))
+	binary.LittleEndian.PutUint64(header[24:32], uint64(len(entries)))
+	if _, err := tmp.Write(header); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	buf := make([]byte, legacyIndexEntrySize)
+	for _, entry := range entries {
+		binary.LittleEndian.PutUint64(buf[0:8], uint64(entry.seq))
+		binary.LittleEndian.PutUint64(buf[8:16], uint64(entry.offset))
+		binary.LittleEndian.PutUint64(buf[16:24], uint64(entry.size))
+		binary.LittleEndian.PutUint64(buf[24:32], uint64(entry.occurredAtNano))
+		if _, err := tmp.Write(buf); err != nil {
+			_ = tmp.Close()
+			return err
+		}
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	err = file.Sync()
+	return errors.Join(err, file.Close())
+}
+
+func readLegacyJournalIndex(path string, validBytes int64) ([]journalEntry, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	header := make([]byte, legacyIndexHeaderSize)
+	if _, err := io.ReadFull(file, header); err != nil {
+		return nil, err
+	}
+	if string(header[:8]) != string(legacyIndexMagic[:]) || binary.LittleEndian.Uint32(header[8:12]) != journalFormatVersion {
+		return nil, errors.New("legacy journal index header is invalid")
+	}
+	if got := int64(binary.LittleEndian.Uint64(header[16:24])); got != validBytes {
+		return nil, fmt.Errorf("legacy journal index covers %d bytes, want %d", got, validBytes)
+	}
+	count := int64(binary.LittleEndian.Uint64(header[24:32]))
+	if count < 0 || count > validBytes+1 {
+		return nil, errors.New("legacy journal index entry count is invalid")
+	}
+	entries := make([]journalEntry, 0, count)
+	buf := make([]byte, legacyIndexEntrySize)
+	previousSeq := int64(0)
+	previousEnd := int64(0)
+	for i := int64(0); i < count; i++ {
+		if _, err := io.ReadFull(file, buf); err != nil {
+			return nil, err
+		}
+		entry := journalEntry{
+			seq:            int64(binary.LittleEndian.Uint64(buf[0:8])),
+			offset:         int64(binary.LittleEndian.Uint64(buf[8:16])),
+			size:           int64(binary.LittleEndian.Uint64(buf[16:24])),
+			occurredAtNano: int64(binary.LittleEndian.Uint64(buf[24:32])),
+		}
+		if entry.seq <= previousSeq || entry.offset != previousEnd || entry.size <= 0 || entry.offset+entry.size > validBytes {
+			return nil, errors.New("legacy journal index entry is invalid")
+		}
+		entries = append(entries, entry)
+		previousSeq = entry.seq
+		previousEnd = entry.offset + entry.size
+	}
+	if previousEnd != validBytes {
+		return nil, fmt.Errorf("legacy journal index ends at %d, want %d", previousEnd, validBytes)
+	}
+	return entries, nil
+}
+
+func segmentMetaLatest(segments []journalSegmentMeta) int64 {
+	latest := int64(0)
+	for _, segment := range segments {
+		if segment.LastSeq > latest {
+			latest = segment.LastSeq
+		}
+	}
+	return latest
+}
+
+func maxInt64(values ...int64) int64 {
+	maximum := int64(0)
+	for _, value := range values {
+		if value > maximum {
+			maximum = value
+		}
+	}
+	return maximum
+}

--- a/manager/procd/pkg/session/journal_test.go
+++ b/manager/procd/pkg/session/journal_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -12,7 +13,7 @@ import (
 
 func TestJournalCursorRetentionAndReopen(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "events.jsonl")
-	journal, err := OpenJournal(path, EventRetentionSpec{MaxBytes: 350, MaxAgeSeconds: 3600}, 0)
+	journal, err := OpenJournal(path, EventRetentionSpec{MaxBytes: 350, MaxAgeSeconds: 3600}, EventCursor{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +24,7 @@ func TestJournalCursorRetentionAndReopen(t *testing.T) {
 	}
 	cursor := journal.Cursor()
 	if cursor.Latest != 8 || cursor.Earliest <= 1 {
-		t.Fatalf("cursor = %#v, want compacted history ending at 8", cursor)
+		t.Fatalf("cursor = %#v, want retained history ending at 8", cursor)
 	}
 	if _, err := journal.Read(1, 100); !errors.Is(err, ErrCursorExpired) {
 		t.Fatalf("Read() error = %v, want cursor expired", err)
@@ -52,11 +53,12 @@ func TestJournalCursorRetentionAndReopen(t *testing.T) {
 	if _, ok := <-live; ok {
 		t.Fatal("subscription remained open after cancellation")
 	}
+	closeCursor := journal.Cursor()
 	if err := journal.Close(); err != nil {
 		t.Fatal(err)
 	}
 
-	reopened, err := OpenJournal(path, EventRetentionSpec{MaxBytes: 350, MaxAgeSeconds: 3600}, cursor.Latest)
+	reopened, err := OpenJournal(path, EventRetentionSpec{MaxBytes: 350, MaxAgeSeconds: 3600}, closeCursor)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +76,7 @@ func TestJournalCursorWhenRetentionRemovesEveryEvent(t *testing.T) {
 	journal, err := OpenJournal(
 		filepath.Join(t.TempDir(), "events.jsonl"),
 		EventRetentionSpec{MaxBytes: 1, MaxAgeSeconds: 3600},
-		0,
+		EventCursor{},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -107,18 +109,14 @@ func TestJournalReadPrunesEventsThatExpiredWhileIdle(t *testing.T) {
 	journal, err := OpenJournal(
 		filepath.Join(t.TempDir(), "events.jsonl"),
 		EventRetentionSpec{MaxBytes: 1 << 20, MaxAgeSeconds: 1},
-		0,
+		EventCursor{},
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer journal.Close()
 
-	if _, err := journal.Append(Event{
-		SessionID:  "ses-test",
-		Type:       "session.created",
-		OccurredAt: time.Now().Add(-2 * time.Second),
-	}); err != nil {
+	if _, err := journal.Append(Event{SessionID: "ses-test", Type: "session.created", OccurredAt: time.Now().Add(-2 * time.Second)}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := journal.Read(0, 100); !errors.Is(err, ErrCursorExpired) {
@@ -129,32 +127,33 @@ func TestJournalReadPrunesEventsThatExpiredWhileIdle(t *testing.T) {
 	}
 }
 
-func TestJournalReopenTruncatesIncompleteTail(t *testing.T) {
+func TestJournalReopenTruncatesIncompleteActiveTail(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "events.jsonl")
 	retention := EventRetentionSpec{MaxBytes: 1 << 20, MaxAgeSeconds: 3600}
-	journal, err := OpenJournal(path, retention, 0)
+	journal, err := OpenJournal(path, retention, EventCursor{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if _, err := journal.Append(Event{SessionID: "ses-test", Type: "session.created"}); err != nil {
 		t.Fatal(err)
 	}
+	activePath := filepath.Join(journal.dir, journal.manifest.ActiveFile)
+	cursor := journal.Cursor()
 	if err := journal.Close(); err != nil {
 		t.Fatal(err)
 	}
-
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o600)
+	file, err := os.OpenFile(activePath, os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := file.WriteString(`{"seq":2`); err != nil {
+	if _, err := file.Write([]byte{0x20, 0x00, 0x00}); err != nil {
 		t.Fatal(err)
 	}
 	if err := file.Close(); err != nil {
 		t.Fatal(err)
 	}
 
-	reopened, err := OpenJournal(path, retention, 1)
+	reopened, err := OpenJournal(path, retention, cursor)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +168,7 @@ func TestJournalReopenTruncatesIncompleteTail(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	verified, err := OpenJournal(path, retention, 2)
+	verified, err := OpenJournal(path, retention, EventCursor{Earliest: 1, Latest: 2})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,11 +182,65 @@ func TestJournalReopenTruncatesIncompleteTail(t *testing.T) {
 	}
 }
 
+func TestJournalReopenDropsCorruptFinalFrameWithoutReusingSequence(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+	retention := EventRetentionSpec{MaxBytes: 1 << 20, MaxAgeSeconds: 3600}
+	journal, err := OpenJournal(path, retention, EventCursor{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := journal.Append(Event{SessionID: "ses-test", Type: "output", DataBase64: "payload"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	activePath := filepath.Join(journal.dir, journal.manifest.ActiveFile)
+	corruptOffset := journal.activeEntries[1].offset + segmentFrameHeaderSize
+	if err := journal.Close(); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.OpenFile(activePath, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	value := []byte{0}
+	if _, err := file.ReadAt(value, corruptOffset); err != nil {
+		t.Fatal(err)
+	}
+	value[0] ^= 0xff
+	if _, err := file.WriteAt(value, corruptOffset); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := OpenJournal(path, retention, EventCursor{Earliest: 1, Latest: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	next, err := reopened.Append(Event{SessionID: "ses-test", Type: "session.ready"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next.Seq != 3 {
+		t.Fatalf("sequence after corrupt tail = %d, want 3", next.Seq)
+	}
+	page, err := reopened.Read(0, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Events) != 2 || page.Events[0].Seq != 1 || page.Events[1].Seq != 3 {
+		t.Fatalf("events after corrupt tail recovery = %#v, want sequences 1 and 3", page.Events)
+	}
+}
+
 func TestJournalRetainedPayloadDoesNotStayInHeap(t *testing.T) {
 	journal, err := OpenJournal(
 		filepath.Join(t.TempDir(), "events.jsonl"),
 		EventRetentionSpec{MaxBytes: 32 << 20, MaxAgeSeconds: 3600},
-		0,
+		EventCursor{},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -200,30 +253,32 @@ func TestJournalRetainedPayloadDoesNotStayInHeap(t *testing.T) {
 	runtime.GC()
 	var before runtime.MemStats
 	runtime.ReadMemStats(&before)
-
 	const (
 		eventCount = 64
 		eventBytes = 256 << 10
 	)
 	for i := 0; i < eventCount; i++ {
 		payload := strings.Repeat(string(rune('a'+i%26)), eventBytes)
-		if _, err := journal.Append(Event{
-			SessionID:  "ses-test",
-			Type:       "output",
-			DataBase64: payload,
-		}); err != nil {
+		if _, err := journal.Append(Event{SessionID: "ses-test", Type: "output", DataBase64: payload}); err != nil {
 			t.Fatal(err)
 		}
 	}
 	runtime.GC()
 	var after runtime.MemStats
 	runtime.ReadMemStats(&after)
-
 	if retained := int64(after.HeapAlloc) - int64(before.HeapAlloc); retained > 4<<20 {
 		t.Fatalf("journal retained %d heap bytes after storing %d bytes of event payload", retained, eventCount*eventBytes)
 	}
-	if len(journal.entries) != eventCount+1 {
-		t.Fatalf("entry count = %d, want %d", len(journal.entries), eventCount+1)
+	stats := journal.Stats()
+	if stats.SealedSegments == 0 {
+		t.Fatal("journal did not seal any segments")
+	}
+	indexedEvents := int64(stats.ActiveEvents)
+	for _, segment := range journal.manifest.Segments {
+		indexedEvents += segment.EventCount
+	}
+	if indexedEvents != eventCount+1 {
+		t.Fatalf("indexed event count = %d, want %d", indexedEvents, eventCount+1)
 	}
 }
 
@@ -231,13 +286,12 @@ func TestJournalSubscribeStreamsBacklogWithBoundedLiveBuffer(t *testing.T) {
 	journal, err := OpenJournal(
 		filepath.Join(t.TempDir(), "events.jsonl"),
 		EventRetentionSpec{MaxBytes: 1 << 20, MaxAgeSeconds: 3600},
-		0,
+		EventCursor{},
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer journal.Close()
-
 	const count = defaultSubscriptionBacklog + 100
 	for i := 0; i < count; i++ {
 		if _, err := journal.Append(Event{SessionID: "ses-test", Type: "output", DataBase64: "dGVzdA=="}); err != nil {
@@ -258,11 +312,8 @@ func TestJournalSubscribeStreamsBacklogWithBoundedLiveBuffer(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !ok {
-			t.Fatalf("backlog ended at event %d, want %d events", i-1, count)
-		}
-		if event.Seq != int64(i) {
-			t.Fatalf("event seq = %d, want %d", event.Seq, i)
+		if !ok || event.Seq != int64(i) {
+			t.Fatalf("backlog event %d = (%#v, %t), want seq %d", i, event, ok, i)
 		}
 	}
 	if _, ok, err := backlog.Next(); err != nil || ok {
@@ -270,34 +321,36 @@ func TestJournalSubscribeStreamsBacklogWithBoundedLiveBuffer(t *testing.T) {
 	}
 }
 
-func TestJournalBacklogSnapshotSurvivesCompaction(t *testing.T) {
+func TestJournalBacklogSnapshotSurvivesSegmentDeletion(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "events.jsonl")
-	journal, err := OpenJournal(
-		path,
-		EventRetentionSpec{MaxBytes: 1 << 20, MaxAgeSeconds: 3600},
-		0,
-	)
+	journal, err := OpenJournal(path, EventRetentionSpec{MaxBytes: 1 << 20, MaxAgeSeconds: 3600}, EventCursor{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer journal.Close()
-
-	for i := 0; i < 10; i++ {
-		if _, err := journal.Append(Event{SessionID: "ses-test", Type: "output", DataBase64: strings.Repeat("eA==", 128)}); err != nil {
+	journal.manifest.SegmentTargetBytes = minimumJournalSegmentBytes
+	for i := 0; i < 12; i++ {
+		if _, err := journal.Append(Event{SessionID: "ses-test", Type: "output", DataBase64: strings.Repeat("x", 12<<10)}); err != nil {
 			t.Fatal(err)
 		}
 	}
+	if len(journal.manifest.Segments) == 0 {
+		t.Fatal("test requires sealed segments")
+	}
+	firstSegmentPath := filepath.Join(journal.dir, journal.manifest.Segments[0].File)
 	backlog, _, cancel, _, err := journal.Subscribe(0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer backlog.Close()
 	defer cancel()
-
 	if err := journal.SetRetention(EventRetentionSpec{MaxBytes: 1, MaxAgeSeconds: 3600}); err != nil {
 		t.Fatal(err)
 	}
-	for i := 1; i <= 10; i++ {
+	if _, err := os.Stat(firstSegmentPath); err != nil {
+		t.Fatalf("pinned segment was removed before backlog close: %v", err)
+	}
+	for i := 1; i <= 12; i++ {
 		event, ok, err := backlog.Next()
 		if err != nil {
 			t.Fatal(err)
@@ -306,38 +359,261 @@ func TestJournalBacklogSnapshotSurvivesCompaction(t *testing.T) {
 			t.Fatalf("backlog event %d = (%#v, %t), want seq %d", i, event, ok, i)
 		}
 	}
+	if err := backlog.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(firstSegmentPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("segment stat error = %v, want removal after backlog close", err)
+	}
 }
 
-func TestJournalCompactionKeepsFileBounded(t *testing.T) {
+func TestJournalSegmentRetentionKeepsPhysicalFilesBounded(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "events.jsonl")
 	const maxBytes = int64(32 << 10)
-	journal, err := OpenJournal(
-		path,
-		EventRetentionSpec{MaxBytes: maxBytes, MaxAgeSeconds: 3600},
-		0,
-	)
+	journal, err := OpenJournal(path, EventRetentionSpec{MaxBytes: maxBytes, MaxAgeSeconds: 3600}, EventCursor{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer journal.Close()
-
 	for i := 0; i < 300; i++ {
-		if _, err := journal.Append(Event{
-			SessionID:  "ses-test",
-			Type:       "output",
-			DataBase64: strings.Repeat("eA==", 256),
-		}); err != nil {
+		if _, err := journal.Append(Event{SessionID: "ses-test", Type: "output", DataBase64: strings.Repeat("x", 1024)}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	info, err := os.Stat(path)
+	entries, err := os.ReadDir(journal.dir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Size() > maxBytes*2 {
-		t.Fatalf("journal file size = %d, want at most %d", info.Size(), maxBytes*2)
+	var physical int64
+	for _, entry := range entries {
+		if filepath.Ext(entry.Name()) != ".sjr" {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			t.Fatal(err)
+		}
+		physical += info.Size()
 	}
-	if journal.totalBytes > maxBytes {
-		t.Fatalf("retained bytes = %d, want at most %d", journal.totalBytes, maxBytes)
+	if physical > 3*minimumJournalSegmentBytes {
+		t.Fatalf("journal segment bytes = %d, want at most %d", physical, 3*minimumJournalSegmentBytes)
+	}
+	if journal.retainedBytes > maxBytes {
+		t.Fatalf("retained bytes = %d, want at most %d", journal.retainedBytes, maxBytes)
+	}
+}
+
+func TestJournalLegacyMigrationIsLazyAndPreservesCursor(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	writeLegacyEvents(t, path, 1, 128, 4096)
+	retention := EventRetentionSpec{MaxBytes: 4 << 20, MaxAgeSeconds: 3600}
+	journal, err := OpenJournal(path, retention, EventCursor{Earliest: 1, Latest: 128})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !journal.Stats().LegacyDeferred {
+		t.Fatal("legacy journal was indexed during activation")
+	}
+	if _, err := os.Stat(filepath.Join(journal.dir, journalLegacyIndexName)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("legacy index stat error = %v, want deferred index", err)
+	}
+	appended, err := journal.Append(Event{SessionID: "ses-test", Type: "session.updated"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if appended.Seq != 129 {
+		t.Fatalf("appended sequence = %d, want 129", appended.Seq)
+	}
+	page, err := journal.Read(126, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Events) != 3 || page.Events[0].Seq != 127 || page.Events[2].Seq != 129 {
+		t.Fatalf("migration page = %#v, want sequences 127..129", page.Events)
+	}
+	if journal.Stats().LegacyDeferred {
+		t.Fatal("legacy journal remained deferred after history read")
+	}
+	if _, err := os.Stat(filepath.Join(journal.dir, journalLegacyIndexName)); err != nil {
+		t.Fatalf("legacy index was not persisted: %v", err)
+	}
+	if err := journal.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := OpenJournal(path, retention, EventCursor{Earliest: 1, Latest: 129})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	if !reopened.Stats().LegacyDeferred {
+		t.Fatal("reopen eagerly loaded the persisted legacy index")
+	}
+	next, err := reopened.Append(Event{SessionID: "ses-test", Type: "session.ready"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next.Seq != 130 {
+		t.Fatalf("reopened sequence = %d, want 130", next.Seq)
+	}
+	reopenedPage, err := reopened.Read(128, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reopenedPage.Events) != 2 || reopenedPage.Events[0].Seq != 129 || reopenedPage.Events[1].Seq != 130 {
+		t.Fatalf("indexed legacy reopen page = %#v, want sequences 129 and 130", reopenedPage.Events)
+	}
+}
+
+func TestJournalPruneIndexesAndExpiresLegacyHistory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+	writeLegacyEvents(t, path, 1, 20, 256)
+	journal, err := OpenJournal(path, EventRetentionSpec{MaxBytes: 1 << 20, MaxAgeSeconds: 1}, EventCursor{Earliest: 1, Latest: 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer journal.Close()
+	if !journal.Stats().LegacyDeferred {
+		t.Fatal("legacy journal was indexed during activation")
+	}
+	if err := journal.Prune(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if cursor := journal.Cursor(); cursor.Earliest != 21 || cursor.Latest != 20 {
+		t.Fatalf("cursor after legacy prune = %#v, want empty retained window [21, 20]", cursor)
+	}
+	if journal.manifest.Legacy != nil {
+		t.Fatal("expired legacy journal remained in the manifest")
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("legacy journal stat error = %v, want removal", err)
+	}
+}
+
+func TestJournalRecoversSealedActiveBeforeManifestUpdate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+	retention := EventRetentionSpec{MaxBytes: 1 << 20, MaxAgeSeconds: 3600}
+	journal, err := OpenJournal(path, retention, EventCursor{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 4; i++ {
+		if _, err := journal.Append(Event{SessionID: "ses-test", Type: "output", DataBase64: "test"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	activeName := journal.manifest.ActiveFile
+	activePath := filepath.Join(journal.dir, activeName)
+	entries := append([]journalRecordMeta(nil), journal.activeEntries...)
+	dataEnd := journal.activeSize
+	cursor := journal.Cursor()
+	if err := journal.Close(); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.OpenFile(activePath, os.O_RDWR|os.O_APPEND, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJournalSegmentFooter(file, segmentMetaFromEntries(activeName, entries, dataEnd)); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	recovered, err := OpenJournal(path, retention, cursor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer recovered.Close()
+	if len(recovered.manifest.Segments) != 1 || recovered.manifest.Segments[0].File != activeName {
+		t.Fatalf("recovered segments = %#v, want sealed former active", recovered.manifest.Segments)
+	}
+	if recovered.manifest.ActiveFile == activeName {
+		t.Fatal("recovery did not create a new active segment")
+	}
+	next, err := recovered.Append(Event{SessionID: "ses-test", Type: "session.ready"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next.Seq != 5 {
+		t.Fatalf("recovered append sequence = %d, want 5", next.Seq)
+	}
+	page, err := recovered.Read(0, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Events) != 5 {
+		t.Fatalf("recovered event count = %d, want 5", len(page.Events))
+	}
+}
+
+func TestJournalReopenTruncatesPartialSegmentFooter(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+	retention := EventRetentionSpec{MaxBytes: 1 << 20, MaxAgeSeconds: 3600}
+	journal, err := OpenJournal(path, retention, EventCursor{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 4; i++ {
+		if _, err := journal.Append(Event{SessionID: "ses-test", Type: "output", DataBase64: "test"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	activePath := filepath.Join(journal.dir, journal.manifest.ActiveFile)
+	dataEnd := journal.activeSize
+	cursor := journal.Cursor()
+	if err := journal.Close(); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.OpenFile(activePath, os.O_WRONLY|os.O_APPEND, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	partialFooter := append(append([]byte(nil), segmentFooterMagic[:]...), []byte(`{"file":`)...)
+	if _, err := file.Write(partialFooter); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := OpenJournal(path, retention, cursor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	if reopened.activeSize != dataEnd {
+		t.Fatalf("recovered active size = %d, want %d", reopened.activeSize, dataEnd)
+	}
+	next, err := reopened.Append(Event{SessionID: "ses-test", Type: "session.ready"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next.Seq != 5 {
+		t.Fatalf("sequence after partial footer = %d, want 5", next.Seq)
+	}
+}
+
+func writeLegacyEvents(t *testing.T, path string, first, count, payloadBytes int) {
+	t.Helper()
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < count; i++ {
+		event := Event{Seq: int64(first + i), SessionID: "ses-test", Type: "output", DataBase64: strings.Repeat("x", payloadBytes), OccurredAt: time.Now().UTC()}
+		line, err := json.Marshal(event)
+		if err != nil {
+			t.Fatal(err)
+		}
+		line = append(line, '\n')
+		if _, err := file.Write(line); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/manager/procd/pkg/session/store.go
+++ b/manager/procd/pkg/session/store.go
@@ -11,9 +11,9 @@ import (
 )
 
 const (
-	sessionStateFile  = "state.json"
-	sessionEventsFile = "events.jsonl"
-	sandboxIDFile     = "sandbox-id"
+	sessionStateFile        = "state.json"
+	sessionLegacyEventsFile = "events.jsonl"
+	sandboxIDFile           = "sandbox-id"
 )
 
 type persistedSession struct {
@@ -163,7 +163,9 @@ func (s *FileStore) JournalPath(id string) (string, error) {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", fmt.Errorf("create session directory: %w", err)
 	}
-	return filepath.Join(dir, sessionEventsFile), nil
+	// V2 derives its segmented directory from this path. Keeping the legacy
+	// filename here makes upgrades read-only and does not create new JSONL data.
+	return filepath.Join(dir, sessionLegacyEventsFile), nil
 }
 
 func (s *FileStore) sessionDir(id string) (string, error) {

--- a/manager/procd/pkg/session/supervisor.go
+++ b/manager/procd/pkg/session/supervisor.go
@@ -88,10 +88,15 @@ func (s *Supervisor) loadPersistedSessionsLocked() error {
 	if len(s.sessions) > 0 {
 		return nil
 	}
+	loadStartedAt := time.Now()
 	stored, err := s.store.Load()
 	if err != nil {
 		return err
 	}
+	s.logger.Info("Loaded persisted session directory",
+		zap.Duration("duration", time.Since(loadStartedAt)),
+		zap.Int("sessions", len(stored)),
+	)
 	loadedSessions := make(map[string]*managedSession, len(stored))
 	loadedKeys := make(map[string]string)
 	closeLoaded := func() {
@@ -112,11 +117,24 @@ func (s *Supervisor) loadPersistedSessionsLocked() error {
 			closeLoaded()
 			return err
 		}
-		journal, err := OpenJournal(path, record.Spec.EventRetention, record.Cursor.Latest)
+		openStartedAt := time.Now()
+		journal, err := OpenJournal(path, record.Spec.EventRetention, record.Cursor)
 		if err != nil {
 			closeLoaded()
 			return fmt.Errorf("open journal for %s: %w", record.ID, err)
 		}
+		stats := journal.Stats()
+		s.logger.Info("Opened session event journal",
+			zap.String("session_id", record.ID),
+			zap.Duration("duration", time.Since(openStartedAt)),
+			zap.Int("format_version", stats.FormatVersion),
+			zap.Int("sealed_segments", stats.SealedSegments),
+			zap.Int64("active_bytes", stats.ActiveBytes),
+			zap.Int("active_events", stats.ActiveEvents),
+			zap.Int64("retained_bytes", stats.RetainedBytes),
+			zap.Bool("retained_bytes_known", stats.RetainedBytesKnown),
+			zap.Bool("legacy_deferred", stats.LegacyDeferred),
+		)
 		record.Cursor = journal.Cursor()
 		loadedSessions[record.ID] = &managedSession{record: record, journal: journal}
 	}
@@ -315,7 +333,7 @@ func (s *Supervisor) Create(spec SessionSpec, creationKey string) (*Session, boo
 		s.mu.Unlock()
 		return nil, false, err
 	}
-	journal, err := OpenJournal(path, spec.EventRetention, 0)
+	journal, err := OpenJournal(path, spec.EventRetention, EventCursor{})
 	if err != nil {
 		s.mu.Unlock()
 		return nil, false, err


### PR DESCRIPTION
## Summary

- replace the single-file JSONL session journal with v2 immutable sealed segments plus one bounded active tail
- make normal session recovery read only the manifest and active tail; retention advances a logical head and deletes whole segments instead of copying retained history
- keep legacy `events.jsonl` read-only and build its binary offset index lazily on the first history read or background prune
- preserve sequence, cursor expiry, paged reads, SSE/WebSocket backlog snapshots, and slow-subscriber behavior
- add structured session-directory and per-journal activation timings without using session IDs as metric labels

This narrows #795 to the synchronous procd session-journal portion of runtime activation. It does not change the external API or weaken runtime revision/generation fencing.

## Durability and compatibility

- frames carry sequence/time/logical-size metadata and Castagnoli CRCs
- sealed segments carry sparse indexes and checksummed, double-magic footers
- manifest replacement is atomic and synced for both POSIX and S0FS behavior
- recovery truncates incomplete frames/footers, recovers a sealed-active crash window, and never reuses a persisted sequence floor
- snapshot readers pin files until their stable backlog is closed

## Validation

- `go test -race -count=1 ./manager/procd/pkg/session`
- `go test -count=1 ./manager/procd/...`
- full non-e2e repository race suite matching `pr-quick-check`
- golangci-lint v2.5.0: 0 issues
- remote AMD64 race test in the persistent kind environment
- remote deployed API validation with retained session histories and 3 consecutive pause/resume cycles at each size:
  - regular: 1.41 MB journal directory
  - large: 91.38 MB journal directory
  - huge: 451.28 MB journal directory, including a 359.55 MB journal with 86 sealed segments
- final footer layout revalidated remotely with 89.97 MB and 21 sealed segments

Remote AMD64 benchmark, 3 iterations per size:

| Retained history | v2 resume open | v1 JSONL full scan | v2 allocs |
| --- | ---: | ---: | ---: |
| 1 MiB | 0.302 ms | 4.54 ms | 76 KB |
| 64 MiB | 0.290 ms | 278.61 ms | 91 KB |
| 256 MiB | 0.714 ms | 1190.16 ms | 164 KB |

On the deployed 451 MB validation sandbox, final procd journal-open logs were 8.59 ms, 23.39 ms, and 14.28 ms for the regular, large, and huge sessions respectively. End-to-end resume still varied from 0.44 s to 5.90 s, confirming the remaining variance is outside journal history scanning and should be handled by the other #795 subphases.
