### PR TITLE
fix(ctld): avoid node-wide CRI stats fan-out

### DIFF
--- a/ctld/cmd/ctld/runtime_metrics.go
+++ b/ctld/cmd/ctld/runtime_metrics.go
@@ -168,6 +168,10 @@ func newCtldRuntimeMetricsProducer(cfg *config.CtldConfig, statsClient ctldrunti
 	if err != nil {
 		return nil, fmt.Errorf("create runtime sample worker: %w", err)
 	}
+	var runtimeMetricsObserver *ctldruntimemetrics.Observer
+	if obsProvider != nil {
+		runtimeMetricsObserver = ctldruntimemetrics.NewObserver(obsProvider.MetricsRegistryOrNil())
+	}
 	collector, err := ctldruntimemetrics.NewCollector(ctldruntimemetrics.CollectorConfig{
 		RegionID:    cfg.RegionID,
 		ClusterID:   cfg.DefaultClusterId,
@@ -178,6 +182,7 @@ func newCtldRuntimeMetricsProducer(cfg *config.CtldConfig, statsClient ctldrunti
 		StatsClient: statsClient,
 		PodLister:   podLister,
 		Sink:        worker,
+		Observer:    runtimeMetricsObserver,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create runtime metric collector: %w", err)

--- a/ctld/cmd/ctld/runtime_metrics_test.go
+++ b/ctld/cmd/ctld/runtime_metrics_test.go
@@ -101,13 +101,23 @@ func TestCtldRuntimeMetricsProducerPostsAuthorizedRuntimeSample(t *testing.T) {
 		SandboxObservabilityIngestRetryBackoff:      metav1.Duration{Duration: time.Millisecond},
 		SandboxObservabilityRuntimeSampleInterval:   metav1.Duration{Duration: time.Minute},
 		SandboxObservabilityRuntimeSampleJitter:     metav1.Duration{Duration: time.Second},
-	}, staticStatsClient{onCall: statsCalled, stats: []*runtimeapi.PodSandboxStats{{
-		Attributes: &runtimeapi.PodSandboxAttributes{
+	}, staticStatsClient{
+		onCall: statsCalled,
+		sandboxes: []*runtimeapi.PodSandbox{{
 			Id:       "cri-sandbox-a",
 			Metadata: &runtimeapi.PodSandboxMetadata{Namespace: "ns-a", Name: "pod-a", Uid: "pod-uid-a"},
+			State:    runtimeapi.PodSandboxState_SANDBOX_READY,
+		}},
+		statsByID: map[string]*runtimeapi.PodSandboxStats{
+			"cri-sandbox-a": {
+				Attributes: &runtimeapi.PodSandboxAttributes{
+					Id:       "cri-sandbox-a",
+					Metadata: &runtimeapi.PodSandboxMetadata{Namespace: "ns-a", Name: "pod-a", Uid: "pod-uid-a"},
+				},
+				Linux: &runtimeapi.LinuxPodSandboxStats{},
+			},
 		},
-		Linux: &runtimeapi.LinuxPodSandboxStats{},
-	}}}, testPodLister(t, pod), generator, nil, nil)
+	}, testPodLister(t, pod), generator, nil, nil)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -182,15 +192,20 @@ func TestCtldRuntimeMetricsShutdownStopsCollectorBeforeWorkerDrain(t *testing.T)
 }
 
 type staticStatsClient struct {
-	stats  []*runtimeapi.PodSandboxStats
-	onCall chan<- struct{}
+	sandboxes []*runtimeapi.PodSandbox
+	statsByID map[string]*runtimeapi.PodSandboxStats
+	onCall    chan<- struct{}
 }
 
-func (c staticStatsClient) ListPodSandboxStats(context.Context) ([]*runtimeapi.PodSandboxStats, error) {
+func (c staticStatsClient) ListPodSandboxes(context.Context) ([]*runtimeapi.PodSandbox, error) {
+	return c.sandboxes, nil
+}
+
+func (c staticStatsClient) PodSandboxStats(_ context.Context, id string) (*runtimeapi.PodSandboxStats, error) {
 	if c.onCall != nil {
 		c.onCall <- struct{}{}
 	}
-	return c.stats, nil
+	return c.statsByID[id], nil
 }
 
 var _ ctldruntimemetrics.StatsClient = staticStatsClient{}

--- a/ctld/internal/ctld/rootfs/containerd_runtime.go
+++ b/ctld/internal/ctld/rootfs/containerd_runtime.go
@@ -46,7 +46,6 @@ type criRuntimeService interface {
 	ListContainers(ctx context.Context, in *runtimeapi.ListContainersRequest, opts ...grpc.CallOption) (*runtimeapi.ListContainersResponse, error)
 	ListPodSandbox(ctx context.Context, in *runtimeapi.ListPodSandboxRequest, opts ...grpc.CallOption) (*runtimeapi.ListPodSandboxResponse, error)
 	PodSandboxStats(ctx context.Context, in *runtimeapi.PodSandboxStatsRequest, opts ...grpc.CallOption) (*runtimeapi.PodSandboxStatsResponse, error)
-	ListPodSandboxStats(ctx context.Context, in *runtimeapi.ListPodSandboxStatsRequest, opts ...grpc.CallOption) (*runtimeapi.ListPodSandboxStatsResponse, error)
 }
 
 type ContainerdRuntimeConfig struct {
@@ -497,21 +496,9 @@ func normalizeContainerID(containerID string) string {
 	return containerID
 }
 
-// ListPodSandboxStats returns one bulk node-local CRI stats snapshot.
-func (r *ContainerdRuntime) ListPodSandboxStats(ctx context.Context) ([]*runtimeapi.PodSandboxStats, error) {
-	client, err := r.runtimeClient(ctx)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.ListPodSandboxStats(ctx, &runtimeapi.ListPodSandboxStatsRequest{})
-	if err != nil {
-		return nil, fmt.Errorf("list CRI pod sandbox stats: %w", err)
-	}
-	return resp.GetStats(), nil
-}
-
 // ListPodSandboxes returns ready node-local CRI sandboxes for isolated stats
-// fallback after a bulk stats failure.
+// collection. Callers match this cheap metadata snapshot against claimed pods
+// before requesting individual sandbox stats.
 func (r *ContainerdRuntime) ListPodSandboxes(ctx context.Context) ([]*runtimeapi.PodSandbox, error) {
 	client, err := r.runtimeClient(ctx)
 	if err != nil {

--- a/ctld/internal/ctld/rootfs/containerd_runtime_test.go
+++ b/ctld/internal/ctld/rootfs/containerd_runtime_test.go
@@ -239,26 +239,6 @@ func TestResolveContainerIDReturnsNotFound(t *testing.T) {
 	assert.True(t, errors.Is(err, ErrNotFound))
 }
 
-func TestListPodSandboxStatsUsesBulkCRIRequest(t *testing.T) {
-	want := []*runtimeapi.PodSandboxStats{{
-		Attributes: &runtimeapi.PodSandboxAttributes{Id: "sandbox-1"},
-	}}
-	runtime := NewContainerdRuntime(ContainerdRuntimeConfig{CRIClient: fakeCRIClient{stats: want}})
-
-	got, err := runtime.ListPodSandboxStats(context.Background())
-
-	require.NoError(t, err)
-	assert.Equal(t, want, got)
-}
-
-func TestListPodSandboxStatsWrapsCRIError(t *testing.T) {
-	runtime := NewContainerdRuntime(ContainerdRuntimeConfig{CRIClient: fakeCRIClient{err: errors.New("unavailable")}})
-
-	_, err := runtime.ListPodSandboxStats(context.Background())
-
-	require.ErrorContains(t, err, "list CRI pod sandbox stats")
-}
-
 func TestListPodSandboxesReturnsReadyCRIItems(t *testing.T) {
 	want := []*runtimeapi.PodSandbox{{
 		Id:       "sandbox-1",
@@ -326,9 +306,9 @@ func TestContainerdRuntimeReusesAndClosesCRIConnection(t *testing.T) {
 		},
 	})
 
-	_, err := runtime.ListPodSandboxStats(context.Background())
+	_, err := runtime.ListPodSandboxes(context.Background())
 	require.NoError(t, err)
-	_, err = runtime.ListPodSandboxStats(context.Background())
+	_, err = runtime.ListPodSandboxes(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), dialCount.Load())
 
@@ -408,7 +388,6 @@ func TestNormalizeContainerID(t *testing.T) {
 type fakeCRIClient struct {
 	containers []*runtimeapi.Container
 	sandboxes  []*runtimeapi.PodSandbox
-	stats      []*runtimeapi.PodSandboxStats
 	statsByID  map[string]*runtimeapi.PodSandboxStats
 	err        error
 }
@@ -417,9 +396,9 @@ type fakeRuntimeServiceServer struct {
 	runtimeapi.UnimplementedRuntimeServiceServer
 }
 
-func (*fakeRuntimeServiceServer) ListPodSandboxStats(context.Context, *runtimeapi.ListPodSandboxStatsRequest) (*runtimeapi.ListPodSandboxStatsResponse, error) {
-	return &runtimeapi.ListPodSandboxStatsResponse{Stats: []*runtimeapi.PodSandboxStats{{
-		Attributes: &runtimeapi.PodSandboxAttributes{Id: "sandbox-1"},
+func (*fakeRuntimeServiceServer) ListPodSandbox(context.Context, *runtimeapi.ListPodSandboxRequest) (*runtimeapi.ListPodSandboxResponse, error) {
+	return &runtimeapi.ListPodSandboxResponse{Items: []*runtimeapi.PodSandbox{{
+		Id: "sandbox-1",
 	}}}, nil
 }
 
@@ -442,13 +421,6 @@ func (c fakeCRIClient) PodSandboxStats(_ context.Context, req *runtimeapi.PodSan
 		return nil, c.err
 	}
 	return &runtimeapi.PodSandboxStatsResponse{Stats: c.statsByID[req.PodSandboxId]}, nil
-}
-
-func (c fakeCRIClient) ListPodSandboxStats(_ context.Context, _ *runtimeapi.ListPodSandboxStatsRequest, _ ...grpc.CallOption) (*runtimeapi.ListPodSandboxStatsResponse, error) {
-	if c.err != nil {
-		return nil, c.err
-	}
-	return &runtimeapi.ListPodSandboxStatsResponse{Stats: c.stats}, nil
 }
 
 func minimalRuntimePodStats(id string) *runtimeapi.PodSandboxStats {

--- a/ctld/internal/ctld/runtimemetrics/collector.go
+++ b/ctld/internal/ctld/runtimemetrics/collector.go
@@ -15,14 +15,8 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
-// StatsClient exposes the CRI node-wide pod sandbox stats snapshot.
+// StatsClient exposes the bounded CRI calls used to collect claimed sandbox stats.
 type StatsClient interface {
-	ListPodSandboxStats(context.Context) ([]*runtimeapi.PodSandboxStats, error)
-}
-
-// PerSandboxStatsClient provides the bounded fallback used when a node-wide
-// CRI stats request is poisoned by one unresponsive runtime.
-type PerSandboxStatsClient interface {
 	ListPodSandboxes(context.Context) ([]*runtimeapi.PodSandbox, error)
 	PodSandboxStats(context.Context, string) (*runtimeapi.PodSandboxStats, error)
 }
@@ -34,70 +28,68 @@ type SampleSink interface {
 
 // CollectorConfig configures node identity, cadence, and producer dependencies.
 type CollectorConfig struct {
-	RegionID                 string
-	ClusterID                string
-	NodeName                 string
-	Interval                 time.Duration
-	Jitter                   time.Duration
-	BulkRequestTimeout       time.Duration
-	FallbackMaxConcurrency   int
-	FallbackMaxSandboxes     int
-	FallbackRequestTimeout   time.Duration
-	FallbackCollectionBudget time.Duration
-	Now                      func() time.Time
-	Random                   func() float64
-	Logger                   *zap.Logger
-	StatsClient              StatsClient
-	PodLister                corelisters.PodLister
-	Sink                     SampleSink
+	RegionID         string
+	ClusterID        string
+	NodeName         string
+	Interval         time.Duration
+	Jitter           time.Duration
+	MaxConcurrency   int
+	MaxSandboxes     int
+	RequestTimeout   time.Duration
+	CollectionBudget time.Duration
+	Now              func() time.Time
+	Random           func() float64
+	Logger           *zap.Logger
+	StatsClient      StatsClient
+	PodLister        corelisters.PodLister
+	Sink             SampleSink
+	Observer         *Observer
 }
 
 // Collector maps CRI pod sandbox stats to sandbox runtime samples.
 type Collector struct {
-	collectMu                sync.Mutex
-	regionID                 string
-	clusterID                string
-	nodeName                 string
-	interval                 time.Duration
-	jitter                   time.Duration
-	bulkRequestTimeout       time.Duration
-	fallbackMaxConcurrency   int
-	fallbackMaxSandboxes     int
-	fallbackRequestTimeout   time.Duration
-	fallbackCollectionBudget time.Duration
-	fallbackCursor           int
-	now                      func() time.Time
-	random                   func() float64
-	logger                   *zap.Logger
-	statsClient              StatsClient
-	podLister                corelisters.PodLister
-	sink                     SampleSink
-	cpuUsage                 *cpuUsageTracker
+	collectMu        sync.Mutex
+	regionID         string
+	clusterID        string
+	nodeName         string
+	interval         time.Duration
+	jitter           time.Duration
+	maxConcurrency   int
+	maxSandboxes     int
+	requestTimeout   time.Duration
+	collectionBudget time.Duration
+	targetCursor     int
+	now              func() time.Time
+	random           func() float64
+	logger           *zap.Logger
+	statsClient      StatsClient
+	podLister        corelisters.PodLister
+	sink             SampleSink
+	observer         *Observer
+	cpuUsage         *cpuUsageTracker
 }
 
-// CollectResult summarizes one bulk collection attempt.
+// CollectResult summarizes one bounded collection attempt.
 type CollectResult struct {
 	StatsReceived int
 	Matched       int
 	Enqueued      int
 	Dropped       int
 	Failed        int
-	Fallback      bool
 }
 
 const (
-	defaultBulkRequestTimeout       = 3 * time.Second
-	defaultFallbackMaxConcurrency   = 4
-	defaultFallbackMaxSandboxes     = 16
-	defaultFallbackRequestTimeout   = 2 * time.Second
-	defaultFallbackCollectionBudget = 10 * time.Second
+	defaultMaxConcurrency   = 4
+	defaultMaxSandboxes     = 16
+	defaultRequestTimeout   = 2 * time.Second
+	defaultCollectionBudget = 10 * time.Second
 )
 
-type fallbackTarget struct {
+type collectionTarget struct {
 	id string
 }
 
-// NewCollector creates a node-local bulk CRI runtime metric collector.
+// NewCollector creates a node-local, bounded CRI runtime metric collector.
 func NewCollector(cfg CollectorConfig) (*Collector, error) {
 	if cfg.StatsClient == nil {
 		return nil, fmt.Errorf("stats client is nil")
@@ -120,20 +112,17 @@ func NewCollector(cfg CollectorConfig) (*Collector, error) {
 	if cfg.Jitter >= cfg.Interval {
 		cfg.Jitter = cfg.Interval / 2
 	}
-	if cfg.BulkRequestTimeout <= 0 {
-		cfg.BulkRequestTimeout = defaultBulkRequestTimeout
+	if cfg.MaxConcurrency <= 0 {
+		cfg.MaxConcurrency = defaultMaxConcurrency
 	}
-	if cfg.FallbackMaxConcurrency <= 0 {
-		cfg.FallbackMaxConcurrency = defaultFallbackMaxConcurrency
+	if cfg.MaxSandboxes <= 0 {
+		cfg.MaxSandboxes = defaultMaxSandboxes
 	}
-	if cfg.FallbackMaxSandboxes <= 0 {
-		cfg.FallbackMaxSandboxes = defaultFallbackMaxSandboxes
+	if cfg.RequestTimeout <= 0 {
+		cfg.RequestTimeout = defaultRequestTimeout
 	}
-	if cfg.FallbackRequestTimeout <= 0 {
-		cfg.FallbackRequestTimeout = defaultFallbackRequestTimeout
-	}
-	if cfg.FallbackCollectionBudget <= 0 {
-		cfg.FallbackCollectionBudget = defaultFallbackCollectionBudget
+	if cfg.CollectionBudget <= 0 {
+		cfg.CollectionBudget = defaultCollectionBudget
 	}
 	if cfg.Now == nil {
 		cfg.Now = time.Now
@@ -145,23 +134,23 @@ func NewCollector(cfg CollectorConfig) (*Collector, error) {
 		cfg.Logger = zap.NewNop()
 	}
 	return &Collector{
-		regionID:                 cfg.RegionID,
-		clusterID:                cfg.ClusterID,
-		nodeName:                 cfg.NodeName,
-		interval:                 cfg.Interval,
-		jitter:                   cfg.Jitter,
-		bulkRequestTimeout:       cfg.BulkRequestTimeout,
-		fallbackMaxConcurrency:   cfg.FallbackMaxConcurrency,
-		fallbackMaxSandboxes:     cfg.FallbackMaxSandboxes,
-		fallbackRequestTimeout:   cfg.FallbackRequestTimeout,
-		fallbackCollectionBudget: cfg.FallbackCollectionBudget,
-		now:                      cfg.Now,
-		random:                   cfg.Random,
-		logger:                   cfg.Logger,
-		statsClient:              cfg.StatsClient,
-		podLister:                cfg.PodLister,
-		sink:                     cfg.Sink,
-		cpuUsage:                 &cpuUsageTracker{},
+		regionID:         cfg.RegionID,
+		clusterID:        cfg.ClusterID,
+		nodeName:         cfg.NodeName,
+		interval:         cfg.Interval,
+		jitter:           cfg.Jitter,
+		maxConcurrency:   cfg.MaxConcurrency,
+		maxSandboxes:     cfg.MaxSandboxes,
+		requestTimeout:   cfg.RequestTimeout,
+		collectionBudget: cfg.CollectionBudget,
+		now:              cfg.Now,
+		random:           cfg.Random,
+		logger:           cfg.Logger,
+		statsClient:      cfg.StatsClient,
+		podLister:        cfg.PodLister,
+		sink:             cfg.Sink,
+		observer:         cfg.Observer,
+		cpuUsage:         &cpuUsageTracker{},
 	}, nil
 }
 
@@ -175,7 +164,6 @@ func (c *Collector) Run(ctx context.Context) {
 		if err != nil && ctx.Err() == nil {
 			c.logger.Warn("Failed to collect some sandbox runtime metrics",
 				zap.Error(err),
-				zap.Bool("fallback", result.Fallback),
 				zap.Int("matched", result.Matched),
 				zap.Int("enqueued", result.Enqueued),
 				zap.Int("failed", result.Failed),
@@ -196,29 +184,36 @@ func (c *Collector) Run(ctx context.Context) {
 	}
 }
 
-// Collect projects one bulk CRI snapshot against the current node pod cache.
-func (c *Collector) Collect(ctx context.Context) (CollectResult, error) {
+// Collect resolves current claimed pods to CRI sandboxes and requests stats only
+// for those targets. It intentionally avoids ListPodSandboxStats because
+// containerd fans that request out to every ready sandbox on the node.
+func (c *Collector) Collect(ctx context.Context) (result CollectResult, err error) {
 	if c == nil {
 		return CollectResult{}, fmt.Errorf("collector is nil")
 	}
+	started := time.Now()
+	defer func() {
+		if c.observer != nil {
+			c.observer.ObserveCollection(time.Since(started), result, err)
+		}
+	}()
 	c.collectMu.Lock()
 	defer c.collectMu.Unlock()
 	identities, err := buildIdentityIndex(c.podLister, c.nodeName)
 	if err != nil {
 		return CollectResult{}, err
 	}
-	bulkCtx, cancel := context.WithTimeout(ctx, c.bulkRequestTimeout)
-	stats, err := c.statsClient.ListPodSandboxStats(bulkCtx)
-	cancel()
-	if err != nil {
-		return c.collectFallback(ctx, identities, fmt.Errorf("list CRI pod sandbox stats: %w", err))
+	if identities.empty() {
+		if c.cpuUsage != nil {
+			c.cpuUsage.prune(nil)
+		}
+		return CollectResult{}, nil
 	}
-	return c.projectStats(identities, stats, false)
+	return c.collectTargets(ctx, identities)
 }
 
-func (c *Collector) projectStats(identities identityIndex, stats []*runtimeapi.PodSandboxStats, fallback bool) (CollectResult, error) {
+func (c *Collector) projectStats(identities identityIndex, stats []*runtimeapi.PodSandboxStats, pruneCPUUsage bool) (CollectResult, error) {
 	result := CollectResult{StatsReceived: len(stats)}
-	result.Fallback = fallback
 	collectedAt := c.now().UTC()
 	activeCPUSeries := make(map[cpuSeriesKey]struct{})
 	if c.cpuUsage == nil {
@@ -250,37 +245,34 @@ func (c *Collector) projectStats(identities identityIndex, stats []*runtimeapi.P
 			result.Dropped++
 		}
 	}
-	if !fallback {
+	if pruneCPUUsage {
 		c.cpuUsage.prune(activeCPUSeries)
 	}
 	return result, nil
 }
 
-func (c *Collector) collectFallback(ctx context.Context, identities identityIndex, bulkErr error) (CollectResult, error) {
-	result := CollectResult{Fallback: true}
-	client, ok := c.statsClient.(PerSandboxStatsClient)
-	if !ok {
-		return result, bulkErr
-	}
-	budgetCtx, cancel := context.WithTimeout(ctx, c.fallbackCollectionBudget)
+func (c *Collector) collectTargets(ctx context.Context, identities identityIndex) (CollectResult, error) {
+	result := CollectResult{}
+	budgetCtx, cancel := context.WithTimeout(ctx, c.collectionBudget)
 	defer cancel()
-	sandboxes, err := client.ListPodSandboxes(budgetCtx)
+	sandboxes, err := c.statsClient.ListPodSandboxes(budgetCtx)
 	if err != nil {
-		return result, errors.Join(bulkErr, fmt.Errorf("list CRI pod sandboxes for fallback: %w", err))
+		return result, fmt.Errorf("list CRI pod sandboxes: %w", err)
 	}
-	allTargets := fallbackTargets(identities, sandboxes)
-	targets := c.nextFallbackTargets(allTargets)
+	allTargets := collectionTargets(identities, sandboxes)
+	targets := c.nextCollectionTargets(allTargets)
 	result.Matched = len(targets)
 	if len(targets) == 0 {
-		return result, bulkErr
+		c.cpuUsage.prune(nil)
+		return result, nil
 	}
 
-	type fallbackResult struct {
+	type targetResult struct {
 		stats *runtimeapi.PodSandboxStats
 		err   error
 	}
-	results := make([]fallbackResult, len(targets))
-	semaphore := make(chan struct{}, c.fallbackMaxConcurrency)
+	results := make([]targetResult, len(targets))
+	semaphore := make(chan struct{}, c.maxConcurrency)
 	var wg sync.WaitGroup
 dispatch:
 	for i := range targets {
@@ -296,8 +288,8 @@ dispatch:
 		go func(index int) {
 			defer wg.Done()
 			defer func() { <-semaphore }()
-			requestCtx, requestCancel := context.WithTimeout(budgetCtx, c.fallbackRequestTimeout)
-			results[index].stats, results[index].err = client.PodSandboxStats(requestCtx, targets[index].id)
+			requestCtx, requestCancel := context.WithTimeout(budgetCtx, c.requestTimeout)
+			results[index].stats, results[index].err = c.statsClient.PodSandboxStats(requestCtx, targets[index].id)
 			requestCancel()
 			if results[index].stats == nil && results[index].err == nil {
 				results[index].err = fmt.Errorf("empty CRI pod sandbox stats")
@@ -307,24 +299,25 @@ dispatch:
 	wg.Wait()
 
 	stats := make([]*runtimeapi.PodSandboxStats, 0, len(results))
-	var fallbackErr error
+	var collectionErr error
 	for i := range results {
 		if results[i].err != nil {
 			result.Failed++
-			fallbackErr = errors.Join(fallbackErr, fmt.Errorf("collect CRI pod sandbox %s stats: %w", targets[i].id, results[i].err))
+			collectionErr = errors.Join(collectionErr, fmt.Errorf("collect CRI pod sandbox %s stats: %w", targets[i].id, results[i].err))
 			continue
 		}
 		stats = append(stats, results[i].stats)
 	}
-	projected, projectErr := c.projectStats(identities, stats, true)
+	pruneCPUUsage := len(targets) == len(allTargets) && collectionErr == nil
+	projected, projectErr := c.projectStats(identities, stats, pruneCPUUsage)
 	result.StatsReceived = projected.StatsReceived
 	result.Enqueued = projected.Enqueued
 	result.Dropped = projected.Dropped
-	return result, errors.Join(bulkErr, fallbackErr, projectErr)
+	return result, errors.Join(collectionErr, projectErr)
 }
 
-func fallbackTargets(identities identityIndex, sandboxes []*runtimeapi.PodSandbox) []fallbackTarget {
-	targets := make([]fallbackTarget, 0, len(sandboxes))
+func collectionTargets(identities identityIndex, sandboxes []*runtimeapi.PodSandbox) []collectionTarget {
+	targets := make([]collectionTarget, 0, len(sandboxes))
 	seen := make(map[string]struct{}, len(sandboxes))
 	for _, sandbox := range sandboxes {
 		if sandbox == nil || sandbox.Id == "" || sandbox.Metadata == nil ||
@@ -339,7 +332,7 @@ func fallbackTargets(identities identityIndex, sandboxes []*runtimeapi.PodSandbo
 			continue
 		}
 		seen[sandbox.Id] = struct{}{}
-		targets = append(targets, fallbackTarget{id: sandbox.Id})
+		targets = append(targets, collectionTarget{id: sandbox.Id})
 	}
 	sort.Slice(targets, func(i, j int) bool {
 		return targets[i].id < targets[j].id
@@ -347,21 +340,21 @@ func fallbackTargets(identities identityIndex, sandboxes []*runtimeapi.PodSandbo
 	return targets
 }
 
-func (c *Collector) nextFallbackTargets(targets []fallbackTarget) []fallbackTarget {
+func (c *Collector) nextCollectionTargets(targets []collectionTarget) []collectionTarget {
 	if len(targets) == 0 {
 		return nil
 	}
-	limit := c.fallbackMaxSandboxes
+	limit := c.maxSandboxes
 	if limit <= 0 || limit >= len(targets) {
-		c.fallbackCursor = 0
+		c.targetCursor = 0
 		return targets
 	}
-	start := c.fallbackCursor % len(targets)
-	selected := make([]fallbackTarget, 0, limit)
+	start := c.targetCursor % len(targets)
+	selected := make([]collectionTarget, 0, limit)
 	for i := 0; i < limit; i++ {
 		selected = append(selected, targets[(start+i)%len(targets)])
 	}
-	c.fallbackCursor = (start + limit) % len(targets)
+	c.targetCursor = (start + limit) % len(targets)
 	return selected
 }
 

--- a/ctld/internal/ctld/runtimemetrics/collector.go
+++ b/ctld/internal/ctld/runtimemetrics/collector.go
@@ -34,7 +34,6 @@ type CollectorConfig struct {
 	Interval         time.Duration
 	Jitter           time.Duration
 	MaxConcurrency   int
-	MaxSandboxes     int
 	RequestTimeout   time.Duration
 	CollectionBudget time.Duration
 	Now              func() time.Time
@@ -55,7 +54,6 @@ type Collector struct {
 	interval         time.Duration
 	jitter           time.Duration
 	maxConcurrency   int
-	maxSandboxes     int
 	requestTimeout   time.Duration
 	collectionBudget time.Duration
 	targetCursor     int
@@ -80,7 +78,6 @@ type CollectResult struct {
 
 const (
 	defaultMaxConcurrency   = 4
-	defaultMaxSandboxes     = 16
 	defaultRequestTimeout   = 2 * time.Second
 	defaultCollectionBudget = 10 * time.Second
 )
@@ -115,9 +112,6 @@ func NewCollector(cfg CollectorConfig) (*Collector, error) {
 	if cfg.MaxConcurrency <= 0 {
 		cfg.MaxConcurrency = defaultMaxConcurrency
 	}
-	if cfg.MaxSandboxes <= 0 {
-		cfg.MaxSandboxes = defaultMaxSandboxes
-	}
 	if cfg.RequestTimeout <= 0 {
 		cfg.RequestTimeout = defaultRequestTimeout
 	}
@@ -140,7 +134,6 @@ func NewCollector(cfg CollectorConfig) (*Collector, error) {
 		interval:         cfg.Interval,
 		jitter:           cfg.Jitter,
 		maxConcurrency:   cfg.MaxConcurrency,
-		maxSandboxes:     cfg.MaxSandboxes,
 		requestTimeout:   cfg.RequestTimeout,
 		collectionBudget: cfg.CollectionBudget,
 		now:              cfg.Now,
@@ -260,7 +253,7 @@ func (c *Collector) collectTargets(ctx context.Context, identities identityIndex
 		return result, fmt.Errorf("list CRI pod sandboxes: %w", err)
 	}
 	allTargets := collectionTargets(identities, sandboxes)
-	targets := c.nextCollectionTargets(allTargets)
+	targets, start := c.orderedCollectionTargets(allTargets)
 	result.Matched = len(targets)
 	if len(targets) == 0 {
 		c.cpuUsage.prune(nil)
@@ -274,16 +267,22 @@ func (c *Collector) collectTargets(ctx context.Context, identities identityIndex
 	results := make([]targetResult, len(targets))
 	semaphore := make(chan struct{}, c.maxConcurrency)
 	var wg sync.WaitGroup
+	dispatched := 0
 dispatch:
 	for i := range targets {
+		if budgetCtx.Err() != nil {
+			break
+		}
 		select {
 		case semaphore <- struct{}{}:
-		case <-budgetCtx.Done():
-			for j := i; j < len(results); j++ {
-				results[j].err = budgetCtx.Err()
+			if budgetCtx.Err() != nil {
+				<-semaphore
+				break dispatch
 			}
+		case <-budgetCtx.Done():
 			break dispatch
 		}
+		dispatched++
 		wg.Add(1)
 		go func(index int) {
 			defer wg.Done()
@@ -297,10 +296,11 @@ dispatch:
 		}(i)
 	}
 	wg.Wait()
+	c.advanceTargetCursor(len(targets), start, dispatched)
 
-	stats := make([]*runtimeapi.PodSandboxStats, 0, len(results))
+	stats := make([]*runtimeapi.PodSandboxStats, 0, dispatched)
 	var collectionErr error
-	for i := range results {
+	for i := 0; i < dispatched; i++ {
 		if results[i].err != nil {
 			result.Failed++
 			collectionErr = errors.Join(collectionErr, fmt.Errorf("collect CRI pod sandbox %s stats: %w", targets[i].id, results[i].err))
@@ -308,7 +308,15 @@ dispatch:
 		}
 		stats = append(stats, results[i].stats)
 	}
-	pruneCPUUsage := len(targets) == len(allTargets) && collectionErr == nil
+	if deferred := len(targets) - dispatched; deferred > 0 {
+		collectionErr = errors.Join(collectionErr, fmt.Errorf(
+			"runtime metric collection stopped with %d of %d targets deferred: %w",
+			deferred,
+			len(targets),
+			budgetCtx.Err(),
+		))
+	}
+	pruneCPUUsage := dispatched == len(targets) && collectionErr == nil
 	projected, projectErr := c.projectStats(identities, stats, pruneCPUUsage)
 	result.StatsReceived = projected.StatsReceived
 	result.Enqueued = projected.Enqueued
@@ -340,22 +348,26 @@ func collectionTargets(identities identityIndex, sandboxes []*runtimeapi.PodSand
 	return targets
 }
 
-func (c *Collector) nextCollectionTargets(targets []collectionTarget) []collectionTarget {
+func (c *Collector) orderedCollectionTargets(targets []collectionTarget) ([]collectionTarget, int) {
 	if len(targets) == 0 {
-		return nil
-	}
-	limit := c.maxSandboxes
-	if limit <= 0 || limit >= len(targets) {
-		c.targetCursor = 0
-		return targets
+		return nil, 0
 	}
 	start := c.targetCursor % len(targets)
-	selected := make([]collectionTarget, 0, limit)
-	for i := 0; i < limit; i++ {
-		selected = append(selected, targets[(start+i)%len(targets)])
+	if start == 0 {
+		return targets, start
 	}
-	c.targetCursor = (start + limit) % len(targets)
-	return selected
+	ordered := make([]collectionTarget, 0, len(targets))
+	ordered = append(ordered, targets[start:]...)
+	ordered = append(ordered, targets[:start]...)
+	return ordered, start
+}
+
+func (c *Collector) advanceTargetCursor(targetCount, start, dispatched int) {
+	if targetCount == 0 || dispatched >= targetCount {
+		c.targetCursor = 0
+		return
+	}
+	c.targetCursor = (start + dispatched) % targetCount
 }
 
 func (c *Collector) nextDelay() time.Duration {

--- a/ctld/internal/ctld/runtimemetrics/collector_test.go
+++ b/ctld/internal/ctld/runtimemetrics/collector_test.go
@@ -3,6 +3,7 @@ package runtimemetrics
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -15,14 +16,26 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
-func TestCollectorUsesOneBulkCallAndEnqueuesMatchedSandboxes(t *testing.T) {
+func TestCollectorRequestsStatsOnlyForClaimedSandboxes(t *testing.T) {
 	podA := runtimeMetricPod("ns-a", "pod-a", "pod-uid-a", "node-a", "team-a", "sandbox-a", "2")
 	podB := runtimeMetricPod("ns-a", "pod-b", "pod-uid-b", "node-a", "team-a", "sandbox-b", "3")
-	client := &fakeStatsClient{stats: []*runtimeapi.PodSandboxStats{
-		minimalPodStats("cri-a", "ns-a", "pod-a", "pod-uid-a"),
-		minimalPodStats("cri-b", "ns-a", "pod-b", "pod-uid-b"),
-		minimalPodStats("cri-other", "ns-a", "other", "pod-uid-other"),
-	}}
+	client := &fakeStatsClient{
+		sandboxes: []*runtimeapi.PodSandbox{
+			podSandbox("cri-a", "ns-a", "pod-a", "pod-uid-a"),
+			podSandbox("cri-b", "ns-a", "pod-b", "pod-uid-b"),
+		},
+		statsByID: map[string]*runtimeapi.PodSandboxStats{
+			"cri-a": minimalPodStats("cri-a", "ns-a", "pod-a", "pod-uid-a"),
+			"cri-b": minimalPodStats("cri-b", "ns-a", "pod-b", "pod-uid-b"),
+		},
+	}
+	for i := 0; i < 500; i++ {
+		id := fmt.Sprintf("cri-unclaimed-%03d", i)
+		name := fmt.Sprintf("unclaimed-%03d", i)
+		uid := fmt.Sprintf("unclaimed-uid-%03d", i)
+		client.sandboxes = append(client.sandboxes, podSandbox(id, "ns-a", name, uid))
+		client.statsByID[id] = minimalPodStats(id, "ns-a", name, uid)
+	}
 	sink := &recordingSampleSink{}
 	collector, err := NewCollector(CollectorConfig{
 		RegionID: "region-a", ClusterID: "cluster-a", NodeName: "node-a",
@@ -33,11 +46,34 @@ func TestCollectorUsesOneBulkCallAndEnqueuesMatchedSandboxes(t *testing.T) {
 
 	result, err := collector.Collect(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, 1, client.calls)
-	assert.Equal(t, CollectResult{StatsReceived: 3, Matched: 2, Enqueued: 2}, result)
+	assert.Equal(t, 1, client.listCalls)
+	assert.ElementsMatch(t, []string{"cri-a", "cri-b"}, client.perSandboxCalls)
+	assert.Equal(t, CollectResult{StatsReceived: 2, Matched: 2, Enqueued: 2}, result)
 	require.Len(t, sink.samples, 2)
 	assert.Equal(t, "sandbox-a", sink.samples[0].SandboxID)
 	assert.Equal(t, "sandbox-b", sink.samples[1].SandboxID)
+}
+
+func TestCollectorSkipsCRIWhenNoClaimedSandboxes(t *testing.T) {
+	client := &fakeStatsClient{
+		sandboxes: []*runtimeapi.PodSandbox{
+			podSandbox("cri-unclaimed", "ns-a", "pod-unclaimed", "uid-unclaimed"),
+		},
+	}
+	collector, err := NewCollector(CollectorConfig{
+		StatsClient: client,
+		PodLister:   podLister(t),
+		Sink:        &recordingSampleSink{},
+		NodeName:    "node-a",
+	})
+	require.NoError(t, err)
+
+	result, err := collector.Collect(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, CollectResult{}, result)
+	assert.Zero(t, client.listCalls)
+	assert.Empty(t, client.perSandboxCalls)
 }
 
 func TestCollectorDerivesCPUUsageFromLinuxCumulativeStats(t *testing.T) {
@@ -45,9 +81,12 @@ func TestCollectorDerivesCPUUsageFromLinuxCumulativeStats(t *testing.T) {
 	pod.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
 		corev1.ResourceCPU: resource.MustParse("2"),
 	}
-	client := &fakeStatsClient{stats: []*runtimeapi.PodSandboxStats{
-		cpuOnlyPodStats("cri-a", "ns-a", "pod-a", "pod-uid-a", 10_000_000_000, 10_000_000_000),
-	}}
+	client := &fakeStatsClient{
+		sandboxes: []*runtimeapi.PodSandbox{podSandbox("cri-a", "ns-a", "pod-a", "pod-uid-a")},
+		statsByID: map[string]*runtimeapi.PodSandboxStats{
+			"cri-a": cpuOnlyPodStats("cri-a", "ns-a", "pod-a", "pod-uid-a", 10_000_000_000, 10_000_000_000),
+		},
+	}
 	sink := &recordingSampleSink{}
 	collector, err := NewCollector(CollectorConfig{
 		RegionID: "region-a", ClusterID: "cluster-a", NodeName: "node-a",
@@ -61,9 +100,7 @@ func TestCollectorDerivesCPUUsageFromLinuxCumulativeStats(t *testing.T) {
 	assert.Nil(t, sink.samples[0].CPU.Usage)
 	assertMissing(t, sink.samples[0].Missing, sandboxobservability.RuntimeMetricCPUUsage, nil)
 
-	client.setStats([]*runtimeapi.PodSandboxStats{
-		cpuOnlyPodStats("cri-a", "ns-a", "pod-a", "pod-uid-a", 20_000_000_000, 15_000_000_000),
-	})
+	client.setStatsByID("cri-a", cpuOnlyPodStats("cri-a", "ns-a", "pod-a", "pod-uid-a", 20_000_000_000, 15_000_000_000))
 	_, err = collector.Collect(context.Background())
 	require.NoError(t, err)
 	require.Len(t, sink.samples, 2)
@@ -77,7 +114,7 @@ func TestCollectorDerivesCPUUsageFromLinuxCumulativeStats(t *testing.T) {
 }
 
 func TestCollectorReportsCRIErrorWithoutEnqueuing(t *testing.T) {
-	client := &fakeStatsClient{err: errors.New("containerd unavailable")}
+	client := &fakeStatsClient{listErr: errors.New("containerd unavailable")}
 	sink := &recordingSampleSink{}
 	collector, err := NewCollector(CollectorConfig{
 		StatsClient: client,
@@ -88,15 +125,14 @@ func TestCollectorReportsCRIErrorWithoutEnqueuing(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = collector.Collect(context.Background())
-	require.ErrorContains(t, err, "list CRI pod sandbox stats")
+	require.ErrorContains(t, err, "list CRI pod sandboxes")
 	assert.Empty(t, sink.samples)
 }
 
-func TestCollectorFallsBackToIsolatedStatsAfterBulkFailure(t *testing.T) {
+func TestCollectorIsolatesPerSandboxStatsFailures(t *testing.T) {
 	podA := runtimeMetricPod("ns-a", "pod-a", "uid-a", "node-a", "team-a", "sandbox-a", "1")
 	podB := runtimeMetricPod("ns-a", "pod-b", "uid-b", "node-a", "team-a", "sandbox-b", "1")
 	client := &fakeStatsClient{
-		err: errors.New("one runtime poisoned bulk stats"),
 		sandboxes: []*runtimeapi.PodSandbox{
 			podSandbox("cri-a", "ns-a", "pod-a", "uid-a"),
 			podSandbox("cri-b", "ns-a", "pod-b", "uid-b"),
@@ -116,24 +152,22 @@ func TestCollectorFallsBackToIsolatedStatsAfterBulkFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	result, err := collector.Collect(context.Background())
-	require.ErrorContains(t, err, "one runtime poisoned bulk stats")
 	require.ErrorContains(t, err, "runtime unavailable")
 	assert.Equal(t, CollectResult{
 		StatsReceived: 1,
 		Matched:       2,
 		Enqueued:      1,
 		Failed:        1,
-		Fallback:      true,
 	}, result)
 	require.Len(t, sink.samples, 1)
 	assert.Equal(t, "sandbox-b", sink.samples[0].SandboxID)
 	assert.ElementsMatch(t, []string{"cri-a", "cri-b"}, client.perSandboxCalls)
 }
 
-func TestCollectorFallsBackWhenBulkStatsTimesOut(t *testing.T) {
+func TestCollectorBoundsPerSandboxStatsTimeout(t *testing.T) {
 	pod := runtimeMetricPod("ns-a", "pod-a", "uid-a", "node-a", "team-a", "sandbox-a", "1")
 	client := &fakeStatsClient{
-		bulkBlock: make(chan struct{}),
+		block: make(chan struct{}),
 		sandboxes: []*runtimeapi.PodSandbox{
 			podSandbox("cri-a", "ns-a", "pod-a", "uid-a"),
 		},
@@ -143,28 +177,26 @@ func TestCollectorFallsBackWhenBulkStatsTimesOut(t *testing.T) {
 	}
 	sink := &recordingSampleSink{}
 	collector, err := NewCollector(CollectorConfig{
-		StatsClient:        client,
-		PodLister:          podLister(t, pod),
-		Sink:               sink,
-		NodeName:           "node-a",
-		BulkRequestTimeout: 10 * time.Millisecond,
+		StatsClient:    client,
+		PodLister:      podLister(t, pod),
+		Sink:           sink,
+		NodeName:       "node-a",
+		RequestTimeout: 10 * time.Millisecond,
 	})
 	require.NoError(t, err)
 
 	result, err := collector.Collect(context.Background())
 
 	require.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.True(t, result.Fallback)
-	assert.Equal(t, 1, result.Enqueued)
-	require.Len(t, sink.samples, 1)
-	assert.Equal(t, "sandbox-a", sink.samples[0].SandboxID)
+	assert.Equal(t, 1, result.Failed)
+	assert.Zero(t, result.Enqueued)
+	assert.Empty(t, sink.samples)
 }
 
-func TestCollectorBoundsFallbackConcurrency(t *testing.T) {
+func TestCollectorBoundsStatsConcurrency(t *testing.T) {
 	const sandboxCount = 6
 	pods := make([]*corev1.Pod, 0, sandboxCount)
 	client := &fakeStatsClient{
-		err:       errors.New("bulk unavailable"),
 		statsByID: make(map[string]*runtimeapi.PodSandboxStats, sandboxCount),
 		block:     make(chan struct{}),
 	}
@@ -178,12 +210,12 @@ func TestCollectorBoundsFallbackConcurrency(t *testing.T) {
 		client.statsByID[id] = minimalPodStats(id, "ns-a", name, uid)
 	}
 	collector, err := NewCollector(CollectorConfig{
-		StatsClient:            client,
-		PodLister:              podLister(t, pods...),
-		Sink:                   &recordingSampleSink{},
-		NodeName:               "node-a",
-		FallbackMaxConcurrency: 2,
-		FallbackRequestTimeout: time.Second,
+		StatsClient:    client,
+		PodLister:      podLister(t, pods...),
+		Sink:           &recordingSampleSink{},
+		NodeName:       "node-a",
+		MaxConcurrency: 2,
+		RequestTimeout: time.Second,
 	})
 	require.NoError(t, err)
 
@@ -203,7 +235,7 @@ func TestCollectorBoundsFallbackConcurrency(t *testing.T) {
 			break
 		}
 		if time.Now().After(deadline) {
-			t.Fatal("fallback collector did not reach configured concurrency")
+			t.Fatal("collector did not reach configured concurrency")
 		}
 		time.Sleep(time.Millisecond)
 	}
@@ -211,17 +243,16 @@ func TestCollectorBoundsFallbackConcurrency(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(time.Second):
-		t.Fatal("fallback collection did not complete")
+		t.Fatal("collection did not complete")
 	}
 	client.mu.Lock()
 	defer client.mu.Unlock()
 	assert.LessOrEqual(t, client.maxActive, 2)
 }
 
-func TestCollectorRotatesBoundedFallbackTargets(t *testing.T) {
+func TestCollectorRotatesBoundedTargets(t *testing.T) {
 	pods := make([]*corev1.Pod, 0, 3)
 	client := &fakeStatsClient{
-		err:       errors.New("bulk unavailable"),
 		statsByID: make(map[string]*runtimeapi.PodSandboxStats, 3),
 	}
 	for _, suffix := range []string{"a", "b", "c"} {
@@ -233,12 +264,12 @@ func TestCollectorRotatesBoundedFallbackTargets(t *testing.T) {
 		client.statsByID[id] = minimalPodStats(id, "ns-a", name, uid)
 	}
 	collector, err := NewCollector(CollectorConfig{
-		StatsClient:            client,
-		PodLister:              podLister(t, pods...),
-		Sink:                   &recordingSampleSink{},
-		NodeName:               "node-a",
-		FallbackMaxSandboxes:   2,
-		FallbackMaxConcurrency: 1,
+		StatsClient:    client,
+		PodLister:      podLister(t, pods...),
+		Sink:           &recordingSampleSink{},
+		NodeName:       "node-a",
+		MaxSandboxes:   2,
+		MaxConcurrency: 1,
 	})
 	require.NoError(t, err)
 
@@ -251,10 +282,13 @@ func TestCollectorRotatesBoundedFallbackTargets(t *testing.T) {
 func TestCollectorCountsFullQueueDrops(t *testing.T) {
 	sink := &recordingSampleSink{accept: func(sandboxobservability.RuntimeSample) bool { return false }}
 	collector, err := NewCollector(CollectorConfig{
-		StatsClient: &fakeStatsClient{stats: []*runtimeapi.PodSandboxStats{minimalPodStats("cri-a", "ns-a", "pod-a", "uid-a")}},
-		PodLister:   podLister(t, runtimeMetricPod("ns-a", "pod-a", "uid-a", "node-a", "team-a", "sandbox-a", "1")),
-		Sink:        sink,
-		NodeName:    "node-a",
+		StatsClient: &fakeStatsClient{
+			sandboxes: []*runtimeapi.PodSandbox{podSandbox("cri-a", "ns-a", "pod-a", "uid-a")},
+			statsByID: map[string]*runtimeapi.PodSandboxStats{"cri-a": minimalPodStats("cri-a", "ns-a", "pod-a", "uid-a")},
+		},
+		PodLister: podLister(t, runtimeMetricPod("ns-a", "pod-a", "uid-a", "node-a", "team-a", "sandbox-a", "1")),
+		Sink:      sink,
+		NodeName:  "node-a",
 	})
 	require.NoError(t, err)
 
@@ -266,10 +300,17 @@ func TestCollectorCountsFullQueueDrops(t *testing.T) {
 
 func TestCollectorRunCollectsImmediately(t *testing.T) {
 	called := make(chan struct{}, 1)
-	client := &fakeStatsClient{onCall: func() { called <- struct{}{} }}
+	pod := runtimeMetricPod("ns-a", "pod-a", "uid-a", "node-a", "team-a", "sandbox-a", "1")
+	client := &fakeStatsClient{
+		onList:    func() { called <- struct{}{} },
+		sandboxes: []*runtimeapi.PodSandbox{podSandbox("cri-a", "ns-a", "pod-a", "uid-a")},
+		statsByID: map[string]*runtimeapi.PodSandboxStats{
+			"cri-a": minimalPodStats("cri-a", "ns-a", "pod-a", "uid-a"),
+		},
+	}
 	collector, err := NewCollector(CollectorConfig{
 		StatsClient: client,
-		PodLister:   podLister(t),
+		PodLister:   podLister(t, pod),
 		Sink:        &recordingSampleSink{},
 		Interval:    time.Hour,
 		Random:      func() float64 { return 0.5 },
@@ -315,7 +356,10 @@ func TestCollectorUsesSharedRuntimeSampleCadenceDefaults(t *testing.T) {
 
 	assert.Equal(t, sandboxobservability.DefaultRuntimeSampleInterval, collector.interval)
 	assert.Equal(t, sandboxobservability.DefaultRuntimeSampleJitter, collector.jitter)
-	assert.Equal(t, defaultBulkRequestTimeout, collector.bulkRequestTimeout)
+	assert.Equal(t, defaultMaxConcurrency, collector.maxConcurrency)
+	assert.Equal(t, defaultMaxSandboxes, collector.maxSandboxes)
+	assert.Equal(t, defaultRequestTimeout, collector.requestTimeout)
+	assert.Equal(t, defaultCollectionBudget, collector.collectionBudget)
 }
 
 func minimalPodStats(epoch, namespace, name, uid string) *runtimeapi.PodSandboxStats {
@@ -347,46 +391,29 @@ func cpuOnlyPodStats(epoch, namespace, name, uid string, timestamp int64, cumula
 
 type fakeStatsClient struct {
 	mu              sync.Mutex
-	stats           []*runtimeapi.PodSandboxStats
-	err             error
-	calls           int
-	onCall          func()
+	listCalls       int
+	onList          func()
 	sandboxes       []*runtimeapi.PodSandbox
 	listErr         error
 	statsByID       map[string]*runtimeapi.PodSandboxStats
 	statsErrByID    map[string]error
 	perSandboxCalls []string
-	bulkBlock       chan struct{}
 	block           chan struct{}
 	active          int
 	maxActive       int
 }
 
-func (c *fakeStatsClient) ListPodSandboxStats(ctx context.Context) ([]*runtimeapi.PodSandboxStats, error) {
-	c.mu.Lock()
-	c.calls++
-	onCall := c.onCall
-	stats := c.stats
-	err := c.err
-	bulkBlock := c.bulkBlock
-	c.mu.Unlock()
-	if onCall != nil {
-		onCall()
-	}
-	if bulkBlock != nil {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-bulkBlock:
-		}
-	}
-	return stats, err
-}
-
 func (c *fakeStatsClient) ListPodSandboxes(context.Context) ([]*runtimeapi.PodSandbox, error) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	return append([]*runtimeapi.PodSandbox(nil), c.sandboxes...), c.listErr
+	c.listCalls++
+	onList := c.onList
+	sandboxes := append([]*runtimeapi.PodSandbox(nil), c.sandboxes...)
+	err := c.listErr
+	c.mu.Unlock()
+	if onList != nil {
+		onList()
+	}
+	return sandboxes, err
 }
 
 func (c *fakeStatsClient) PodSandboxStats(ctx context.Context, id string) (*runtimeapi.PodSandboxStats, error) {
@@ -415,10 +442,10 @@ func (c *fakeStatsClient) PodSandboxStats(ctx context.Context, id string) (*runt
 	return stats, err
 }
 
-func (c *fakeStatsClient) setStats(stats []*runtimeapi.PodSandboxStats) {
+func (c *fakeStatsClient) setStatsByID(id string, stats *runtimeapi.PodSandboxStats) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.stats = stats
+	c.statsByID[id] = stats
 }
 
 type recordingSampleSink struct {

--- a/ctld/internal/ctld/runtimemetrics/collector_test.go
+++ b/ctld/internal/ctld/runtimemetrics/collector_test.go
@@ -250,33 +250,75 @@ func TestCollectorBoundsStatsConcurrency(t *testing.T) {
 	assert.LessOrEqual(t, client.maxActive, 2)
 }
 
-func TestCollectorRotatesBoundedTargets(t *testing.T) {
-	pods := make([]*corev1.Pod, 0, 3)
+func TestCollectorCollectsAllClaimedTargetsWithinBudget(t *testing.T) {
+	const sandboxCount = 64
+	pods := make([]*corev1.Pod, 0, sandboxCount)
 	client := &fakeStatsClient{
-		statsByID: make(map[string]*runtimeapi.PodSandboxStats, 3),
+		statsByID: make(map[string]*runtimeapi.PodSandboxStats, sandboxCount),
 	}
-	for _, suffix := range []string{"a", "b", "c"} {
-		name := "pod-" + suffix
-		uid := "uid-" + suffix
-		id := "cri-" + suffix
-		pods = append(pods, runtimeMetricPod("ns-a", name, uid, "node-a", "team-a", "sandbox-"+suffix, "1"))
+	for i := 0; i < sandboxCount; i++ {
+		name := fmt.Sprintf("pod-%03d", i)
+		uid := fmt.Sprintf("uid-%03d", i)
+		id := fmt.Sprintf("cri-%03d", i)
+		pods = append(pods, runtimeMetricPod("ns-a", name, uid, "node-a", "team-a", fmt.Sprintf("sandbox-%03d", i), "1"))
+		client.sandboxes = append(client.sandboxes, podSandbox(id, "ns-a", name, uid))
+		client.statsByID[id] = minimalPodStats(id, "ns-a", name, uid)
+	}
+	sink := &recordingSampleSink{}
+	collector, err := NewCollector(CollectorConfig{
+		StatsClient:    client,
+		PodLister:      podLister(t, pods...),
+		Sink:           sink,
+		NodeName:       "node-a",
+		MaxConcurrency: 4,
+	})
+	require.NoError(t, err)
+
+	result, err := collector.Collect(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, sandboxCount, result.Matched)
+	assert.Equal(t, sandboxCount, result.Enqueued)
+	assert.Len(t, client.perSandboxCalls, sandboxCount)
+	assert.Len(t, sink.samples, sandboxCount)
+}
+
+func TestCollectorRotatesAfterCollectionBudgetExhaustion(t *testing.T) {
+	const sandboxCount = 6
+	pods := make([]*corev1.Pod, 0, sandboxCount)
+	client := &fakeStatsClient{
+		statsByID: make(map[string]*runtimeapi.PodSandboxStats, sandboxCount),
+		block:     make(chan struct{}),
+	}
+	for i := 0; i < sandboxCount; i++ {
+		name := fmt.Sprintf("pod-%c", 'a'+i)
+		uid := fmt.Sprintf("uid-%c", 'a'+i)
+		id := fmt.Sprintf("cri-%c", 'a'+i)
+		pods = append(pods, runtimeMetricPod("ns-a", name, uid, "node-a", "team-a", fmt.Sprintf("sandbox-%c", 'a'+i), "1"))
 		client.sandboxes = append(client.sandboxes, podSandbox(id, "ns-a", name, uid))
 		client.statsByID[id] = minimalPodStats(id, "ns-a", name, uid)
 	}
 	collector, err := NewCollector(CollectorConfig{
-		StatsClient:    client,
-		PodLister:      podLister(t, pods...),
-		Sink:           &recordingSampleSink{},
-		NodeName:       "node-a",
-		MaxSandboxes:   2,
-		MaxConcurrency: 1,
+		StatsClient:      client,
+		PodLister:        podLister(t, pods...),
+		Sink:             &recordingSampleSink{},
+		NodeName:         "node-a",
+		MaxConcurrency:   2,
+		RequestTimeout:   time.Second,
+		CollectionBudget: 20 * time.Millisecond,
 	})
 	require.NoError(t, err)
 
-	_, _ = collector.Collect(context.Background())
-	_, _ = collector.Collect(context.Background())
+	first, firstErr := collector.Collect(context.Background())
+	second, secondErr := collector.Collect(context.Background())
 
-	assert.Equal(t, []string{"cri-a", "cri-b", "cri-c", "cri-a"}, client.perSandboxCalls)
+	require.ErrorIs(t, firstErr, context.DeadlineExceeded)
+	require.ErrorIs(t, secondErr, context.DeadlineExceeded)
+	assert.Equal(t, sandboxCount, first.Matched)
+	assert.Equal(t, sandboxCount, second.Matched)
+	require.Len(t, client.perSandboxCalls, 4)
+	assert.ElementsMatch(t, []string{"cri-a", "cri-b"}, client.perSandboxCalls[:2])
+	assert.ElementsMatch(t, []string{"cri-c", "cri-d"}, client.perSandboxCalls[2:])
 }
 
 func TestCollectorCountsFullQueueDrops(t *testing.T) {
@@ -357,7 +399,6 @@ func TestCollectorUsesSharedRuntimeSampleCadenceDefaults(t *testing.T) {
 	assert.Equal(t, sandboxobservability.DefaultRuntimeSampleInterval, collector.interval)
 	assert.Equal(t, sandboxobservability.DefaultRuntimeSampleJitter, collector.jitter)
 	assert.Equal(t, defaultMaxConcurrency, collector.maxConcurrency)
-	assert.Equal(t, defaultMaxSandboxes, collector.maxSandboxes)
 	assert.Equal(t, defaultRequestTimeout, collector.requestTimeout)
 	assert.Equal(t, defaultCollectionBudget, collector.collectionBudget)
 }

--- a/ctld/internal/ctld/runtimemetrics/identity.go
+++ b/ctld/internal/ctld/runtimemetrics/identity.go
@@ -30,6 +30,10 @@ type identityIndex struct {
 	byName map[string]sandboxIdentity
 }
 
+func (i identityIndex) empty() bool {
+	return len(i.byUID) == 0 && len(i.byName) == 0
+}
+
 func buildIdentityIndex(podLister corelisters.PodLister, nodeName string) (identityIndex, error) {
 	if podLister == nil {
 		return identityIndex{}, fmt.Errorf("pod lister is nil")

--- a/ctld/internal/ctld/runtimemetrics/observer.go
+++ b/ctld/internal/ctld/runtimemetrics/observer.go
@@ -1,0 +1,77 @@
+package runtimemetrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Observer records low-cardinality health signals for runtime metric collection.
+type Observer struct {
+	collectionDuration *prometheus.HistogramVec
+	collections        *prometheus.CounterVec
+	targets            prometheus.Gauge
+	samples            *prometheus.CounterVec
+}
+
+// NewObserver registers runtime metric collection health signals when a registry is available.
+func NewObserver(registry prometheus.Registerer) *Observer {
+	observer := &Observer{}
+	if registry == nil {
+		return observer
+	}
+	factory := promauto.With(registry)
+	observer.collectionDuration = factory.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "ctld_runtime_metric_collection_duration_seconds",
+		Help:    "Duration of bounded ctld runtime metric collection attempts",
+		Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2, 5, 10, 15},
+	}, []string{"status"})
+	observer.collections = factory.NewCounterVec(prometheus.CounterOpts{
+		Name: "ctld_runtime_metric_collections_total",
+		Help: "Ctld runtime metric collection attempts by result",
+	}, []string{"status"})
+	observer.targets = factory.NewGauge(prometheus.GaugeOpts{
+		Name: "ctld_runtime_metric_collection_targets",
+		Help: "Claimed sandboxes selected by the latest ctld runtime metric collection",
+	})
+	observer.samples = factory.NewCounterVec(prometheus.CounterOpts{
+		Name: "ctld_runtime_metric_samples_total",
+		Help: "Ctld runtime metric samples by collection result",
+	}, []string{"result"})
+	return observer
+}
+
+// ObserveCollection records one complete bounded collection attempt.
+func (o *Observer) ObserveCollection(duration time.Duration, result CollectResult, err error) {
+	if o == nil {
+		return
+	}
+	status := "success"
+	if err != nil {
+		status = "error"
+		if result.Enqueued > 0 {
+			status = "partial"
+		}
+	}
+	if o.collectionDuration != nil {
+		o.collectionDuration.WithLabelValues(status).Observe(duration.Seconds())
+	}
+	if o.collections != nil {
+		o.collections.WithLabelValues(status).Inc()
+	}
+	if o.targets != nil {
+		o.targets.Set(float64(result.Matched))
+	}
+	if o.samples != nil {
+		if result.Enqueued > 0 {
+			o.samples.WithLabelValues("enqueued").Add(float64(result.Enqueued))
+		}
+		if result.Dropped > 0 {
+			o.samples.WithLabelValues("dropped").Add(float64(result.Dropped))
+		}
+		if result.Failed > 0 {
+			o.samples.WithLabelValues("failed").Add(float64(result.Failed))
+		}
+	}
+}

--- a/ctld/internal/ctld/runtimemetrics/observer_test.go
+++ b/ctld/internal/ctld/runtimemetrics/observer_test.go
@@ -1,0 +1,29 @@
+package runtimemetrics
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestObserverRecordsPartialCollection(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	observer := NewObserver(registry)
+
+	observer.ObserveCollection(2*time.Second, CollectResult{
+		Matched:  3,
+		Enqueued: 1,
+		Dropped:  1,
+		Failed:   1,
+	}, errors.New("one sandbox stats request failed"))
+
+	assert.Equal(t, float64(1), testutil.ToFloat64(observer.collections.WithLabelValues("partial")))
+	assert.Equal(t, float64(3), testutil.ToFloat64(observer.targets))
+	assert.Equal(t, float64(1), testutil.ToFloat64(observer.samples.WithLabelValues("enqueued")))
+	assert.Equal(t, float64(1), testutil.ToFloat64(observer.samples.WithLabelValues("dropped")))
+	assert.Equal(t, float64(1), testutil.ToFloat64(observer.samples.WithLabelValues("failed")))
+}


### PR DESCRIPTION
## Summary

- stop calling CRI `ListPodSandboxStats`, which fans out to every stored sandbox on a node
- resolve claimed Sandbox0 pods through the informer and request only their individual `PodSandboxStats`
- bound collection to 4 concurrent requests, a 2-second per-target timeout, and a 10-second total budget
- collect every healthy claimed target within the budget; if the budget is exhausted, continue the next round from the first deferred target instead of starving the tail
- expose low-cardinality ctld metrics for collection duration/status, matched targets, and enqueued/dropped/failed samples
- remove the node-wide bulk stats method from `ContainerdRuntime`

## Production incident

On 2026-08-03, an ali-ue1 runtime rollout promoted two ctld primaries within roughly 40 seconds. Each new primary immediately issued an unfiltered node-wide `ListPodSandboxStats` against a high-density sandbox worker with about 522 CRI pod sandboxes.

containerd v2.1.5 implements that request by starting one goroutine per stored sandbox and waiting for every result. The overlapping waves saturated the 8-vCPU node and its containerd ttrpc paths: load reached roughly 665, ctld/kubelet scrapes timed out, and runtime sample ingestion stopped at 05:38:09 CST. The narrow incident window contained 34,765 containerd metric collection failures across 735 distinct sandbox/container IDs, which rules out a single poisoned gVisor sandbox. There were no corresponding OOM, disk-pressure, kernel-lockup, or gVisor panic signals.

The release was the trigger because it rolled ctld; the deployed commit range did not change this collector path.

Production was recovered by restarting only containerd on the affected node after confirming `KillMode=process`. Existing shims and target sandbox pods remained running/Ready. At the final check, both Sandpi sandboxes reported fresh metrics, containerd was active, one-minute load was 1.30, CPU idle was 88.7%, and there were no containerd metric collection errors in the preceding three minutes.

## Why this fixes it

`ListPodSandbox` is a metadata lookup and is filtered to Ready sandboxes. ctld then matches that list against currently claimed Sandbox0 pods before issuing any stats call. The number of simultaneous CRI/gVisor requests is always at most four, so a ctld rollout or HA transition cannot turn one collection tick into hundreds of concurrent requests.

The total collection budget is the overload boundary, rather than a fixed target-count cap. This preserves the 15-second healthy-path sampling contract for dense nodes while still stopping slow or wedged runtimes after ten seconds. Round-robin continuation gives deferred targets a chance on the next tick.

Regression tests cover 500 unclaimed sandboxes with only two stats calls, all 64 claimed targets collected in one healthy round, bounded concurrency, per-target timeouts, partial failures, and fair continuation after budget exhaustion.

## Verification

- `go test ./ctld/...`
- `go test -race ./ctld/internal/ctld/runtimemetrics`
- repeated budget/fairness tests with `-count=50`
- `go vet ./ctld/...`
- `git diff --check`

`go test ./...` was also attempted. It reaches an unrelated existing blocker outside this change:

- `storage-proxy/pkg/snapshot`: `TestS0FSForkFreshEmptyVolumeCreatesEmptyChild` fails with `pending materialization wal checkpoint is invalid` (reproduces independently with `-count=1`)
- the local e2e setup cannot start because `kind` is not installed

The first PR quick-check independently passed formatting, generated-artifact verification, go.mod/go.sum verification, Helm lint, and golangci-lint. Its repository-wide unit-test step failed only on the same `storage-proxy/pkg/snapshot` test above.
