### PR TITLE
Remove Chrome from the coding-agent image

### DIFF
--- a/manager/procd/Dockerfile.coding-agent
+++ b/manager/procd/Dockerfile.coding-agent
@@ -4,6 +4,7 @@
 
 FROM sandbox0ai/otemplates:default-v0.2.0
 
+# Keep Playwright CLI and its Agent Skill without bundling a browser runtime.
 ENV DEBIAN_FRONTEND=noninteractive \
     NPM_CONFIG_AUDIT=false \
     NPM_CONFIG_FUND=false \
@@ -12,21 +13,19 @@ ENV DEBIAN_FRONTEND=noninteractive \
     OPENCODE_DISABLE_AUTOUPDATE=1 \
     PI_SKIP_VERSION_CHECK=1 \
     PI_TELEMETRY=0 \
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
     PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright \
     PLAYWRIGHT_MCP_BROWSER=chromium \
     PLAYWRIGHT_MCP_ISOLATED=false \
-    PLAYWRIGHT_MCP_SANDBOX=false \
-    SANDPI_BROWSER_USER=sandbox-browser
+    PLAYWRIGHT_MCP_SANDBOX=false
 
 # Claude Code and Pi require Node.js 22. Pi currently requires Node.js 22.19+
 # specifically, so fail the build if the repository ever resolves an older 22.x.
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates curl gnupg openbox tigervnc-standalone-server x11vnc xvfb \
-  && command -v Xtigervnc >/dev/null \
+  && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
   && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
   && apt-get install -y --no-install-recommends nodejs \
   && node -e 'const [major, minor] = process.versions.node.split(".").map(Number); if (major < 22 || (major === 22 && minor < 19)) process.exit(1)' \
-  && useradd --create-home --home-dir /home/sandbox-browser --shell /bin/bash "$SANDPI_BROWSER_USER" \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/coding-agents
@@ -36,7 +35,6 @@ COPY manager/procd/coding-agents/THIRD_PARTY.md ./
 
 RUN npm ci --omit=dev \
   && for agent in codex claude opencode pi playwright-cli; do ln -sf "/opt/coding-agents/node_modules/.bin/$agent" "/usr/local/bin/$agent"; done \
-  && ./node_modules/.bin/playwright install chromium --with-deps --no-shell \
   && test -f /opt/coding-agents/node_modules/playwright-core/lib/tools/cli-client/skill/SKILL.md \
   && codex --version \
   && claude --version \
@@ -44,14 +42,6 @@ RUN npm ci --omit=dev \
   && pi --version \
   && playwright-cli --version \
   && npm cache clean --force
-
-# Chrome for Testing ships its process-sandbox helper without the setuid bit.
-# Human-owned headed sessions run as sandbox-browser, so configure the helper
-# explicitly instead of weakening those sessions with --no-sandbox.
-RUN chrome_sandbox="$(find /opt/ms-playwright -type f -path '*/chrome-linux*/chrome_sandbox' | head -n 1)" \
-  && test -n "$chrome_sandbox" \
-  && chown root:root "$chrome_sandbox" \
-  && chmod 4755 "$chrome_sandbox"
 
 RUN mkdir -p /workspace
 

--- a/manager/procd/coding-agents/THIRD_PARTY.md
+++ b/manager/procd/coding-agents/THIRD_PARTY.md
@@ -9,6 +9,5 @@ The `coding-agent` template installs these pinned third-party packages:
 | `opencode-ai` | `1.17.18` | MIT |
 | `@earendil-works/pi-coding-agent` | `0.80.6` | MIT |
 | `@playwright/cli` | `0.1.17` | Apache-2.0 |
-| `ws` | `8.21.0` | MIT |
 
 This inventory does not replace the license and notice files distributed in each npm package. Review the current upstream terms before publishing a derived image, especially for packages that do not use an open-source license.

