### PR TITLE
fix(s0fs): bound WAL recovery and checkpoint growth

### DIFF
--- a/ctld/internal/ctld/portal/observer.go
+++ b/ctld/internal/ctld/portal/observer.go
@@ -1,6 +1,7 @@
 package portal
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -162,6 +163,33 @@ func (o *Observer) ObserveS0FSOpen(observation s0fs.OpenObservation) {
 		o.stateItems.WithLabelValues("directory_entries", observation.Source, format).Observe(float64(observation.DirectoryEntries))
 		o.stateItems.WithLabelValues("segments", observation.Source, format).Observe(float64(observation.Segments))
 		o.stateItems.WithLabelValues("wal_records", observation.Source, format).Observe(float64(observation.WALRecords))
+		o.stateItems.WithLabelValues("wal_records_scanned", observation.Source, format).Observe(float64(observation.WALRecordsScanned))
+		o.stateItems.WithLabelValues("wal_records_skipped", observation.Source, format).Observe(float64(observation.WALRecordsSkipped))
+	}
+	if observation.Phase == "complete" && observation.WALMaxRecordBytes > 0 && o.stateBytes != nil {
+		o.stateBytes.WithLabelValues("wal_max_record", observation.Source, format).Observe(float64(observation.WALMaxRecordBytes))
+	}
+	if observation.Phase == "complete" && observation.WALMaxDecodedBytes > 0 && o.stateBytes != nil {
+		o.stateBytes.WithLabelValues("wal_max_decoded_record", observation.Source, format).Observe(float64(observation.WALMaxDecodedBytes))
+	}
+	if observation.Phase == "wal_replay" && o.logger != nil {
+		fields := []zap.Field{
+			zap.String("volume_id", observation.VolumeID),
+			zap.String("source", observation.Source),
+			zap.String("format", format),
+			zap.Int64("wal_bytes_scanned", observation.Bytes),
+			zap.Int("wal_records_scanned", observation.WALRecordsScanned),
+			zap.Int("wal_records_skipped", observation.WALRecordsSkipped),
+			zap.Int("wal_records_replayed", observation.WALRecords),
+			zap.Int64("wal_max_record_bytes", observation.WALMaxRecordBytes),
+			zap.Int64("wal_max_decoded_record_bytes", observation.WALMaxDecodedBytes),
+			zap.Duration("duration", observation.Duration),
+			zap.String("status", observationStatus(observation.Err)),
+		}
+		if observation.Err != nil {
+			fields = append(fields, zap.Error(observation.Err))
+		}
+		o.logger.Debug("S0FS WAL recovery completed", fields...)
 	}
 }
 
