### PR TITLE
Fix public warm-pool claim metering

### DIFF
--- a/manager/pkg/metering/lifecycle_projector.go
+++ b/manager/pkg/metering/lifecycle_projector.go
@@ -777,7 +777,13 @@ func isTeamOwnedIdlePoolPod(pod *corev1.Pod) bool {
 	if pod.Labels[controller.LabelTemplateID] == "" {
 		return false
 	}
-	return pod.Annotations[controller.AnnotationTeamID] != ""
+	if strings.TrimSpace(pod.Annotations[controller.AnnotationTeamID]) == "" {
+		return false
+	}
+	// A public idle pod temporarily receives claim ownership annotations before
+	// its pool type changes to active. Only templates that explicitly created a
+	// team-owned warm pool may accrue idle runtime for that team.
+	return strings.TrimSpace(pod.Annotations[controller.AnnotationOwnerKind]) == controller.OwnerKindTeamWarmPool
 }
 
 func warmPoolMeteringIDFromPod(pod *corev1.Pod) string {

--- a/manager/pkg/metering/lifecycle_projector_test.go
+++ b/manager/pkg/metering/lifecycle_projector_test.go
@@ -484,6 +484,53 @@ func TestLifecycleProjectorIgnoresPublicIdlePoolPods(t *testing.T) {
 	}
 }
 
+func TestLifecycleProjectorIgnoresPublicIdlePoolDuringClaimInitialization(t *testing.T) {
+	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{}}
+	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")
+
+	createdAt := time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC)
+	claimedAt := createdAt.Add(3 * time.Hour)
+	projector.now = func() time.Time { return claimedAt.Add(time.Second) }
+
+	idlePod := withSandboxResources(buildTeamWarmPoolPod(createdAt, "1"), "100m", "128Mi")
+	delete(idlePod.Labels, controller.LabelOwnerKind)
+	delete(idlePod.Annotations, controller.AnnotationTeamID)
+	delete(idlePod.Annotations, controller.AnnotationUserID)
+	delete(idlePod.Annotations, controller.AnnotationOwnerKind)
+
+	initializingPod := idlePod.DeepCopy()
+	initializingPod.ResourceVersion = "2"
+	initializingPod.Labels[controller.LabelSandboxID] = "sb-1"
+	initializingPod.Annotations[controller.AnnotationTeamID] = "team-1"
+	initializingPod.Annotations[controller.AnnotationUserID] = "user-1"
+	initializingPod.Annotations[controller.AnnotationClaimedAt] = claimedAt.Format(time.RFC3339)
+	projector.handleUpdate(idlePod, initializingPod)
+
+	if len(recorder.events) != 0 || len(recorder.windows) != 0 {
+		t.Fatalf("public idle claim initialization should not be metered, events=%#v windows=%#v", recorder.events, recorder.windows)
+	}
+	if state := recorder.states["warm-pool/pod-uid-1"]; state != nil {
+		t.Fatalf("public idle claim initialization created warm-pool state: %#v", state)
+	}
+
+	activePod := initializingPod.DeepCopy()
+	activePod.ResourceVersion = "3"
+	activePod.Labels[controller.LabelPoolType] = controller.PoolTypeActive
+	activePod = withSandboxResources(activePod, "2", "4Gi")
+	projector.handleUpdate(initializingPod, activePod)
+
+	if len(recorder.events) != 1 || recorder.events[0].EventType != meteringpkg.EventTypeSandboxClaimed {
+		t.Fatalf("active claim events = %#v, want one sandbox claimed event", recorder.events)
+	}
+	if len(recorder.windows) != 0 {
+		t.Fatalf("active claim emitted retroactive runtime windows: %#v", recorder.windows)
+	}
+	state := recorder.states["sb-1"]
+	if state == nil || state.ActiveSince == nil || !state.ActiveSince.Equal(claimedAt) {
+		t.Fatalf("active claim state = %#v, want active_since %v", state, claimedAt)
+	}
+}
+
 func TestLifecycleProjectorMetersTeamOwnedWarmPoolMemory(t *testing.T) {
 	recorder := &fakeRecorder{states: map[string]*meteringpkg.SandboxProjectionState{}}
 	projector := NewLifecycleProjector(recorder, "aws-us-east-1", "cluster-a")


### PR DESCRIPTION
## What changed

- require the explicit `team_warm_pool` owner marker before metering an idle pod to a team
- add a regression test for the two-phase public hot-claim transition
- verify that active sandbox metering still starts at `claimed_at` without a retroactive runtime window

## Root cause

Public idle pods stay labeled as `idle` while the hot-claim path initializes them. During that interval they receive the claiming team annotation. The lifecycle projector treated any idle pod with a team annotation as a team-owned warm-pool pod, initialized its projection from the Pod creation timestamp, and attributed the public pool's historical idle runtime to the claimant.

## Impact

Public warm-pool capacity is no longer charged to the team that claims it. Explicit team-owned warm pools continue to accrue team usage.

## Validation

- `go test ./manager/pkg/metering`
- `go test ./manager/pkg/...`
- `git diff --check`