--- a/manager/procd/coding-agents/package-lock.json
+++ b/manager/procd/coding-agents/package-lock.json
@@ -13,8 +13,7 @@
         "@earendil-works/pi-coding-agent": "0.80.6",
         "@openai/codex": "0.144.1",
         "@playwright/cli": "0.1.17",
-        "opencode-ai": "1.17.18",
-        "ws": "8.21.0"
+        "opencode-ai": "1.17.18"
       }
     },
     "node_modules/@anthropic-ai/claude-code": {
@@ -2355,27 +2354,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     }
   }

--- a/manager/procd/coding-agents/package.json
+++ b/manager/procd/coding-agents/package.json
@@ -9,7 +9,6 @@
     "@earendil-works/pi-coding-agent": "0.80.6",
     "@openai/codex": "0.144.1",
     "@playwright/cli": "0.1.17",
-    "opencode-ai": "1.17.18",
-    "ws": "8.21.0"
+    "opencode-ai": "1.17.18"
   }
 }

--- a/manager/procd/coding_agent_image_test.go
+++ b/manager/procd/coding_agent_image_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestCodingAgentImageIncludesRemoteResizeVNCServer(t *testing.T) {
+func TestCodingAgentImageKeepsPlaywrightWithoutBundledBrowser(t *testing.T) {
 	dockerfile, err := os.ReadFile("Dockerfile.coding-agent")
 	if err != nil {
 		t.Fatalf("read coding-agent Dockerfile: %v", err)
@@ -14,11 +14,26 @@ func TestCodingAgentImageIncludesRemoteResizeVNCServer(t *testing.T) {
 
 	contents := string(dockerfile)
 	for _, expected := range []string{
-		"tigervnc-standalone-server",
-		"command -v Xtigervnc >/dev/null",
+		"PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1",
+		"playwright-cli; do ln -sf",
+		"playwright-cli --version",
 	} {
 		if !strings.Contains(contents, expected) {
 			t.Fatalf("coding-agent Dockerfile does not contain %q", expected)
+		}
+	}
+
+	for _, forbidden := range []string{
+		"playwright install chromium",
+		"openbox",
+		"tigervnc-standalone-server",
+		"x11vnc",
+		"xvfb",
+		"SANDPI_BROWSER_USER",
+		"chrome_sandbox",
+	} {
+		if strings.Contains(contents, forbidden) {
+			t.Fatalf("coding-agent Dockerfile unexpectedly contains %q", forbidden)
 		}
 	}
 }


### PR DESCRIPTION
## What

- Retain the pinned official `@playwright/cli`, its command, and its bundled Agent Skill verification.
- Set `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` and stop installing Playwright Chromium.
- Remove Openbox, TigerVNC, x11vnc, Xvfb, the `sandbox-browser` user, and Chrome's setuid sandbox-helper configuration.
- Remove the direct `ws` dependency that existed for Sandpi's Browser/VNC bridge.
- Replace the image regression test with assertions that Playwright remains while no browser or headed/VNC runtime is bundled.

## Why

The general coding-agent template currently owns a full browser executable and two headed-display paths solely to support Sandpi's combined Environment Browser. That increases image weight and couples coding-agent cold start to a browser product surface. Browser and Preview will instead be independent capabilities.

## Impact

- The next image built from this Dockerfile will contain Playwright CLI and its Agent Skill, but no browser executable or GUI/VNC runtime.
- Playwright automation will require a browser runtime to be provisioned separately.
- This source PR does not publish or tag an image and does not change the current `coding-agent-v0.4.0` operator default. A follow-up image build and default-tag update are required before the new image is deployed; the current version-specific docs therefore remain unchanged.
- Companion Sandpi removal: https://github.com/sandbox0-ai/sandpi/pull/67

## Validation

- `npm ci --ignore-scripts` in `manager/procd/coding-agents`
- `npm ls --omit=dev`
- `go test ./manager/procd`
- Docker image build was not run because Docker is unavailable in this environment.
