### PR TITLE
Add remote-resize VNC server to coding-agent image

### DIFF
--- a/manager/procd/Dockerfile.coding-agent
+++ b/manager/procd/Dockerfile.coding-agent
@@ -21,7 +21,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # Claude Code and Pi require Node.js 22. Pi currently requires Node.js 22.19+
 # specifically, so fail the build if the repository ever resolves an older 22.x.
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates curl gnupg openbox x11vnc xvfb \
+  && apt-get install -y --no-install-recommends ca-certificates curl gnupg openbox tigervnc-standalone-server x11vnc xvfb \
+  && command -v Xtigervnc >/dev/null \
   && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
   && apt-get install -y --no-install-recommends nodejs \
   && node -e 'const [major, minor] = process.versions.node.split(".").map(Number); if (major < 22 || (major === 22 && minor < 19)) process.exit(1)' \

--- a/manager/procd/coding_agent_image_test.go
+++ b/manager/procd/coding_agent_image_test.go
@@ -1,0 +1,24 @@
+package procd
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestCodingAgentImageIncludesRemoteResizeVNCServer(t *testing.T) {
+	dockerfile, err := os.ReadFile("Dockerfile.coding-agent")
+	if err != nil {
+		t.Fatalf("read coding-agent Dockerfile: %v", err)
+	}
+
+	contents := string(dockerfile)
+	for _, expected := range []string{
+		"tigervnc-standalone-server",
+		"command -v Xtigervnc >/dev/null",
+	} {
+		if !strings.Contains(contents, expected) {
+			t.Fatalf("coding-agent Dockerfile does not contain %q", expected)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- install TigerVNC in the coding-agent template so browser takeover can negotiate the remote desktop size
- keep Xvfb/x11vnc temporarily for rolling compatibility with the currently deployed Sandpi runtime
- assert the image contains `Xtigervnc` during both tests and image build

## Validation

- `go test ./manager/procd`
- all non-e2e/non-integration Go packages
- `go vet ./...`
- `git diff --check`

Image-level and browser takeover validation will run after publishing the template image and on the persistent remote test environment.