### PR TITLE
fix(s0fs): align empty materialization checkpoint

### DIFF
--- a/storage-proxy/pkg/s0fs/engine.go
+++ b/storage-proxy/pkg/s0fs/engine.go
@@ -1119,6 +1119,9 @@ func (e *Engine) restoreStateLocked(state *SnapshotState) error {
 }
 
 func (e *Engine) ReplaceState(state *SnapshotState) error {
+	state = cloneState(state)
+	ensureMaterializableSequence(state)
+
 	e.mutationMu.Lock()
 	defer e.mutationMu.Unlock()
 
@@ -1130,7 +1133,7 @@ func (e *Engine) ReplaceState(state *SnapshotState) error {
 	if err := e.reserveLocalDiskLocked(estimatedStateBytes(state)); err != nil {
 		return err
 	}
-	e.replaceStateLocked(cloneState(state))
+	e.replaceStateLocked(state)
 	if err := e.persistCurrentStateLockedWithReserve(false); err != nil {
 		return err
 	}

--- a/storage-proxy/pkg/s0fs/materializer.go
+++ b/storage-proxy/pkg/s0fs/materializer.go
@@ -143,9 +143,7 @@ func (m *Materializer) Materialize(ctx context.Context, state *SnapshotState, ex
 	inline := cloneStateForMaterialization(state)
 	normalizeState(inline)
 	defaultSegmentVolumeIDs(inline, m.volumeID)
-	if inline.NextSeq <= 1 {
-		inline.NextSeq = 2
-	}
+	ensureMaterializableSequence(inline)
 
 	nextSeq := checkpointSequence(inline)
 	if nextSeq == 0 {
@@ -763,6 +761,12 @@ func checkpointSequence(state *SnapshotState) uint64 {
 		return 0
 	}
 	return state.NextSeq - 1
+}
+
+func ensureMaterializableSequence(state *SnapshotState) {
+	if state != nil && state.NextSeq <= 1 {
+		state.NextSeq = 2
+	}
 }
 
 func (m *Materializer) putManifest(ctx context.Context, key string, manifest *Manifest) error {


### PR DESCRIPTION
## What changed

- normalize imported empty S0FS state to the first materializable sequence before persisting it
- reuse the same sequence normalization in the materializer

## Root cause

`ReplaceState` persisted a fresh empty state with `NextSeq=1`, while the materializer promoted its private clone to `NextSeq=2`. After the bounded WAL checkpoint change, the pending manifest used checkpoint sequence 1 but the captured WAL checkpoint used sequence 0, so finalization rejected the otherwise valid first materialization.

Normalizing before `ReplaceState` persists the local base also ensures later concurrent WAL mutations start at sequence 2 instead of colliding with the synthetic first manifest checkpoint.

## Impact

Restores fresh empty S0FS volume forks and unblocks the repository quick check without changing non-empty imported states.

## Validation

- `go test ./storage-proxy/pkg/snapshot -run '^TestS0FSForkFreshEmptyVolumeCreatesEmptyChild$' -count=20`
- `go test ./storage-proxy/pkg/s0fs ./storage-proxy/pkg/snapshot -count=1`
- `go test ./storage-proxy/pkg/s0fs -run 'TestEngineSyncMaterialize|TestEngineForkedMaterialization' -count=20`
