### PR TITLE
Fix fast CMD wait output race

### DIFF
--- a/manager/procd/pkg/http/handlers/context.go
+++ b/manager/procd/pkg/http/handlers/context.go
@@ -374,7 +374,16 @@ func (h *ContextHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.WaitUntilDone {
-		output, execErr, aborted := h.execInputSyncWithTimeout(ctx, input, r.Context(), 0)
+		var (
+			output  string
+			execErr *execError
+			aborted bool
+		)
+		if ctx.Type == process.ProcessTypeCMD {
+			output, execErr, aborted = waitForCMDCompletion(ctx, r.Context())
+		} else {
+			output, execErr, aborted = h.execInputSyncWithTimeout(ctx, input, r.Context(), 0)
+		}
 		if aborted {
 			return
 		}
@@ -610,6 +619,30 @@ func applySplitOutputToExecResponse(response *ContextExecResponse, ctx *ctxpkg.C
 
 func (h *ContextHandler) execInputSync(ctx *ctxpkg.Context, input string, requestCtx context.Context) (string, *execError, bool) {
 	return h.execInputSyncWithTimeout(ctx, input, requestCtx, h.execTimeout)
+}
+
+func waitForCMDCompletion(ctx *ctxpkg.Context, requestCtx context.Context) (string, *execError, bool) {
+	if ctx == nil || ctx.MainProcess == nil {
+		return "", &execError{
+			status:  http.StatusConflict,
+			code:    "process_not_running",
+			message: process.ErrProcessNotRunning.Error(),
+		}, false
+	}
+	provider, ok := ctx.MainProcess.(process.CompletionOutputProvider)
+	if !ok {
+		return "", &execError{
+			status:  http.StatusInternalServerError,
+			code:    "wait_failed",
+			message: "process completion output is unavailable",
+		}, false
+	}
+	select {
+	case <-requestCtx.Done():
+		return "", nil, true
+	case <-provider.OutputDone():
+		return provider.GetOutputRaw(), nil, false
+	}
 }
 
 // execInputSyncWithTimeout waits for a prompt or process completion. A

--- a/manager/procd/pkg/http/handlers/context_test.go
+++ b/manager/procd/pkg/http/handlers/context_test.go
@@ -35,6 +35,8 @@ type fakeProcess struct {
 	exitHandlers []process.ExitHandler
 	handlerAdded chan struct{}
 	writeErr     error
+	completionCh <-chan struct{}
+	outputRaw    string
 }
 
 func (f *fakeProcess) ID() string { return "proc-test" }
@@ -94,6 +96,8 @@ func (f *fakeProcess) GetOutput() (stdout, stderr string) {
 	defer f.mu.RUnlock()
 	return f.stdout, f.stderr
 }
+func (f *fakeProcess) OutputDone() <-chan struct{}     { return f.completionCh }
+func (f *fakeProcess) GetOutputRaw() string            { return f.outputRaw }
 func (f *fakeProcess) ResizePTY(process.PTYSize) error { return nil }
 func (f *fakeProcess) SendSignal(syscall.Signal) error { return nil }
 func (f *fakeProcess) ExitCode() (int, error) {
@@ -315,6 +319,31 @@ func TestCreateContextWaitUntilDoneCanExceedExecTimeout(t *testing.T) {
 	}
 	if !resp.Success || resp.Data.Stdout == nil || *resp.Data.Stdout != "done" {
 		t.Fatalf("response = %+v, want successful output after exec timeout", resp)
+	}
+}
+
+func TestWaitForCMDCompletionIncludesOutputCapturedBeforeWait(t *testing.T) {
+	done := make(chan struct{})
+	close(done)
+	proc := &fakeProcess{
+		completionCh: done,
+		outputRaw:    "outerr",
+		finished:     true,
+		state:        process.ProcessStateCrashed,
+		processType:  process.ProcessTypeCMD,
+	}
+	_, ctx := newHandlerWithContext(proc, process.ProcessTypeCMD)
+
+	output, execErr, aborted := waitForCMDCompletion(ctx, context.Background())
+
+	if aborted {
+		t.Fatal("waitForCMDCompletion() aborted")
+	}
+	if execErr != nil {
+		t.Fatalf("waitForCMDCompletion() error = %#v", execErr)
+	}
+	if output != "outerr" {
+		t.Fatalf("waitForCMDCompletion() output = %q, want outerr", output)
 	}
 }
 

--- a/manager/procd/pkg/process/cmd/cmd.go
+++ b/manager/procd/pkg/process/cmd/cmd.go
@@ -27,6 +27,7 @@ type CMD struct {
 
 var _ process.Process = (*CMD)(nil)
 var _ process.OutputProvider = (*CMD)(nil)
+var _ process.CompletionOutputProvider = (*CMD)(nil)
 
 // NewCMD creates a new CMD process.
 // The command parameter should be the full command path and arguments, e.g., []string{"/bin/ls", "-la"}

--- a/manager/procd/pkg/process/direct_runner.go
+++ b/manager/procd/pkg/process/direct_runner.go
@@ -37,8 +37,8 @@ func NewDirectRunner(base *BaseProcess, ctx context.Context, onStop func()) *Dir
 		base:   base,
 		ctx:    ctx,
 		onStop: onStop,
-		stdout: newLimitedBuffer(maxDirectRunnerOutputBytes),
-		stderr: newLimitedBuffer(maxDirectRunnerOutputBytes),
+		stdout: newLimitedBuffer(maxCapturedOutputBytes),
+		stderr: newLimitedBuffer(maxCapturedOutputBytes),
 	}
 }
 
@@ -215,8 +215,6 @@ func (w *directRunnerOutputWriter) Write(p []byte) (int, error) {
 
 	return len(p), nil
 }
-
-const maxDirectRunnerOutputBytes = 1 << 20
 
 type limitedBuffer struct {
 	mu   sync.Mutex

--- a/manager/procd/pkg/process/process.go
+++ b/manager/procd/pkg/process/process.go
@@ -12,7 +12,10 @@ import (
 	"github.com/creack/pty"
 )
 
-const defaultInputCloseTimeout = 5 * time.Second
+const (
+	defaultInputCloseTimeout = 5 * time.Second
+	maxCapturedOutputBytes   = 1 << 20
+)
 
 // ProcessType defines the type of process.
 type ProcessType string
@@ -165,6 +168,14 @@ type OutputProvider interface {
 	GetOutput() (stdout, stderr string)
 }
 
+// CompletionOutputProvider exposes the merged process output after all output
+// readers have reached EOF. It is used by one-shot callers that need a stable
+// result even when the process exits before they begin waiting.
+type CompletionOutputProvider interface {
+	OutputDone() <-chan struct{}
+	GetOutputRaw() string
+}
+
 // Process interface defines the contract for all process types.
 type Process interface {
 	// Identity
@@ -212,6 +223,8 @@ type BaseProcess struct {
 	reliableOutput  chan ProcessOutput
 	outputMultiplex *MultiplexedChannel[ProcessOutput]
 	outputForwarder OutputForwarder
+	rawOutput       *limitedBuffer
+	outputDone      chan struct{}
 	startTime       time.Time
 
 	// cpuTracker tracks CPU time between samples for percentage calculation
@@ -228,6 +241,7 @@ type BaseProcess struct {
 	inputReadyOnce  sync.Once
 	inputWriterOnce sync.Once
 	inputStopOnce   sync.Once
+	outputDoneOnce  sync.Once
 }
 
 type inputOperation struct {
@@ -248,10 +262,14 @@ func NewBaseProcess(id string, processType ProcessType, config ProcessConfig) *B
 		state:           ProcessStateCreated,
 		outputMultiplex: NewMultiplexedChannel[ProcessOutput](config.BufferSize),
 		outputForwarder: defaultOutputForwarderSnapshot(),
+		outputDone:      make(chan struct{}),
 		cpuTracker:      newCPUTracker(),
 		inputQueue:      make(chan inputOperation, config.BufferSize),
 		inputReady:      make(chan struct{}),
 		inputStop:       make(chan struct{}),
+	}
+	if processType == ProcessTypeCMD {
+		bp.rawOutput = newLimitedBuffer(maxCapturedOutputBytes)
 	}
 	if processType != ProcessTypeREPL {
 		close(bp.inputReady)
@@ -447,6 +465,19 @@ func (bp *BaseProcess) ReadOutput() <-chan ProcessOutput {
 // SubscribeOutput returns a cancellable subscription to process output.
 func (bp *BaseProcess) SubscribeOutput() (<-chan ProcessOutput, func()) {
 	return bp.outputMultiplex.Fork()
+}
+
+// OutputDone closes after the process output readers have reached EOF.
+func (bp *BaseProcess) OutputDone() <-chan struct{} {
+	return bp.outputDone
+}
+
+// GetOutputRaw returns the bounded merged output captured for the process.
+func (bp *BaseProcess) GetOutputRaw() string {
+	if bp.rawOutput == nil {
+		return ""
+	}
+	return bp.rawOutput.String()
 }
 
 // SetReliableOutput installs a lossless output sink for a process owner. The
@@ -720,6 +751,9 @@ func (bp *BaseProcess) NotifyStart(event StartEvent) {
 
 // PublishOutput publishes output to all subscribers.
 func (bp *BaseProcess) PublishOutput(output ProcessOutput) {
+	if len(output.Data) > 0 && bp.rawOutput != nil {
+		bp.rawOutput.Write(output.Data)
+	}
 	bp.mu.RLock()
 	if bp.reliableOutput != nil {
 		bp.reliableOutput <- output
@@ -733,16 +767,19 @@ func (bp *BaseProcess) PublishOutput(output ProcessOutput) {
 
 // CloseOutput closes the output channel.
 func (bp *BaseProcess) CloseOutput() {
-	if forwarder, ok := bp.outputForwarderSnapshot().(FlushableOutputForwarder); ok && forwarder != nil {
-		forwarder.FlushProcessOutput(bp.descriptor())
-	}
-	bp.mu.Lock()
-	if bp.reliableOutput != nil {
-		close(bp.reliableOutput)
-		bp.reliableOutput = nil
-	}
-	bp.mu.Unlock()
-	bp.outputMultiplex.Close()
+	bp.outputDoneOnce.Do(func() {
+		if forwarder, ok := bp.outputForwarderSnapshot().(FlushableOutputForwarder); ok && forwarder != nil {
+			forwarder.FlushProcessOutput(bp.descriptor())
+		}
+		bp.mu.Lock()
+		if bp.reliableOutput != nil {
+			close(bp.reliableOutput)
+			bp.reliableOutput = nil
+		}
+		bp.mu.Unlock()
+		bp.outputMultiplex.Close()
+		close(bp.outputDone)
+	})
 }
 
 func (bp *BaseProcess) outputForwarderSnapshot() OutputForwarder {

--- a/manager/procd/pkg/process/process_test.go
+++ b/manager/procd/pkg/process/process_test.go
@@ -236,6 +236,28 @@ func TestBaseProcess_PublishAndReadOutput(t *testing.T) {
 	}
 }
 
+func TestBaseProcessCompletionOutputCapturesBeforeWait(t *testing.T) {
+	bp := NewBaseProcess("test-id", ProcessTypeCMD, ProcessConfig{Type: ProcessTypeCMD})
+	bp.PublishOutput(ProcessOutput{Source: OutputSourceStdout, Data: []byte("out")})
+	bp.PublishOutput(ProcessOutput{Source: OutputSourceStderr, Data: []byte("err")})
+	bp.CloseOutput()
+
+	select {
+	case <-bp.OutputDone():
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for output completion")
+	}
+	if got := bp.GetOutputRaw(); got != "outerr" {
+		t.Fatalf("GetOutputRaw() = %q, want outerr", got)
+	}
+
+	// Closing twice must leave the completed result stable.
+	bp.CloseOutput()
+	if got := bp.GetOutputRaw(); got != "outerr" {
+		t.Fatalf("GetOutputRaw() after second close = %q, want outerr", got)
+	}
+}
+
 // TestBaseProcess_ConcurrentStateAccess tests concurrent state access.
 func TestBaseProcess_ConcurrentStateAccess(t *testing.T) {
 	config := ProcessConfig{


### PR DESCRIPTION
## Summary

- capture merged CMD output at the process boundary before fan-out subscribers can miss it
- expose an output-completion signal that closes only after process output readers reach EOF
- use that boundary for `cmd + wait_until_done` while preserving the existing REPL subscribe/drain path
- add deterministic coverage for output produced before the waiter starts

## Root cause

Context creation starts a CMD before the synchronous waiter subscribes. A late subscription replays multiplexed history, but the generic REPL-oriented drain step can discard that replay as stale. The independently captured stdout/stderr buffers therefore remained complete while `output_raw` could be partial or empty.

## Impact

Fast CMD contexts now return stable merged `output_raw` after output EOF, including output emitted before the HTTP handler begins waiting. The capture is bounded consistently with the existing CMD stdout/stderr buffers, and REPL execution semantics are unchanged.

## Checks

- `go test ./manager/procd/pkg/...`
- `go test -race ./manager/procd/pkg/...`
- `go test -race -count=1000 ./manager/procd/pkg/http/handlers -run '^TestCreateContextWaitUntilDoneIncludesCMDSplitOutput$'`

Fixes #803
