### PR TITLE
fix(apispec): make sandbox expirations optional

### DIFF
--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -5219,12 +5219,12 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: Soft expiration timestamp. Null means disabled or not set.
+          description: Soft expiration timestamp. Omitted or null means disabled or not set.
         hard_expires_at:
           type: string
           format: date-time
           nullable: true
-          description: Hard expiration timestamp. Null means disabled or not set.
+          description: Hard expiration timestamp. Omitted or null means disabled or not set.
         claimed_at:
           type: string
           format: date-time
@@ -5243,8 +5243,6 @@ components:
         - auto_resume
         - pod_name
         - runtime_generation
-        - expires_at
-        - hard_expires_at
         - claimed_at
         - created_at
         - updated_at
@@ -5490,12 +5488,12 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: Soft expiration timestamp. Null means disabled or not set.
+          description: Soft expiration timestamp. Omitted or null means disabled or not set.
         hard_expires_at:
           type: string
           format: date-time
           nullable: true
-          description: Hard expiration timestamp. Null means disabled or not set.
+          description: Hard expiration timestamp. Omitted or null means disabled or not set.
         updated_at:
           type: string
           format: date-time
@@ -5506,8 +5504,6 @@ components:
         - paused
         - runtime_generation
         - created_at
-        - expires_at
-        - hard_expires_at
         - updated_at
     SuccessSandboxListResponse:
       allOf:
@@ -6118,13 +6114,13 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: Soft expiration timestamp. Null means disabled or not set.
+          description: Soft expiration timestamp. Omitted or null means disabled or not set.
         hard_expires_at:
           type: string
           format: date-time
           nullable: true
-          description: Hard expiration timestamp. Null means disabled or not set.
-      required: [sandbox_id, expires_at, hard_expires_at]
+          description: Hard expiration timestamp. Omitted or null means disabled or not set.
+      required: [sandbox_id]
     SuccessRefreshResponse:
       allOf:
         - $ref: "#/components/schemas/SuccessEnvelope"

--- a/pkg/apispec/openapi_test.go
+++ b/pkg/apispec/openapi_test.go
@@ -1,0 +1,34 @@
+package apispec
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+func TestSandboxExpirationFieldsAreOptionalAndNullable(t *testing.T) {
+	document, err := openapi3.NewLoader().LoadFromFile("openapi.yaml")
+	if err != nil {
+		t.Fatalf("load OpenAPI document: %v", err)
+	}
+
+	for _, schemaName := range []string{"Sandbox", "SandboxSummary", "RefreshResponse"} {
+		schemaRef, ok := document.Components.Schemas[schemaName]
+		if !ok || schemaRef.Value == nil {
+			t.Fatalf("schema %q is missing", schemaName)
+		}
+		for _, fieldName := range []string{"expires_at", "hard_expires_at"} {
+			fieldRef, ok := schemaRef.Value.Properties[fieldName]
+			if !ok || fieldRef.Value == nil {
+				t.Fatalf("schema %q field %q is missing", schemaName, fieldName)
+			}
+			if !fieldRef.Value.Nullable {
+				t.Errorf("schema %q field %q must be nullable", schemaName, fieldName)
+			}
+			if slices.Contains(schemaRef.Value.Required, fieldName) {
+				t.Errorf("schema %q field %q must be optional", schemaName, fieldName)
+			}
+		}
+	}
+}

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -1941,10 +1941,10 @@ type RefreshRequest struct {
 
 // RefreshResponse defines model for RefreshResponse.
 type RefreshResponse struct {
-	// ExpiresAt Soft expiration timestamp. Null means disabled or not set.
+	// ExpiresAt Soft expiration timestamp. Omitted or null means disabled or not set.
 	ExpiresAt *time.Time `json:"expires_at"`
 
-	// HardExpiresAt Hard expiration timestamp. Null means disabled or not set.
+	// HardExpiresAt Hard expiration timestamp. Omitted or null means disabled or not set.
 	HardExpiresAt *time.Time `json:"hard_expires_at"`
 	SandboxId     string     `json:"sandbox_id"`
 }
@@ -2063,10 +2063,10 @@ type Sandbox struct {
 	ClaimedAt  time.Time `json:"claimed_at"`
 	CreatedAt  time.Time `json:"created_at"`
 
-	// ExpiresAt Soft expiration timestamp. Null means disabled or not set.
+	// ExpiresAt Soft expiration timestamp. Omitted or null means disabled or not set.
 	ExpiresAt *time.Time `json:"expires_at"`
 
-	// HardExpiresAt Hard expiration timestamp. Null means disabled or not set.
+	// HardExpiresAt Hard expiration timestamp. Omitted or null means disabled or not set.
 	HardExpiresAt *time.Time           `json:"hard_expires_at"`
 	Id            string               `json:"id"`
 	Mounts        *[]ClaimMountRequest `json:"mounts,omitempty"`
@@ -2584,10 +2584,10 @@ type SandboxSummary struct {
 	ClusterId *string   `json:"cluster_id"`
 	CreatedAt time.Time `json:"created_at"`
 
-	// ExpiresAt Soft expiration timestamp. Null means disabled or not set.
+	// ExpiresAt Soft expiration timestamp. Omitted or null means disabled or not set.
 	ExpiresAt *time.Time `json:"expires_at"`
 
-	// HardExpiresAt Hard expiration timestamp. Null means disabled or not set.
+	// HardExpiresAt Hard expiration timestamp. Omitted or null means disabled or not set.
 	HardExpiresAt *time.Time `json:"hard_expires_at"`
 	Id            string     `json:"id"`
 


### PR DESCRIPTION
## Summary

- mark sandbox soft and hard expiration timestamps as optional while retaining nullable wire values
- document omitted or null timestamps as disabled expiration policies
- regenerate the canonical Go API types and add a contract regression test

## Root cause

Required nullable date-time fields are emitted as non-null date types by downstream SDK generators. Disabled TTLs therefore fail to decode or become epoch timestamps. Making these nullable deadlines optional preserves the current null response while allowing generated clients to model the disabled state safely.

## Validation

- `make apispec`
- `go test ./pkg/apispec/...`
- `git diff --check`