@@ -257,6 +285,12 @@ func (o *Observer) observePhaseDuration(operation, phase, source string, format 
 func observationStatus(err error) string {
 	if err == nil {
 		return "success"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "deadline_exceeded"
+	}
+	if errors.Is(err, context.Canceled) {
+		return "canceled"
 	}
 	if errors.Is(err, s0fs.ErrCommittedHeadNotFound) || errors.Is(err, s0fs.ErrMaterializedManifestNotFound) || errors.Is(err, s0fs.ErrSnapshotNotFound) {
 		return "not_found"

--- a/ctld/internal/ctld/portal/observer_test.go
+++ b/ctld/internal/ctld/portal/observer_test.go
@@ -1,6 +1,7 @@
 package portal
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -13,14 +14,19 @@ func TestObserverDoesNotUseVolumeIDAsMetricLabel(t *testing.T) {
 	observer := NewObserver(registry, nil)
 	observer.ObserveBind("s0fs", "hot", "vol-sensitive", time.Now(), nil)
 	observer.ObserveS0FSOpen(s0fs.OpenObservation{
-		VolumeID:         "vol-sensitive",
-		Phase:            "complete",
-		Source:           "local",
-		Format:           s0fs.StateFormatV2,
-		Duration:         time.Millisecond,
-		Bytes:            1024,
-		Nodes:            10,
-		DirectoryEntries: 9,
+		VolumeID:           "vol-sensitive",
+		Phase:              "complete",
+		Source:             "local",
+		Format:             s0fs.StateFormatV2,
+		Duration:           time.Millisecond,
+		Bytes:              1024,
+		WALRecords:         7,
+		WALRecordsScanned:  10,
+		WALRecordsSkipped:  3,
+		WALMaxRecordBytes:  4096,
+		WALMaxDecodedBytes: 2048,
+		Nodes:              10,
+		DirectoryEntries:   9,
 	})
 	observer.ObserveHotCacheRequest("hit", "protected")
 	observer.ObserveHotCacheAdmission("admitted", "protected")
@@ -69,5 +75,14 @@ func TestObserverDoesNotUseVolumeIDAsMetricLabel(t *testing.T) {
 		if !seen {
 			t.Errorf("metric %s was not gathered", name)
 		}
+	}
+}
+
+func TestObservationStatusDistinguishesCancellation(t *testing.T) {
+	if got := observationStatus(context.Canceled); got != "canceled" {
+		t.Fatalf("observationStatus(context.Canceled) = %q, want canceled", got)
+	}
+	if got := observationStatus(context.DeadlineExceeded); got != "deadline_exceeded" {
+		t.Fatalf("observationStatus(context.DeadlineExceeded) = %q, want deadline_exceeded", got)
 	}
 }

--- a/storage-proxy/pkg/s0fs/engine.go
+++ b/storage-proxy/pkg/s0fs/engine.go
@@ -35,31 +35,46 @@ type Engine struct {
 	mutationVersion         uint64
 	lastCommittedManifest   uint64
 	lastMaterializedVersion uint64
+	pendingMaterialization  *pendingMaterialization
 	dirty                   bool
 	dirtyAt                 time.Time
 }
 
+type pendingMaterialization struct {
+	manifestSeq     uint64
+	mutationVersion uint64
+	state           *SnapshotState
+	walCheckpoint   *walCheckpoint
+}
+
 func Open(ctx context.Context, cfg Config) (engine *Engine, retErr error) {
+	ctx = nonNilContext(ctx)
 	openedAt := time.Now()
 	selectedSource := "new"
 	selectedFormat := 0
 	walRecordsApplied := 0
+	walRecordsSkipped := 0
+	var replayStats walReplayStats
 	defer func() {
 		if cfg.OpenObserver == nil {
 			return
 		}
 		observation := OpenObservation{
-			VolumeID: cfg.VolumeID,
-			Phase:    "complete",
-			Source:   selectedSource,
-			Format:   selectedFormat,
-			Duration: time.Since(openedAt),
-			Bytes:    -1,
-			Err:      retErr,
+			VolumeID:           cfg.VolumeID,
+			Phase:              "complete",
+			Source:             selectedSource,
+			Format:             selectedFormat,
+			Duration:           time.Since(openedAt),
+			Bytes:              -1,
+			WALRecords:         walRecordsApplied,
+			WALRecordsScanned:  replayStats.RecordsScanned,
+			WALRecordsSkipped:  walRecordsSkipped,
+			WALMaxRecordBytes:  replayStats.MaxRecordBytes,
+			WALMaxDecodedBytes: replayStats.MaxDecodedBytes,
+			Err:                retErr,
 		}
 		if engine != nil {
 			engine.mu.RLock()
-			observation.WALRecords = walRecordsApplied
 			observation.Nodes = len(engine.nodes)
 			observation.DirectoryEntries = directoryEntryCount(engine.children)
 			observation.Segments = len(engine.segments)
@@ -78,8 +93,15 @@ func Open(ctx context.Context, cfg Config) (engine *Engine, retErr error) {
 	}
 
 	phaseStarted := time.Now()
-	walFile, records, err := openWAL(cfg.WALPath, cfg.VolumeID, cfg.Encryption, cfg.WALSyncHook)
-	emitOpenPhase(cfg, "wal_open", "local", 0, phaseStarted, walFileSize(cfg.WALPath), len(records), nil, err)
+	replay, err := openWALReplay(cfg.WALPath, cfg.VolumeID, cfg.Encryption)
+	if err != nil {
+		emitWALOpenPhase(cfg, "wal_open", 0, phaseStarted, replayStats, 0, 0, nil, err)
+		return nil, err
+	}
+	defer replay.Close()
+	firstWALRecord, hasWALRecords, err := replay.Peek(ctx)
+	replayStats = replay.Stats()
+	emitWALOpenPhase(cfg, "wal_open", 0, phaseStarted, replayStats, 0, 0, nil, err)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +109,7 @@ func Open(ctx context.Context, cfg Config) (engine *Engine, retErr error) {
 	phaseStarted = time.Now()
 	state, localFormat, localBytes, err := loadCurrentState(cfg)
 	localStateErr := err
-	emitOpenPhase(cfg, "state_load", "local", localFormat, phaseStarted, localBytes, len(records), state, err)
+	emitOpenPhase(cfg, "state_load", "local", localFormat, phaseStarted, localBytes, replayStats.RecordsScanned, state, err)
 	materializer := NewMaterializer(cfg.VolumeID, cfg.ObjectStore, cfg.HeadStore, cfg.ObjectStoreForVolume)
 	if materializer != nil {
 		materializer.SetEncryption(cfg.Encryption)
@@ -111,7 +133,7 @@ func Open(ctx context.Context, cfg Config) (engine *Engine, retErr error) {
 				localCommitted = true
 				selectedSource = "local"
 				selectedFormat = localFormat
-				emitOpenPhase(cfg, "state_reuse", "local", localFormat, reuseStarted, localBytes, len(records), state, nil)
+				emitOpenPhase(cfg, "state_reuse", "local", localFormat, reuseStarted, localBytes, replayStats.RecordsScanned, state, nil)
 			} else if headErr != nil && !errors.Is(headErr, ErrCommittedHeadNotFound) {
 				err = headErr
 			}
@@ -123,9 +145,14 @@ func Open(ctx context.Context, cfg Config) (engine *Engine, retErr error) {
 			if manifest != nil && (manifest.Version == StateFormatV1 || manifest.Version == StateFormatV2) {
 				remoteFormat = manifest.Version
 			}
-			emitOpenPhase(cfg, "state_load", "remote", remoteFormat, phaseStarted, -1, len(records), latestState, latestErr)
+			emitOpenPhase(cfg, "state_load", "remote", remoteFormat, phaseStarted, -1, replayStats.RecordsScanned, latestState, latestErr)
+			if latestErr == nil {
+				if baseErr := validateCommittedWALBase(localStateErr, latestState, firstWALRecord, hasWALRecords); baseErr != nil {
+					return nil, baseErr
+				}
+			}
 			switch {
-			case latestErr == nil && shouldUseMaterializedState(state, err, latestState, len(records)):
+			case latestErr == nil && shouldUseMaterializedState(state, err, latestState, hasWALRecords):
 				state = latestState
 				err = nil
 				latestManifest = manifest
@@ -144,7 +171,6 @@ func Open(ctx context.Context, cfg Config) (engine *Engine, retErr error) {
 		materializer.SetOpenObserver(nil)
 	}
 	if err != nil && !errors.Is(err, ErrSnapshotNotFound) && !errors.Is(err, ErrMaterializedManifestNotFound) {
-		_ = walFile.close()
 		return nil, err
 	}
 	if state == nil {
@@ -179,7 +205,6 @@ func Open(ctx context.Context, cfg Config) (engine *Engine, retErr error) {
 
 	e := &Engine{
 		volumeID:           cfg.VolumeID,
-		wal:                walFile,
 		nextSeq:            state.NextSeq,
 		nextInode:          state.NextInode,
 		nodes:              state.Nodes,
@@ -199,19 +224,32 @@ func Open(ctx context.Context, cfg Config) (engine *Engine, retErr error) {
 
 	phaseStarted = time.Now()
 	appliedRecords := 0
-	for _, record := range records {
+	for {
+		record, ok, replayErr := replay.Next(ctx)
+		replayStats = replay.Stats()
+		if replayErr != nil {
+			emitWALOpenPhase(cfg, "wal_replay", selectedFormat, phaseStarted, replayStats, walRecordsSkipped, appliedRecords, e.currentStateLocked(), replayErr)
+			return nil, replayErr
+		}
+		if !ok {
+			break
+		}
 		if record.Seq < e.nextSeq {
+			walRecordsSkipped++
 			continue
 		}
 		if record.Seq > e.nextSeq {
-			_ = walFile.close()
-			return nil, fmt.Errorf("replay wal seq %d: %w: missing wal seq %d", record.Seq, ErrInvalidInput, e.nextSeq)
+			replayErr := fmt.Errorf("replay wal seq %d: %w: missing wal seq %d", record.Seq, ErrInvalidInput, e.nextSeq)
+			emitWALOpenPhase(cfg, "wal_replay", selectedFormat, phaseStarted, replayStats, walRecordsSkipped, appliedRecords, e.currentStateLocked(), replayErr)
+			return nil, replayErr
 		}
 		if err := e.apply(record); err != nil {
-			_ = walFile.close()
-			return nil, fmt.Errorf("replay wal seq %d: %w", record.Seq, err)
+			replayErr := fmt.Errorf("replay wal seq %d: %w", record.Seq, err)
+			emitWALOpenPhase(cfg, "wal_replay", selectedFormat, phaseStarted, replayStats, walRecordsSkipped, appliedRecords, e.currentStateLocked(), replayErr)
+			return nil, replayErr
 		}
 		appliedRecords++
+		walRecordsApplied = appliedRecords
 		if record.Seq >= e.nextSeq {
 			e.nextSeq = record.Seq + 1
 		}
@@ -219,6 +257,16 @@ func Open(ctx context.Context, cfg Config) (engine *Engine, retErr error) {
 			e.nextInode = record.Inode + 1
 		}
 	}
+	if err := replay.Close(); err != nil {
+		emitWALOpenPhase(cfg, "wal_replay", selectedFormat, phaseStarted, replayStats, walRecordsSkipped, appliedRecords, e.currentStateLocked(), err)
+		return nil, err
+	}
+	walFile, err := openWAL(cfg.WALPath, cfg.VolumeID, cfg.Encryption, cfg.WALSyncHook, replayStats)
+	if err != nil {
+		emitWALOpenPhase(cfg, "wal_replay", selectedFormat, phaseStarted, replayStats, walRecordsSkipped, appliedRecords, e.currentStateLocked(), err)
+		return nil, err
+	}
+	e.wal = walFile
 	if !e.retainUnlinked {
 		e.collectUnlinkedLocked()
 	}
@@ -228,10 +276,37 @@ func Open(ctx context.Context, cfg Config) (engine *Engine, retErr error) {
 		e.mutationVersion = 1
 	}
 	walRecordsApplied = appliedRecords
-	emitOpenPhase(cfg, "wal_replay", "local", selectedFormat, phaseStarted, walFileSize(cfg.WALPath), appliedRecords, e.currentStateLocked(), nil)
+	emitWALOpenPhase(cfg, "wal_replay", selectedFormat, phaseStarted, replayStats, walRecordsSkipped, appliedRecords, e.currentStateLocked(), nil)
 
 	engine = e
 	return engine, nil
+}
+
+func emitWALOpenPhase(cfg Config, phase string, format int, started time.Time, stats walReplayStats, skipped, applied int, state *SnapshotState, err error) {
+	bytes := stats.BytesScanned
+	if phase == "wal_open" {
+		bytes = walFileSize(cfg.WALPath)
+	}
+	observation := OpenObservation{
+		VolumeID:           cfg.VolumeID,
+		Phase:              phase,
+		Source:             "local",
+		Format:             format,
+		Duration:           time.Since(started),
+		Bytes:              bytes,
+		WALRecords:         applied,
+		WALRecordsScanned:  stats.RecordsScanned,
+		WALRecordsSkipped:  skipped,
+		WALMaxRecordBytes:  stats.MaxRecordBytes,
+		WALMaxDecodedBytes: stats.MaxDecodedBytes,
+		Err:                err,
+	}
+	if state != nil {
+		observation.Nodes = len(state.Nodes)
+		observation.DirectoryEntries = directoryEntryCount(state.Children)
+		observation.Segments = len(state.Segments)
+	}
+	emitOpenObservation(cfg.OpenObserver, observation)
 }
 
 func emitOpenPhase(cfg Config, phase, source string, format int, started time.Time, bytes int64, walRecords int, state *SnapshotState, err error) {
@@ -280,6 +355,9 @@ func directoryEntryCount(children map[uint64]map[string]uint64) int {
 }
 
 func (e *Engine) Close() error {
+	e.materializeMu.Lock()
+	defer e.materializeMu.Unlock()
+
 	e.mutationMu.Lock()
 	defer e.mutationMu.Unlock()
 
@@ -810,26 +888,45 @@ func (e *Engine) EnsureMaterialized(ctx context.Context) (*Manifest, error) {
 }
 
 func (e *Engine) syncMaterialize(ctx context.Context, force bool) (*Manifest, error) {
+	ctx = nonNilContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	e.materializeMu.Lock()
 	defer e.materializeMu.Unlock()
 
-	e.mu.RLock()
+	e.mutationMu.Lock()
+	e.mu.Lock()
 	if err := e.checkOpen(); err != nil {
-		e.mu.RUnlock()
+		e.mu.Unlock()
+		e.mutationMu.Unlock()
+		return nil, err
+	}
+	if err := e.finalizePendingMaterializationLocked(); err != nil {
+		e.mu.Unlock()
+		e.mutationMu.Unlock()
 		return nil, err
 	}
 	if e.materializer == nil || !e.materializer.Enabled() || (!e.dirty && (!force || !e.needsMaterializationLocked())) {
-		e.mu.RUnlock()
+		e.mu.Unlock()
+		e.mutationMu.Unlock()
 		return nil, nil
 	}
 	version := e.mutationVersion
 	state, err := e.materializeStateLocked()
 	if err != nil {
-		e.mu.RUnlock()
+		e.mu.Unlock()
+		e.mutationMu.Unlock()
 		return nil, err
 	}
 	expectedManifestSeq := e.lastCommittedManifest
-	e.mu.RUnlock()
+	e.mu.Unlock()
+	checkpoint, err := e.wal.checkpoint(checkpointSequence(state))
+	if err != nil {
+		e.mutationMu.Unlock()
+		return nil, err
+	}
+	e.mutationMu.Unlock()
 
 	manifest, err := e.materializer.Materialize(ctx, state, expectedManifestSeq)
 	if err != nil || manifest == nil {
@@ -841,24 +938,53 @@ func (e *Engine) syncMaterialize(ctx context.Context, force bool) (*Manifest, er
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	if e.mutationVersion == version && e.lastCommittedManifest == expectedManifestSeq {
-		if manifest.State != nil {
-			e.replaceStateLocked(cloneState(manifest.State))
-		}
-		if err := e.persistCurrentStateLocked(); err != nil {
-			return nil, err
-		}
-		if err := e.wal.reset(); err != nil {
-			return nil, err
-		}
-		e.refreshLocalDiskGuardLocked()
-		e.lastCommittedManifest = manifest.ManifestSeq
-		e.lastMaterializedVersion = version
-		e.dirty = false
-	} else if manifest.ManifestSeq > e.lastCommittedManifest {
+	if err := e.checkOpen(); err != nil {
+		return nil, err
+	}
+	if manifest.ManifestSeq > e.lastCommittedManifest {
 		e.lastCommittedManifest = manifest.ManifestSeq
 	}
+	e.pendingMaterialization = &pendingMaterialization{
+		manifestSeq:     manifest.ManifestSeq,
+		mutationVersion: version,
+		state:           manifest.State,
+		walCheckpoint:   checkpoint,
+	}
+	if err := e.finalizePendingMaterializationLocked(); err != nil {
+		return nil, err
+	}
 	return manifest, nil
+}
+
+// finalizePendingMaterializationLocked makes a committed remote checkpoint
+// durable locally before reclaiming its WAL prefix. The caller holds
+// mutationMu and e.mu so Close, restore, and new mutations cannot cross the
+// local checkpoint boundary.
+func (e *Engine) finalizePendingMaterializationLocked() error {
+	pending := e.pendingMaterialization
+	if pending == nil {
+		return nil
+	}
+	if pending.state == nil || checkpointSequence(pending.state) != pending.manifestSeq {
+		return fmt.Errorf("%w: pending materialization checkpoint is invalid", ErrInvalidInput)
+	}
+	if err := e.persistStateLocked(pending.state, true); err != nil {
+		return err
+	}
+	if pending.walCheckpoint == nil || pending.walCheckpoint.throughSeq != pending.manifestSeq {
+		return fmt.Errorf("%w: pending materialization wal checkpoint is invalid", ErrInvalidInput)
+	}
+	if err := e.wal.discardThrough(pending.walCheckpoint); err != nil {
+		return err
+	}
+	if e.mutationVersion == pending.mutationVersion {
+		e.replaceStateLocked(cloneState(pending.state))
+		e.lastMaterializedVersion = pending.mutationVersion
+		e.dirty = false
+	}
+	e.pendingMaterialization = nil
+	e.refreshLocalDiskGuardLocked()
+	return nil
 }
 
 func (e *Engine) RefreshMaterialized(ctx context.Context) (bool, error) {
@@ -1108,7 +1234,7 @@ func (e *Engine) appendAndApplyLocked(record walRecord, projectedBytes int64) er
 }
 
 func (e *Engine) appendPreparedAndApplyLocked(record walRecord, walPayload []byte) error {
-	if err := e.wal.appendPrepared(walPayload); err != nil {
+	if err := e.wal.appendPrepared(record, walPayload); err != nil {
 		return err
 	}
 	if err := e.apply(record); err != nil {
@@ -1231,7 +1357,11 @@ func (e *Engine) persistCurrentStateLocked() error {
 }
 
 func (e *Engine) persistCurrentStateLockedWithReserve(reserve bool) error {
-	state := cloneState(e.currentStateLocked())
+	return e.persistStateLocked(e.currentStateLocked(), reserve)
+}
+
+func (e *Engine) persistStateLocked(source *SnapshotState, reserve bool) error {
+	state := cloneState(source)
 	pruneUnreferencedSegments(state)
 	if reserve {
 		if err := e.reserveLocalDiskLocked(estimatedStateBytes(state)); err != nil {
@@ -1248,7 +1378,7 @@ func loadCurrentState(cfg Config) (*SnapshotState, int, int64, error) {
 	return loadSnapshotStateWithFormat(headStatePath(cfg.WALPath), cfg.VolumeID, "head", cfg.Encryption)
 }
 
-func shouldUseMaterializedState(current *SnapshotState, currentErr error, latest *SnapshotState, walRecords int) bool {
+func shouldUseMaterializedState(current *SnapshotState, currentErr error, latest *SnapshotState, hasWALRecords bool) bool {
 	if latest == nil {
 		return false
 	}
@@ -1261,10 +1391,25 @@ func shouldUseMaterializedState(current *SnapshotState, currentErr error, latest
 	if current == nil {
 		return true
 	}
-	if walRecords > 0 {
+	if hasWALRecords {
 		return false
 	}
 	return latest.NextSeq > current.NextSeq
+}
+
+func validateCommittedWALBase(localStateErr error, committed *SnapshotState, firstWALRecord walRecord, hasWALRecords bool) error {
+	if !hasWALRecords || !errors.Is(localStateErr, ErrSnapshotNotFound) || committed == nil {
+		return nil
+	}
+	if firstWALRecord.Seq == committed.NextSeq {
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: local head is missing, committed state expects wal seq %d, and local wal starts at seq %d",
+		ErrCommittedHeadConflict,
+		committed.NextSeq,
+		firstWALRecord.Seq,
+	)
 }
 
 func (e *Engine) apply(record walRecord) error {

--- a/storage-proxy/pkg/s0fs/materializer_test.go
+++ b/storage-proxy/pkg/s0fs/materializer_test.go
@@ -872,6 +872,13 @@ func TestEngineSyncMaterializeDetectsCommittedHeadConflicts(t *testing.T) {
 	if _, err := second.SyncMaterialize(ctx); !errors.Is(err, ErrCommittedHeadConflict) {
 		t.Fatalf("SyncMaterialize(second) err = %v, want %v", err, ErrCommittedHeadConflict)
 	}
+	info, err := os.Stat(second.wal.path)
+	if err != nil {
+		t.Fatalf("Stat(second WAL) error = %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatal("failed commit discarded the local WAL")
+	}
 }
 
 func TestEngineSyncMaterializeSerializesSameEngineCommits(t *testing.T) {
@@ -995,9 +1002,23 @@ func TestEngineSyncMaterializeAdvancesCommittedHeadWhenDirtyDuringCommit(t *test
 	case <-time.After(time.Second):
 		t.Fatal("SyncMaterialize(first) did not complete")
 	}
+	engine.wal.mu.Lock()
+	activeFirstSeq := engine.wal.firstSeq
+	activeLastSeq := engine.wal.lastSeq
+	engine.wal.mu.Unlock()
+	if activeFirstSeq != 3 || activeLastSeq != 4 {
+		t.Fatalf("active WAL sequence range after concurrent writes = %d-%d, want 3-4", activeFirstSeq, activeLastSeq)
+	}
 
 	if _, err := engine.SyncMaterialize(ctx); err != nil {
 		t.Fatalf("SyncMaterialize(second) error = %v", err)
+	}
+	engine.wal.mu.Lock()
+	activeFirstSeq = engine.wal.firstSeq
+	activeLastSeq = engine.wal.lastSeq
+	engine.wal.mu.Unlock()
+	if activeFirstSeq != 0 || activeLastSeq != 0 {
+		t.Fatalf("active WAL sequence range after second checkpoint = %d-%d, want empty", activeFirstSeq, activeLastSeq)
 	}
 	head, err := heads.LoadCommittedHead(ctx, "vol-dirty-during-materialize")
 	if err != nil {
@@ -1005,6 +1026,66 @@ func TestEngineSyncMaterializeAdvancesCommittedHeadWhenDirtyDuringCommit(t *test
 	}
 	if head.ManifestSeq < 2 {
 		t.Fatalf("committed manifest seq = %d, want at least 2", head.ManifestSeq)
+	}
+}
+
+func TestEngineSyncMaterializeRetriesLocalCheckpointAfterRemoteCommit(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	guard := &LocalDiskGuard{Path: dir, MaxBytes: 1 << 30}
+	store := newPrefixedRecordingStore(t, "vol-local-checkpoint-retry")
+	heads := newMemoryHeadStore()
+	engine, err := Open(ctx, Config{
+		VolumeID:       "vol-local-checkpoint-retry",
+		WALPath:        filepath.Join(dir, "engine.wal"),
+		ObjectStore:    store,
+		HeadStore:      heads,
+		LocalDiskGuard: guard,
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+
+	node, err := engine.CreateFile(RootInode, "data.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile() error = %v", err)
+	}
+	if _, err := engine.Write(node.Inode, 0, []byte("payload")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	guard.MaxBytes = 1
+	if _, err := engine.SyncMaterialize(ctx); !errors.Is(err, ErrNoSpace) {
+		t.Fatalf("SyncMaterialize(first) error = %v, want ErrNoSpace", err)
+	}
+	if engine.pendingMaterialization == nil {
+		t.Fatal("committed materialization was not retained for local retry")
+	}
+	info, err := os.Stat(engine.wal.path)
+	if err != nil {
+		t.Fatalf("Stat(WAL before local retry) error = %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatal("remote commit discarded WAL before the local checkpoint was durable")
+	}
+
+	guard.MaxBytes = 1 << 30
+	manifest, err := engine.SyncMaterialize(ctx)
+	if err != nil {
+		t.Fatalf("SyncMaterialize(retry) error = %v", err)
+	}
+	if manifest != nil {
+		t.Fatalf("SyncMaterialize(retry) manifest = %+v, want local-only finalization", manifest)
+	}
+	if engine.pendingMaterialization != nil {
+		t.Fatal("pending materialization was not cleared after local retry")
+	}
+	info, err = os.Stat(engine.wal.path)
+	if err != nil {
+		t.Fatalf("Stat(WAL after local retry) error = %v", err)
+	}
+	if info.Size() != 0 {
+		t.Fatalf("WAL bytes after local retry = %d, want 0", info.Size())
 	}
 }
 

--- a/storage-proxy/pkg/s0fs/types.go
+++ b/storage-proxy/pkg/s0fs/types.go
@@ -42,17 +42,21 @@ const (
 // OpenObservation describes one bounded S0FS engine-open phase. Callers must
 // keep metric labels low-cardinality; VolumeID is intended for logs only.
 type OpenObservation struct {
-	VolumeID         string
-	Phase            string
-	Source           string
-	Format           int
-	Duration         time.Duration
-	Bytes            int64
-	WALRecords       int
-	Nodes            int
-	DirectoryEntries int
-	Segments         int
-	Err              error
+	VolumeID           string
+	Phase              string
+	Source             string
+	Format             int
+	Duration           time.Duration
+	Bytes              int64
+	WALRecords         int
+	WALRecordsScanned  int
+	WALRecordsSkipped  int
+	WALMaxRecordBytes  int64
+	WALMaxDecodedBytes int64
+	Nodes              int
+	DirectoryEntries   int
+	Segments           int
+	Err                error
 }
 
 type OpenObserver func(OpenObservation)

--- a/storage-proxy/pkg/s0fs/wal.go
+++ b/storage-proxy/pkg/s0fs/wal.go
@@ -2,6 +2,7 @@ package s0fs
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,10 +10,24 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"syscall"
 	"time"
 )
 
-const walSyncCoalesceDelay = time.Millisecond
+const (
+	walSyncCoalesceDelay = time.Millisecond
+	// Recovery checks cancellation between 64 KiB scan chunks and before and
+	// after decrypting and decoding each bounded record.
+	walReplayReadBufferBytes = 64 << 10
+
+	// Direct file APIs currently accept writes up to 100 MiB. Encrypted WAL
+	// records wrap the base64-encoded JSON payload in a second JSON envelope, so
+	// the on-disk limit leaves enough room for the supported write size while
+	// still bounding recovery memory and cancellation latency per record.
+	maximumWALRecordBytes int64 = 256 << 20
+
+	walRewriteSuffix = ".rewrite"
+)
 
 type wal struct {
 	path       string
@@ -25,68 +40,291 @@ type wal struct {
 	writeGen   uint64
 	syncedGen  uint64
 	syncing    bool
+	firstSeq   uint64
+	lastSeq    uint64
 }
 
-func openWAL(path, volumeID string, encryption *EncryptionConfig, onSync func()) (*wal, []walRecord, error) {
+type walReplayStats struct {
+	BytesScanned     int64
+	RecordsScanned   int
+	MaxRecordBytes   int64
+	MaxDecodedBytes  int64
+	ActiveFirstSeq   uint64
+	ActiveLastSeq    uint64
+	ActiveValidBytes int64
+}
+
+type walReplay struct {
+	path       string
+	volumeID   string
+	encryption *EncryptionConfig
+	file       *os.File
+	reader     *bufio.Reader
+	bytesRead  int64
+	peeked     *walRecord
+	finished   bool
+	stats      walReplayStats
+}
+
+// walCheckpoint identifies the byte prefix represented by a materialization
+// snapshot. It remains valid while later mutations append to the same WAL.
+type walCheckpoint struct {
+	throughSeq uint64
+	offset     int64
+	applied    bool
+}
+
+// openWALReplay builds a bounded iterator over the legacy-compatible active
+// WAL. It does not create or modify the WAL file.
+func openWALReplay(path, volumeID string, encryption *EncryptionConfig) (*walReplay, error) {
 	if path == "" {
-		return nil, nil, fmt.Errorf("%w: wal path is required", ErrInvalidInput)
+		return nil, fmt.Errorf("%w: wal path is required", ErrInvalidInput)
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return nil, nil, fmt.Errorf("create wal directory: %w", err)
+		return nil, fmt.Errorf("create wal directory: %w", err)
 	}
-
-	records, err := readWAL(path, volumeID, encryption)
-	if err != nil {
-		return nil, nil, err
+	if _, err := os.Stat(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("stat wal: %w", err)
 	}
-
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
-	if err != nil {
-		return nil, nil, fmt.Errorf("open wal: %w", err)
-	}
-	w := &wal{path: path, file: file, volumeID: volumeID, encryption: encryption, onSync: onSync}
-	w.syncCond = sync.NewCond(&w.mu)
-	return w, records, nil
+	return &walReplay{
+		path:       path,
+		volumeID:   volumeID,
+		encryption: encryption,
+	}, nil
 }
 
-func readWAL(path, volumeID string, encryption *EncryptionConfig) ([]walRecord, error) {
-	file, err := os.Open(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil, nil
+func (r *walReplay) Peek(ctx context.Context) (walRecord, bool, error) {
+	if r == nil {
+		return walRecord{}, false, nil
 	}
-	if err != nil {
-		return nil, fmt.Errorf("read wal: %w", err)
+	if r.peeked != nil {
+		return *r.peeked, true, nil
 	}
-	defer file.Close()
+	record, ok, err := r.Next(ctx)
+	if err != nil || !ok {
+		return walRecord{}, ok, err
+	}
+	r.peeked = &record
+	return record, true, nil
+}
 
-	var records []walRecord
-	reader := bufio.NewReader(file)
-	for {
-		line, err := reader.ReadBytes('\n')
-		if len(line) > 0 {
-			if errors.Is(err, io.EOF) && line[len(line)-1] != '\n' {
-				return records, nil
-			}
-			payload := line
-			if plaintext, encrypted, err := encryption.decryptBlobIfEncrypted(line, walRecordAAD(volumeID)); encrypted || err != nil {
-				if err != nil {
-					return nil, fmt.Errorf("decrypt wal record: %w", err)
-				}
-				payload = plaintext
-			}
-			var record walRecord
-			if decodeErr := json.Unmarshal(payload, &record); decodeErr != nil {
-				return nil, fmt.Errorf("decode wal record: %w", decodeErr)
-			}
-			records = append(records, record)
-		}
-		if errors.Is(err, io.EOF) {
-			return records, nil
+// Next decrypts and decodes at most one complete record. The encoded record is
+// no longer retained by the iterator after the call returns.
+func (r *walReplay) Next(ctx context.Context) (walRecord, bool, error) {
+	if r == nil || r.finished {
+		return walRecord{}, false, nil
+	}
+	ctx = nonNilContext(ctx)
+	if err := ctx.Err(); err != nil {
+		return walRecord{}, false, err
+	}
+	if r.peeked != nil {
+		record := *r.peeked
+		r.peeked = nil
+		return record, true, nil
+	}
+	if r.file == nil {
+		file, err := os.Open(r.path)
+		if errors.Is(err, os.ErrNotExist) {
+			r.finished = true
+			return walRecord{}, false, nil
 		}
 		if err != nil {
-			return nil, fmt.Errorf("scan wal: %w", err)
+			return walRecord{}, false, fmt.Errorf("open wal replay source: %w", err)
+		}
+		r.file = file
+		r.reader = bufio.NewReaderSize(file, walReplayReadBufferBytes)
+	}
+
+	line, complete, bytesRead, err := readBoundedWALLine(ctx, r.reader)
+	r.bytesRead += bytesRead
+	r.stats.BytesScanned += bytesRead
+	if err != nil {
+		return walRecord{}, false, err
+	}
+	if !complete {
+		if err := r.finish(); err != nil {
+			return walRecord{}, false, err
+		}
+		return walRecord{}, false, nil
+	}
+
+	record, err := decodeWALRecord(ctx, line, r.volumeID, r.encryption)
+	if err != nil {
+		return walRecord{}, false, err
+	}
+	r.stats.RecordsScanned++
+	if size := int64(len(line)); size > r.stats.MaxRecordBytes {
+		r.stats.MaxRecordBytes = size
+	}
+	if size := estimatedDecodedWALRecordBytes(record); size > r.stats.MaxDecodedBytes {
+		r.stats.MaxDecodedBytes = size
+	}
+	if r.stats.ActiveFirstSeq == 0 {
+		r.stats.ActiveFirstSeq = record.Seq
+	}
+	r.stats.ActiveLastSeq = record.Seq
+	r.stats.ActiveValidBytes = r.bytesRead
+	return record, true, nil
+}
+
+func (r *walReplay) finish() error {
+	if r == nil || r.finished {
+		return nil
+	}
+	r.finished = true
+	if r.file == nil {
+		return nil
+	}
+	err := r.file.Close()
+	r.file = nil
+	r.reader = nil
+	return err
+}
+
+func (r *walReplay) Stats() walReplayStats {
+	if r == nil {
+		return walReplayStats{}
+	}
+	return r.stats
+}
+
+func (r *walReplay) Close() error {
+	if r == nil || r.file == nil {
+		return nil
+	}
+	err := r.file.Close()
+	r.file = nil
+	r.reader = nil
+	return err
+}
+
+func readBoundedWALLine(ctx context.Context, reader *bufio.Reader) ([]byte, bool, int64, error) {
+	return readBoundedWALLineLimit(ctx, reader, maximumWALRecordBytes)
+}
+
+func readBoundedWALLineLimit(ctx context.Context, reader *bufio.Reader, maximumBytes int64) ([]byte, bool, int64, error) {
+	ctx = nonNilContext(ctx)
+	if reader == nil {
+		return nil, false, 0, io.EOF
+	}
+	if maximumBytes <= 0 {
+		return nil, false, 0, fmt.Errorf("%w: wal record limit must be positive", ErrInvalidInput)
+	}
+	var line []byte
+	var bytesRead int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, false, bytesRead, err
+		}
+		fragment, err := reader.ReadSlice('\n')
+		bytesRead += int64(len(fragment))
+		if int64(len(line))+int64(len(fragment)) > maximumBytes {
+			return nil, false, bytesRead, fmt.Errorf("%w: wal record exceeds %d bytes", ErrInvalidInput, maximumBytes)
+		}
+		if err == nil && len(line) == 0 {
+			return fragment, true, bytesRead, nil
+		}
+		line = append(line, fragment...)
+		switch {
+		case err == nil:
+			return line, true, bytesRead, nil
+		case errors.Is(err, bufio.ErrBufferFull):
+			continue
+		case errors.Is(err, io.EOF):
+			// A final record is durable only after its newline is appended. Preserve
+			// the existing truncated-tail behavior and let openWAL remove the tail
+			// before accepting new writes.
+			return line, false, bytesRead, nil
+		default:
+			return nil, false, bytesRead, fmt.Errorf("scan wal: %w", err)
 		}
 	}
+}
+
+func decodeWALRecord(ctx context.Context, line []byte, volumeID string, encryption *EncryptionConfig) (walRecord, error) {
+	if err := nonNilContext(ctx).Err(); err != nil {
+		return walRecord{}, err
+	}
+	payload := line
+	if plaintext, encrypted, err := encryption.decryptBlobIfEncrypted(line, walRecordAAD(volumeID)); encrypted || err != nil {
+		if err != nil {
+			return walRecord{}, fmt.Errorf("decrypt wal record: %w", err)
+		}
+		payload = plaintext
+	}
+	if err := nonNilContext(ctx).Err(); err != nil {
+		return walRecord{}, err
+	}
+	var record walRecord
+	if err := json.Unmarshal(payload, &record); err != nil {
+		return walRecord{}, fmt.Errorf("decode wal record: %w", err)
+	}
+	if err := nonNilContext(ctx).Err(); err != nil {
+		return walRecord{}, err
+	}
+	return record, nil
+}
+
+func estimatedDecodedWALRecordBytes(record walRecord) int64 {
+	// The fixed allowance covers the decoded struct, string headers, and slice
+	// header; dynamic payloads are counted exactly.
+	const fixedRecordBytes = 256
+	return fixedRecordBytes + int64(len(record.Op)+len(record.Name)+len(record.NewName)+len(record.Target)+len(record.Data))
+}
+
+func nonNilContext(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx
+}
+
+func openWAL(path, volumeID string, encryption *EncryptionConfig, onSync func(), replay walReplayStats) (*wal, error) {
+	if path == "" {
+		return nil, fmt.Errorf("%w: wal path is required", ErrInvalidInput)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("create wal directory: %w", err)
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open wal: %w", err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("stat wal: %w", err)
+	}
+	if replay.ActiveValidBytes < 0 || replay.ActiveValidBytes > info.Size() {
+		_ = file.Close()
+		return nil, fmt.Errorf("%w: invalid active wal length %d for file size %d", ErrInvalidInput, replay.ActiveValidBytes, info.Size())
+	}
+	if info.Size() != replay.ActiveValidBytes {
+		if err := file.Truncate(replay.ActiveValidBytes); err != nil {
+			_ = file.Close()
+			return nil, fmt.Errorf("truncate partial wal tail: %w", err)
+		}
+	}
+	if (replay.ActiveFirstSeq == 0) != (replay.ActiveLastSeq == 0) || replay.ActiveLastSeq < replay.ActiveFirstSeq {
+		_ = file.Close()
+		return nil, fmt.Errorf("%w: invalid active wal sequence range", ErrInvalidInput)
+	}
+	if err := removeStaleWALRewrite(path); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	w := &wal{
+		path:       path,
+		file:       file,
+		volumeID:   volumeID,
+		encryption: encryption,
+		onSync:     onSync,
+		firstSeq:   replay.ActiveFirstSeq,
+		lastSeq:    replay.ActiveLastSeq,
+	}
+	w.syncCond = sync.NewCond(&w.mu)
+	return w, nil
 }
 
 func (w *wal) prepare(record walRecord) ([]byte, error) {
@@ -103,26 +341,42 @@ func (w *wal) prepare(record walRecord) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("marshal wal record: %w", err)
 	}
+	if int64(len(payload)) > maximumWALRecordBytes {
+		return nil, fmt.Errorf("%w: wal record exceeds %d bytes", ErrInvalidInput, maximumWALRecordBytes)
+	}
 	payload, err = w.encryption.encryptBlob(payload, walRecordAAD(w.volumeID))
 	if err != nil {
 		return nil, fmt.Errorf("encrypt wal record: %w", err)
 	}
 	payload = append(payload, '\n')
+	if int64(len(payload)) > maximumWALRecordBytes {
+		return nil, fmt.Errorf("%w: encoded wal record exceeds %d bytes", ErrInvalidInput, maximumWALRecordBytes)
+	}
 	return payload, nil
 }
 
-func (w *wal) appendPrepared(payload []byte) error {
+func (w *wal) appendPrepared(record walRecord, payload []byte) error {
 	if w == nil {
 		return ErrClosed
+	}
+	if int64(len(payload)) > maximumWALRecordBytes {
+		return fmt.Errorf("%w: encoded wal record exceeds %d bytes", ErrInvalidInput, maximumWALRecordBytes)
 	}
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.file == nil {
 		return ErrClosed
 	}
+	if w.lastSeq != 0 && record.Seq <= w.lastSeq {
+		return fmt.Errorf("%w: wal seq %d does not advance beyond %d", ErrInvalidInput, record.Seq, w.lastSeq)
+	}
 	if _, err := w.file.Write(payload); err != nil {
 		return fmt.Errorf("append wal record: %w", err)
 	}
+	if w.firstSeq == 0 {
+		w.firstSeq = record.Seq
+	}
+	w.lastSeq = record.Seq
 	w.writeGen++
 	return nil
 }
@@ -207,6 +461,124 @@ func (w *wal) runSync(target uint64) error {
 	return nil
 }
 
+// checkpoint captures the current append boundary without changing the WAL
+// format or blocking mutations while the snapshot is committed remotely.
+func (w *wal) checkpoint(throughSeq uint64) (*walCheckpoint, error) {
+	if w == nil {
+		return nil, ErrClosed
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for w.syncing {
+		w.syncCond.Wait()
+	}
+	if w.file == nil {
+		return nil, ErrClosed
+	}
+	if w.lastSeq > throughSeq {
+		return nil, fmt.Errorf("%w: active wal ends at %d beyond checkpoint %d", ErrInvalidInput, w.lastSeq, throughSeq)
+	}
+	info, err := w.file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat wal checkpoint: %w", err)
+	}
+	return &walCheckpoint{throughSeq: throughSeq, offset: info.Size()}, nil
+}
+
+// discardThrough atomically rewrites the WAL to the suffix appended after the
+// checkpoint. The on-disk path and record format remain readable by older CTLD
+// versions throughout rolling upgrades and rollback.
+func (w *wal) discardThrough(checkpoint *walCheckpoint) error {
+	if w == nil {
+		return ErrClosed
+	}
+	if checkpoint == nil {
+		return fmt.Errorf("%w: wal checkpoint is required", ErrInvalidInput)
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for w.syncing {
+		w.syncCond.Wait()
+	}
+	if w.file == nil {
+		return ErrClosed
+	}
+	if checkpoint.applied {
+		return nil
+	}
+	info, err := w.file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat wal before checkpoint rewrite: %w", err)
+	}
+	if checkpoint.offset < 0 || checkpoint.offset > info.Size() {
+		return fmt.Errorf("%w: wal checkpoint offset %d exceeds file size %d", ErrInvalidInput, checkpoint.offset, info.Size())
+	}
+	if checkpoint.offset == info.Size() {
+		if err := w.file.Truncate(0); err != nil {
+			return fmt.Errorf("truncate committed wal checkpoint: %w", err)
+		}
+		checkpoint.applied = true
+		w.firstSeq = 0
+		w.lastSeq = 0
+		w.writeGen = 0
+		w.syncedGen = 0
+		return nil
+	}
+
+	rewritePath := walRewritePath(w.path)
+	rewrite, err := os.OpenFile(rewritePath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o600)
+	if err != nil {
+		return fmt.Errorf("create wal checkpoint rewrite: %w", err)
+	}
+	cleanupRewrite := true
+	defer func() {
+		if cleanupRewrite {
+			_ = os.Remove(rewritePath)
+		}
+	}()
+	suffixBytes := info.Size() - checkpoint.offset
+	if _, err := io.CopyN(rewrite, io.NewSectionReader(w.file, checkpoint.offset, suffixBytes), suffixBytes); err != nil {
+		_ = rewrite.Close()
+		return fmt.Errorf("copy wal checkpoint suffix: %w", err)
+	}
+	if err := rewrite.Sync(); err != nil {
+		_ = rewrite.Close()
+		return fmt.Errorf("sync wal checkpoint suffix: %w", err)
+	}
+	if err := rewrite.Close(); err != nil {
+		return fmt.Errorf("close wal checkpoint suffix: %w", err)
+	}
+	if err := os.Rename(rewritePath, w.path); err != nil {
+		return fmt.Errorf("replace wal with checkpoint suffix: %w", err)
+	}
+	cleanupRewrite = false
+	checkpoint.applied = true
+
+	reopened, err := os.OpenFile(w.path, os.O_RDWR|os.O_APPEND, 0o600)
+	if err != nil {
+		_ = w.file.Close()
+		w.file = nil
+		return fmt.Errorf("reopen wal checkpoint suffix: %w", err)
+	}
+	oldFile := w.file
+	w.file = reopened
+	if err := oldFile.Close(); err != nil {
+		return fmt.Errorf("close replaced wal: %w", err)
+	}
+	if w.lastSeq > checkpoint.throughSeq {
+		w.firstSeq = checkpoint.throughSeq + 1
+	} else {
+		w.firstSeq = 0
+		w.lastSeq = 0
+	}
+	w.writeGen = 0
+	w.syncedGen = 0
+	if err := syncDirectory(filepath.Dir(w.path)); err != nil {
+		return fmt.Errorf("sync wal checkpoint rewrite: %w", err)
+	}
+	return nil
+}
+
 func (w *wal) close() error {
 	if w == nil {
 		return nil
@@ -237,13 +609,40 @@ func (w *wal) reset() error {
 		if err := w.file.Close(); err != nil {
 			return err
 		}
+		w.file = nil
 	}
-	file, err := os.OpenFile(w.path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	file, err := os.OpenFile(w.path, os.O_CREATE|os.O_TRUNC|os.O_RDWR|os.O_APPEND, 0o600)
 	if err != nil {
 		return fmt.Errorf("reset wal: %w", err)
 	}
 	w.file = file
 	w.writeGen = 0
 	w.syncedGen = 0
+	w.firstSeq = 0
+	w.lastSeq = 0
+	return removeStaleWALRewrite(w.path)
+}
+
+func walRewritePath(path string) string {
+	return path + walRewriteSuffix
+}
+
+func removeStaleWALRewrite(path string) error {
+	if err := os.Remove(walRewritePath(path)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove stale wal checkpoint rewrite: %w", err)
+	}
 	return nil
+}
+
+func syncDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	syncErr := directory.Sync()
+	closeErr := directory.Close()
+	if syncErr != nil && !errors.Is(syncErr, syscall.ENOSYS) && !errors.Is(syncErr, syscall.EINVAL) {
+		return errors.Join(syncErr, closeErr)
+	}
+	return closeErr
 }

--- a/storage-proxy/pkg/s0fs/wal_replay_test.go
+++ b/storage-proxy/pkg/s0fs/wal_replay_test.go
@@ -1,15 +1,220 @@
 package s0fs
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 )
+
+func TestWALCheckpointRetainsConcurrentSuffix(t *testing.T) {
+	walPath := filepath.Join(t.TempDir(), "volume.wal")
+	w, err := openWAL(walPath, "vol-1", nil, nil, walReplayStats{})
+	if err != nil {
+		t.Fatalf("openWAL() error = %v", err)
+	}
+	for seq := uint64(1); seq <= 2; seq++ {
+		appendPreparedWALRecord(t, w, walRecord{Seq: seq, Op: "chmod", Inode: RootInode, Mode: uint32(seq), TimeUnix: time.Now().UnixNano()})
+	}
+	checkpoint, err := w.checkpoint(2)
+	if err != nil {
+		t.Fatalf("checkpoint() error = %v", err)
+	}
+	appendPreparedWALRecord(t, w, walRecord{Seq: 3, Op: "chmod", Inode: RootInode, Mode: 3, TimeUnix: time.Now().UnixNano()})
+	if err := w.discardThrough(checkpoint); err != nil {
+		t.Fatalf("discardThrough() error = %v", err)
+	}
+	if err := w.close(); err != nil {
+		t.Fatalf("close() error = %v", err)
+	}
+
+	replay, err := openWALReplay(walPath, "vol-1", nil)
+	if err != nil {
+		t.Fatalf("openWALReplay() error = %v", err)
+	}
+	defer replay.Close()
+
+	first, ok, err := replay.Peek(context.Background())
+	if err != nil || !ok || first.Seq != 3 {
+		t.Fatalf("Peek() = seq %d, ok %v, err %v; want seq 3", first.Seq, ok, err)
+	}
+	if stats := replay.Stats(); stats.RecordsScanned != 1 {
+		t.Fatalf("stats after Peek() = %+v, want one scanned record", stats)
+	}
+
+	var sequences []uint64
+	for {
+		record, ok, err := replay.Next(context.Background())
+		if err != nil {
+			t.Fatalf("Next() error = %v", err)
+		}
+		if !ok {
+			break
+		}
+		sequences = append(sequences, record.Seq)
+	}
+	if got, want := sequences, []uint64{3}; !slices.Equal(got, want) {
+		t.Fatalf("replayed sequences = %v, want %v", got, want)
+	}
+	stats := replay.Stats()
+	if stats.RecordsScanned != 1 || stats.ActiveFirstSeq != 3 || stats.ActiveLastSeq != 3 {
+		t.Fatalf("final replay stats = %+v", stats)
+	}
+}
+
+func TestWALCheckpointRetainsEncryptedSuffix(t *testing.T) {
+	walPath := filepath.Join(t.TempDir(), "volume.wal")
+	encryption := testEncryptionConfig(16)
+	w, err := openWAL(walPath, "vol-encrypted", encryption, nil, walReplayStats{})
+	if err != nil {
+		t.Fatalf("openWAL() error = %v", err)
+	}
+	prefix := walRecord{
+		Seq:      1,
+		Op:       "create",
+		Inode:    RootInode + 1,
+		Parent:   RootInode,
+		Name:     "secret-name.txt",
+		Type:     TypeFile,
+		Mode:     0o600,
+		TimeUnix: time.Now().UnixNano(),
+	}
+	appendPreparedWALRecord(t, w, prefix)
+	checkpoint, err := w.checkpoint(prefix.Seq)
+	if err != nil {
+		t.Fatalf("checkpoint() error = %v", err)
+	}
+	suffix := prefix
+	suffix.Seq = 2
+	suffix.Name = "retained-secret.txt"
+	appendPreparedWALRecord(t, w, suffix)
+	if err := w.discardThrough(checkpoint); err != nil {
+		t.Fatalf("discardThrough() error = %v", err)
+	}
+	if err := w.close(); err != nil {
+		t.Fatalf("close() error = %v", err)
+	}
+	payload, err := os.ReadFile(walPath)
+	if err != nil {
+		t.Fatalf("ReadFile(WAL) error = %v", err)
+	}
+	if bytes.Contains(payload, []byte(suffix.Name)) {
+		t.Fatal("rewritten encrypted WAL contains the plaintext record name")
+	}
+
+	replay, err := openWALReplay(walPath, "vol-encrypted", encryption)
+	if err != nil {
+		t.Fatalf("openWALReplay() error = %v", err)
+	}
+	defer replay.Close()
+	got, ok, err := replay.Next(context.Background())
+	if err != nil || !ok {
+		t.Fatalf("Next() = ok %v, err %v", ok, err)
+	}
+	if got.Seq != suffix.Seq || got.Name != suffix.Name {
+		t.Fatalf("decrypted record = %+v, want seq %d name %q", got, suffix.Seq, suffix.Name)
+	}
+}
+
+func TestWALReplayStopsWhenContextIsCanceled(t *testing.T) {
+	walPath := filepath.Join(t.TempDir(), "volume.wal")
+	appendPlainWALRecords(t, walPath,
+		walRecord{Seq: 1, Op: "chmod", Inode: RootInode, Mode: 1, TimeUnix: time.Now().UnixNano()},
+		walRecord{Seq: 2, Op: "chmod", Inode: RootInode, Mode: 2, TimeUnix: time.Now().UnixNano()},
+	)
+	replay, err := openWALReplay(walPath, "vol-1", nil)
+	if err != nil {
+		t.Fatalf("openWALReplay() error = %v", err)
+	}
+	defer replay.Close()
+
+	if record, ok, err := replay.Next(context.Background()); err != nil || !ok || record.Seq != 1 {
+		t.Fatalf("first Next() = seq %d, ok %v, err %v", record.Seq, ok, err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, _, err := replay.Next(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Next(canceled) error = %v, want context.Canceled", err)
+	}
+	if got := replay.Stats().RecordsScanned; got != 1 {
+		t.Fatalf("records scanned after cancellation = %d, want 1", got)
+	}
+}
+
+func TestReadBoundedWALLineRejectsOversizedRecord(t *testing.T) {
+	reader := bufio.NewReaderSize(strings.NewReader("123456789\n"), 4)
+	if _, _, _, err := readBoundedWALLineLimit(context.Background(), reader, 8); !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("readBoundedWALLineLimit() error = %v, want ErrInvalidInput", err)
+	}
+}
+
+func TestReadBoundedWALLineChecksCancellationBetweenChunks(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	reader := bufio.NewReaderSize(&cancelAfterRead{
+		reader: strings.NewReader(strings.Repeat("x", 128<<10) + "\n"),
+		cancel: cancel,
+	}, 64<<10)
+	_, _, bytesRead, err := readBoundedWALLine(ctx, reader)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("readBoundedWALLine() error = %v, want context.Canceled", err)
+	}
+	if bytesRead <= 0 || bytesRead > 64<<10 {
+		t.Fatalf("bytes read before cancellation = %d, want at most one 64 KiB chunk", bytesRead)
+	}
+}
+
+func TestOpenStopsBeforeReplayingPeekedRecordWhenCanceled(t *testing.T) {
+	walPath := filepath.Join(t.TempDir(), "volume.wal")
+	appendPlainWALRecords(t, walPath,
+		walRecord{Seq: 1, Op: "create", Inode: RootInode + 1, Parent: RootInode, Name: "first.txt", Type: TypeFile, Mode: 0o644, TimeUnix: time.Now().UnixNano()},
+		walRecord{Seq: 2, Op: "create", Inode: RootInode + 2, Parent: RootInode, Name: "second.txt", Type: TypeFile, Mode: 0o644, TimeUnix: time.Now().UnixNano()},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var completed OpenObservation
+	_, err := Open(ctx, Config{
+		VolumeID: "vol-1",
+		WALPath:  walPath,
+		OpenObserver: func(observation OpenObservation) {
+			if observation.Phase == "state_load" && observation.Source == "local" {
+				cancel()
+			}
+			if observation.Phase == "complete" {
+				completed = observation
+			}
+		},
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Open() error = %v, want context.Canceled", err)
+	}
+	if completed.WALRecords != 0 || completed.WALRecordsScanned != 1 {
+		t.Fatalf("completed observation = %+v, want one peeked and zero applied records", completed)
+	}
+	if !errors.Is(completed.Err, context.Canceled) {
+		t.Fatalf("completed observation error = %v, want context.Canceled", completed.Err)
+	}
+
+	retried, err := Open(context.Background(), Config{VolumeID: "vol-1", WALPath: walPath})
+	if err != nil {
+		t.Fatalf("Open(retry) error = %v", err)
+	}
+	defer retried.Close()
+	for _, name := range []string{"first.txt", "second.txt"} {
+		if _, err := retried.Lookup(RootInode, name); err != nil {
+			t.Fatalf("Lookup(%s) after canceled retry error = %v", name, err)
+		}
+	}
+}
 
 func TestOpenSkipsWALRecordsOlderThanHead(t *testing.T) {
 	walPath, inode := createHeadWithFile(t, "base")
@@ -81,6 +286,61 @@ func TestOpenRejectsWALGapAfterHead(t *testing.T) {
 	}
 }
 
+func TestOpenRejectsCorruptWALRecord(t *testing.T) {
+	walPath := filepath.Join(t.TempDir(), "volume.wal")
+	appendPlainWALRecords(t, walPath,
+		walRecord{Seq: 1, Op: "create", Inode: RootInode + 1, Parent: RootInode, Name: "data.txt", Type: TypeFile, Mode: 0o644, TimeUnix: time.Now().UnixNano()},
+	)
+	appendPlainWALTail(t, walPath, []byte("not-json\n"))
+	if _, err := Open(context.Background(), Config{VolumeID: "vol-1", WALPath: walPath}); err == nil {
+		t.Fatal("Open() accepted a corrupt complete WAL record")
+	}
+}
+
+func TestOpenRejectsUnprovenWALPrefixWithoutLocalHead(t *testing.T) {
+	store, heads, inode := createCommittedWALBase(t, "vol-unproven-wal")
+	walPath := filepath.Join(t.TempDir(), "volume.wal")
+	appendPlainWALRecords(t, walPath,
+		walRecord{Seq: 1, Op: "create", Inode: inode, Parent: RootInode, Name: "conflicting.txt", Type: TypeFile, Mode: 0o644, TimeUnix: time.Now().UnixNano()},
+	)
+
+	_, err := Open(context.Background(), Config{
+		VolumeID:    "vol-unproven-wal",
+		WALPath:     walPath,
+		ObjectStore: store,
+		HeadStore:   heads,
+	})
+	if !errors.Is(err, ErrCommittedHeadConflict) {
+		t.Fatalf("Open() error = %v, want ErrCommittedHeadConflict", err)
+	}
+}
+
+func TestOpenUsesCommittedStateForProvenWALSuffix(t *testing.T) {
+	store, heads, inode := createCommittedWALBase(t, "vol-proven-wal")
+	walPath := filepath.Join(t.TempDir(), "volume.wal")
+	appendPlainWALRecords(t, walPath,
+		walRecord{Seq: 3, Op: "write", Inode: inode, Offset: 4, Data: []byte("++"), TimeUnix: time.Now().UnixNano()},
+	)
+
+	engine, err := Open(context.Background(), Config{
+		VolumeID:    "vol-proven-wal",
+		WALPath:     walPath,
+		ObjectStore: store,
+		HeadStore:   heads,
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+	payload, err := engine.Read(inode, 0, 16)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if got := string(payload); got != "base++" {
+		t.Fatalf("Read() = %q, want base++", got)
+	}
+}
+
 func TestOpenIgnoresPartialWALTail(t *testing.T) {
 	walPath := filepath.Join(t.TempDir(), "volume.wal")
 	appendPlainWALRecords(t, walPath,
@@ -100,6 +360,118 @@ func TestOpenIgnoresPartialWALTail(t *testing.T) {
 	if _, err := engine.Lookup(RootInode, "partial.txt"); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("Lookup(partial) error = %v, want ErrNotFound", err)
 	}
+}
+
+func TestOpenTruncatesPartialWALTailBeforeAppending(t *testing.T) {
+	walPath := filepath.Join(t.TempDir(), "volume.wal")
+	appendPlainWALRecords(t, walPath,
+		walRecord{Seq: 1, Op: "create", Inode: RootInode + 1, Parent: RootInode, Name: "first.txt", Type: TypeFile, Mode: 0o644, TimeUnix: time.Now().UnixNano()},
+	)
+	appendPlainWALTail(t, walPath, []byte(`{"seq":2,"op":"create"`))
+
+	engine, err := Open(context.Background(), Config{VolumeID: "vol-1", WALPath: walPath})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer engine.Close()
+	if _, err := engine.CreateFile(RootInode, "second.txt", 0o644); err != nil {
+		t.Fatalf("CreateFile(second) error = %v", err)
+	}
+
+	payload, err := os.ReadFile(walPath)
+	if err != nil {
+		t.Fatalf("ReadFile(WAL) error = %v", err)
+	}
+	lines := bytes.Split(bytes.TrimSpace(payload), []byte{'\n'})
+	if len(lines) != 2 {
+		t.Fatalf("complete WAL lines = %d, want 2; payload = %q", len(lines), payload)
+	}
+	for index, line := range lines {
+		var record walRecord
+		if err := json.Unmarshal(line, &record); err != nil {
+			t.Fatalf("decode WAL line %d: %v", index, err)
+		}
+		if record.Seq != uint64(index+1) {
+			t.Fatalf("WAL line %d sequence = %d, want %d", index, record.Seq, index+1)
+		}
+	}
+}
+
+func BenchmarkWALReplayStreaming(b *testing.B) {
+	for _, recordCount := range []int{10_000, 100_000, 1_000_000} {
+		b.Run(fmt.Sprintf("records_%d", recordCount), func(b *testing.B) {
+			benchmarkWALReplayStreaming(b, recordCount)
+		})
+	}
+}
+
+func benchmarkWALReplayStreaming(b *testing.B, recordCount int) {
+	walPath := filepath.Join(b.TempDir(), "volume.wal")
+	file, err := os.Create(walPath)
+	if err != nil {
+		b.Fatal(err)
+	}
+	writer := bufio.NewWriterSize(file, 64<<10)
+	encoder := json.NewEncoder(writer)
+	for index := range recordCount {
+		if err := encoder.Encode(walRecord{
+			Seq:      uint64(index + 1),
+			Op:       "chmod",
+			Inode:    RootInode,
+			Mode:     uint32(index),
+			TimeUnix: int64(index + 1),
+		}); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if err := writer.Flush(); err != nil {
+		b.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		b.Fatal(err)
+	}
+	info, err := os.Stat(walPath)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.SetBytes(info.Size())
+	b.ReportAllocs()
+	runtime.GC()
+	var baseline runtime.MemStats
+	runtime.ReadMemStats(&baseline)
+	peakHeapBytes := baseline.HeapAlloc
+	b.ResetTimer()
+
+	for range b.N {
+		replay, err := openWALReplay(walPath, "vol-benchmark", nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for scanned := 0; ; scanned++ {
+			_, ok, err := replay.Next(context.Background())
+			if err != nil {
+				b.Fatal(err)
+			}
+			if !ok {
+				break
+			}
+			if scanned%1024 == 0 {
+				var current runtime.MemStats
+				runtime.ReadMemStats(&current)
+				if current.HeapAlloc > peakHeapBytes {
+					peakHeapBytes = current.HeapAlloc
+				}
+			}
+		}
+		if err := replay.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	if peakHeapBytes < baseline.HeapAlloc {
+		peakHeapBytes = baseline.HeapAlloc
+	}
+	b.ReportMetric(float64(peakHeapBytes-baseline.HeapAlloc), "peak_heap_bytes/op")
 }
 
 func createHeadWithFile(t *testing.T, payload string) (string, uint64) {
@@ -123,7 +495,37 @@ func createHeadWithFile(t *testing.T, payload string) (string, uint64) {
 	return walPath, node.Inode
 }
 
-func appendPlainWALRecords(t *testing.T, walPath string, records ...walRecord) {
+func createCommittedWALBase(t *testing.T, volumeID string) (*recordingStore, *memoryHeadStore, uint64) {
+	t.Helper()
+	ctx := context.Background()
+	store := newPrefixedRecordingStore(t, volumeID)
+	heads := newMemoryHeadStore()
+	engine, err := Open(ctx, Config{
+		VolumeID:    volumeID,
+		WALPath:     filepath.Join(t.TempDir(), "committed.wal"),
+		ObjectStore: store,
+		HeadStore:   heads,
+	})
+	if err != nil {
+		t.Fatalf("Open(committed base) error = %v", err)
+	}
+	node, err := engine.CreateFile(RootInode, "data.txt", 0o644)
+	if err != nil {
+		t.Fatalf("CreateFile(committed base) error = %v", err)
+	}
+	if _, err := engine.Write(node.Inode, 0, []byte("base")); err != nil {
+		t.Fatalf("Write(committed base) error = %v", err)
+	}
+	if _, err := engine.SyncMaterialize(ctx); err != nil {
+		t.Fatalf("SyncMaterialize(committed base) error = %v", err)
+	}
+	if err := engine.Close(); err != nil {
+		t.Fatalf("Close(committed base) error = %v", err)
+	}
+	return store, heads, node.Inode
+}
+
+func appendPlainWALRecords(t testing.TB, walPath string, records ...walRecord) {
 	t.Helper()
 
 	var payload []byte
@@ -138,7 +540,7 @@ func appendPlainWALRecords(t *testing.T, walPath string, records ...walRecord) {
 	appendPlainWALTail(t, walPath, payload)
 }
 
-func appendPlainWALTail(t *testing.T, walPath string, payload []byte) {
+func appendPlainWALTail(t testing.TB, walPath string, payload []byte) {
 	t.Helper()
 
 	file, err := os.OpenFile(walPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
@@ -149,4 +551,30 @@ func appendPlainWALTail(t *testing.T, walPath string, payload []byte) {
 	if _, err := file.Write(payload); err != nil {
 		t.Fatalf("append WAL payload: %v", err)
 	}
+}
+
+func appendPreparedWALRecord(t testing.TB, w *wal, record walRecord) {
+	t.Helper()
+	payload, err := w.prepare(record)
+	if err != nil {
+		t.Fatalf("prepare() error = %v", err)
+	}
+	if err := w.appendPrepared(record, payload); err != nil {
+		t.Fatalf("appendPrepared() error = %v", err)
+	}
+}
+
+type cancelAfterRead struct {
+	reader io.Reader
+	cancel context.CancelFunc
+	read   bool
+}
+
+func (r *cancelAfterRead) Read(payload []byte) (int, error) {
+	n, err := r.reader.Read(payload)
+	if !r.read {
+		r.read = true
+		r.cancel()
+	}
+	return n, err
 }


### PR DESCRIPTION
## Summary

- Stream `engine.wal` recovery with cancellation between bounded 64 KiB reads and records, a 256 MiB encoded-record limit, and a one-record peek reused for source selection.
- Fail closed when a committed remote head cannot be proven to align with the first local WAL sequence.
- Reclaim committed WAL prefixes after successful materialization while retaining writes appended during the upload. The on-disk format remains one legacy-compatible `engine.wal`, so mixed A/B ctld versions and rollback continue to see a valid WAL.
- Add low-cardinality recovery metrics and structured completion logs for bytes, records scanned/skipped/replayed, maximum record size, duration, and cancellation status.
- Add corruption, gap, truncated-tail, encrypted replay, cancellation/retry, concurrent checkpoint, failure-retry, and large-WAL benchmark coverage.

## Correctness and hot path

- Ordinary mutations keep the existing single WAL append path; the only added work is in-memory active-sequence bookkeeping under the existing WAL lock.
- A checkpoint captures the current WAL byte boundary before remote materialization. A failed remote commit leaves the WAL untouched.
- After a successful remote commit, the committed head is persisted locally before the WAL is atomically replaced with only the concurrent suffix. If local finalization fails, it is retried without repeating the already-successful remote CAS.
- A partial trailing record is truncated to the last valid byte before a future append, preventing a valid suffix from becoming unreachable.

## Scope

This is the urgent WAL/recovery slice of #805. Bounded or lazy residency for the active namespace metadata remains a separate architectural follow-up in the same issue.

Refs #805

## Validation

Local:

- `go test ./storage-proxy/pkg/s0fs ./ctld/internal/ctld/portal -count=1`
- `go test -race ./storage-proxy/pkg/s0fs ./ctld/internal/ctld/portal -count=1`
- CI-shaped race run across all non-E2E and non-integration packages
- `go vet` on changed packages
- `golangci-lint run` with 0 issues
- `go mod tidy`, `gofmt`, and `git diff --check`

Aliyun Singapore persistent kind environment, linux/amd64:

- Built and loaded the exact worktree images on all three kind nodes.
- Fullmode reached `Ready 10/10`; both ctld A/B DaemonSets were ready on both sandbox workers.
- Remote race tests passed for the S0FS and ctld portal packages.
- `BenchmarkWALReplayStreaming/1000000`: 1.871 s, 37.77 MB/s, 3,583,312-byte sampled peak heap.
- Focused volume E2E passed: write a 6 MiB file, mount it in a sandbox, partially rewrite it, delete the sandbox, claim/remount, and verify the full file (`1/1` spec passed).
