### PR TITLE
Update coding-agent default to v0.4

### DIFF
--- a/docs/use-cases/coding-agents/page.mdx
+++ b/docs/use-cases/coding-agents/page.mdx
@@ -2,7 +2,7 @@
 
 Run Codex, Claude Code, OpenCode, or Pi inside a Sandbox0 sandbox when you want an isolated, persistent workspace with supervised process recovery, replayable I/O, and an agent-controllable browser.
 
-The builtin `coding-agent` template installs all four native CLIs, the official Playwright CLI, Chromium, a lightweight headed-browser runtime (Xvfb, Openbox, and x11vnc), and Docker. It declares `/workspace` as its writable mount point.
+The builtin `coding-agent` template installs all four native CLIs, the official Playwright CLI, Chromium, a lightweight headed-browser runtime (TigerVNC and Openbox, with Xvfb and x11vnc retained for compatibility), and Docker. It declares `/workspace` as its writable mount point.
 
 ## Why Supervised Sessions?
 
@@ -55,7 +55,7 @@ playwright-cli show --host=127.0.0.1 --port=9324
 
 The coding-agent container runs privileged inside the enclosing Sandbox0 runtime so it can host a sandbox-local Docker daemon. The managed Playwright CLI flow disables Chromium's process sandbox and relies on the Sandbox0 runtime boundary for isolation; the unprivileged headed-browser flow uses Chromium's configured setuid sandbox helper. The Dashboard has no Sandbox0 user authentication of its own. Keep it on sandbox loopback unless an authenticated application proxies both its HTTP and WebSocket traffic.
 
-Applications that need exclusive human takeover can use the same template without exposing a CDP endpoint. Stop the Playwright daemon, launch the bundled browser as the unprivileged `sandbox-browser` user on Xvfb, bind x11vnc to loopback, and proxy its stream through an authenticated AppService. Return control by stopping the headed browser before Playwright reopens the same workspace-backed profile. Keep the owner in one application-level record; any file used to block the supported agent command should be treated only as a derived guard.
+Applications that need exclusive human takeover can use the same template without exposing a CDP endpoint. Stop the Playwright daemon, launch the bundled browser as the unprivileged `sandbox-browser` user on the TigerVNC X server, bind VNC to loopback, and proxy its stream through an authenticated AppService. TigerVNC accepts client-requested desktop sizes, so the remote framebuffer can follow the human-control viewport instead of being scaled from a fixed desktop. Xvfb and x11vnc remain available as a compatibility fallback for older application integrations. Return control by stopping the headed browser before Playwright reopens the same workspace-backed profile. Keep the owner in one application-level record; any file used to block the supported agent command should be treated only as a derived guard.
 
 The public template contains Chrome for Testing, not the proprietary Google Chrome stable binary. An operator may extend a private image with another browser after reviewing its license and deployment requirements. Browser ownership inside one privileged coding-agent sandbox is a cooperative application boundary: a root process can bypass wrappers or launch another browser, so use a separate Sandbox or more strongly isolated component when the browser owner is adversarial.
 

--- a/docs/use-cases/page.mdx
+++ b/docs/use-cases/page.mdx
@@ -46,7 +46,7 @@ Operators can pin images, tune pools, or remove a template by setting `Sandbox0I
 
 | Template | Image |
 |----------|-------|
-| `coding-agent` | `sandbox0ai/otemplates:coding-agent-v0.3.0` |
+| `coding-agent` | `sandbox0ai/otemplates:coding-agent-v0.4.0` |
 | `openclaw` | `ghcr.io/openclaw/openclaw:latest` |
 | `hermes` | `nousresearch/hermes-agent:latest` |
 | `browser` | `ghcr.io/steel-dev/steel-browser:latest` |

--- a/infra-operator/chart/samples/multi-cluster/data-plane.yaml
+++ b/infra-operator/chart/samples/multi-cluster/data-plane.yaml
@@ -109,7 +109,7 @@ spec:
         minIdle: 0
         maxIdle: 2
     - templateId: coding-agent
-      image: sandbox0ai/otemplates:coding-agent-v0.3.0
+      image: sandbox0ai/otemplates:coding-agent-v0.4.0
       displayName: Coding Agents
       description: Builtin coding-agent template with Docker, Codex, Claude Code, OpenCode, Pi, Playwright CLI, and headed browser runtime installed by infra-operator.
       pool:

--- a/infra-operator/chart/samples/single-cluster/fullmode-gke-gvisor.yaml
+++ b/infra-operator/chart/samples/single-cluster/fullmode-gke-gvisor.yaml
@@ -67,7 +67,7 @@ spec:
         minIdle: 0
         maxIdle: 2
     - templateId: coding-agent
-      image: sandbox0ai/otemplates:coding-agent-v0.3.0
+      image: sandbox0ai/otemplates:coding-agent-v0.4.0
       displayName: Coding Agents
       description: Builtin coding-agent template with Docker, Codex, Claude Code, OpenCode, Pi, Playwright CLI, and headed browser runtime installed by infra-operator.
       pool:

--- a/infra-operator/chart/samples/single-cluster/fullmode.yaml
+++ b/infra-operator/chart/samples/single-cluster/fullmode.yaml
@@ -137,7 +137,7 @@ spec:
         minIdle: 0
         maxIdle: 2
     - templateId: coding-agent
-      image: sandbox0ai/otemplates:coding-agent-v0.3.0
+      image: sandbox0ai/otemplates:coding-agent-v0.4.0
       displayName: Coding Agents
       description: Builtin coding-agent template with Docker, Codex, Claude Code, OpenCode, Pi, Playwright CLI, and headed browser runtime installed by infra-operator.
       pool:

--- a/pkg/template/defaults.go
+++ b/pkg/template/defaults.go
@@ -16,7 +16,7 @@ const (
 	DockerDataRootMount             = "/var/lib/docker"
 
 	CodingAgentTemplateID          = "coding-agent"
-	CodingAgentTemplateImage       = "sandbox0ai/otemplates:coding-agent-v0.3.0"
+	CodingAgentTemplateImage       = "sandbox0ai/otemplates:coding-agent-v0.4.0"
 	CodingAgentTemplateDisplayName = "Coding Agents"
 	CodingAgentTemplateDescription = "Builtin coding-agent template with Docker, Codex, Claude Code, OpenCode, Pi, Playwright CLI, and headed browser runtime installed by infra-operator."
 	CodingAgentCPU                 = "1"


### PR DESCRIPTION
## Summary
- switch the public coding-agent template default and operator samples to v0.4.0
- document TigerVNC remote desktop resizing and the legacy Xvfb/x11vnc compatibility path
- keep production digest pinning explicitly separate from the self-hosted tag default

Published image: `sandbox0ai/otemplates:coding-agent-v0.4.0`
Multi-arch digest: `sha256:58b2bdc6d51681e9747ab03d49d51ec8dad58de3ee7ea2bef14e173362e86784`

## Validation
- `go test ./pkg/template/... ./infra-operator/internal/controller/pkg/common/...`
- `helm lint infra-operator/chart`
- `git diff --check`
- remote pull verified the published digest and TigerVNC resize capability flags