### PR TITLE
feat(ctld): expose HA election metrics

### DIFF
--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -73,6 +73,7 @@ var (
 	haSlot                         = os.Getenv("CTLD_HA_SLOT")
 	haProbe                        string
 	haProbeSocket                  = "/run/sandbox0/ctld-ha.sock"
+	haMetricsAddr                  string
 	networkRuntimeConfigPath       = strings.TrimSpace(os.Getenv("NETD_CONFIG_PATH"))
 )
 
@@ -113,6 +114,7 @@ func main() {
 	flag.StringVar(&haSlot, "ha-slot", os.Getenv("CTLD_HA_SLOT"), "stable ctld HA deployment slot")
 	flag.StringVar(&haProbe, "ha-probe", "", "run one ctld HA probe (live or ready) and exit")
 	flag.StringVar(&haProbeSocket, "ha-probe-socket", "/run/sandbox0/ctld-ha.sock", "container-local ctld HA probe socket")
+	flag.StringVar(&haMetricsAddr, "ha-metrics-addr", "", "dedicated pre-election HTTP listen address for ctld HA metrics; empty disables it")
 	flag.StringVar(&networkRuntimeConfigPath, "netd-config-path", strings.TrimSpace(os.Getenv("NETD_CONFIG_PATH")), "explicit ctld network runtime config path; empty disables network policy enforcement")
 	flag.Parse()
 
@@ -139,12 +141,33 @@ func run() error {
 	if err != nil {
 		return err
 	}
+	haMetricsServer, err := ctldha.StartMetricsServer(ctx, haMetricsAddr, coordinator, nodeName, haSlot)
+	if err != nil {
+		return err
+	}
+	if haMetricsServer != nil {
+		defer haMetricsServer.Close()
+		log.Printf("ctld HA metrics server listening on %q", haMetricsServer.Addr())
+	}
 	probeServer, err := ctldha.StartProbeServer(ctx, haProbeSocket, coordinator)
 	if err != nil {
 		return err
 	}
 	defer probeServer.Close()
-	return runHAPrimary(ctx, coordinator, probeServer.SetServiceReady, networkFactory, runPrimary)
+	if haMetricsServer == nil {
+		return runHAPrimary(ctx, coordinator, probeServer.SetServiceReady, networkFactory, runPrimary)
+	}
+	primaryErrors := make(chan error, 1)
+	go func() {
+		primaryErrors <- runHAPrimary(ctx, coordinator, probeServer.SetServiceReady, networkFactory, runPrimary)
+	}()
+	select {
+	case err := <-primaryErrors:
+		return err
+	case err := <-haMetricsServer.Errors():
+		cancel()
+		return errors.Join(fmt.Errorf("ctld HA metrics server: %w", err), <-primaryErrors)
+	}
 }
 
 type primaryRunner func(context.Context, primaryRunOptions) error

--- a/ctld/internal/ctld/ha/coordinator_linux.go
+++ b/ctld/internal/ctld/ha/coordinator_linux.go
@@ -44,6 +44,27 @@ type State struct {
 	Standbys     int
 }
 
+// RoleTransition identifies one observed HA role change.
+type RoleTransition struct {
+	From Role
+	To   Role
+}
+
+// LockIdentity identifies the shared filesystem object used for primary fencing.
+type LockIdentity struct {
+	Device uint64
+	Inode  uint64
+	Known  bool
+}
+
+// MetricsSnapshot is a consistent view of the node-local HA election state.
+type MetricsSnapshot struct {
+	State        State
+	StateSince   time.Time
+	Transitions  map[RoleTransition]uint64
+	LockIdentity LockIdentity
+}
+
 type Config struct {
 	RootDir string
 	Slot    string
@@ -55,8 +76,11 @@ type Coordinator struct {
 	slot    string
 	logger  *zap.Logger
 
-	mu    sync.RWMutex
-	state State
+	mu           sync.RWMutex
+	state        State
+	stateSince   time.Time
+	transitions  map[RoleTransition]uint64
+	lockIdentity LockIdentity
 }
 
 type RecoveredPortal struct {
@@ -92,10 +116,12 @@ func NewCoordinator(cfg Config) (*Coordinator, error) {
 		logger = zap.NewNop()
 	}
 	coordinator := &Coordinator{
-		rootDir: rootDir,
-		slot:    slot,
-		logger:  logger,
-		state:   State{Role: RoleStarting},
+		rootDir:     rootDir,
+		slot:        slot,
+		logger:      logger,
+		state:       State{Role: RoleStarting},
+		stateSince:  time.Now(),
+		transitions: make(map[RoleTransition]uint64),
 	}
 	return coordinator, nil
 }
@@ -114,8 +140,49 @@ func (c *Coordinator) setState(update func(*State)) {
 		return
 	}
 	c.mu.Lock()
+	previousRole := c.state.Role
 	update(&c.state)
+	if c.state.Role != previousRole {
+		if c.transitions == nil {
+			c.transitions = make(map[RoleTransition]uint64)
+		}
+		c.transitions[RoleTransition{From: previousRole, To: c.state.Role}]++
+		c.stateSince = time.Now()
+	}
 	c.mu.Unlock()
+}
+
+// MetricsSnapshot returns HA state and transition counters from one lock hold.
+func (c *Coordinator) MetricsSnapshot() MetricsSnapshot {
+	if c == nil {
+		return MetricsSnapshot{}
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	transitions := make(map[RoleTransition]uint64, len(c.transitions))
+	for transition, count := range c.transitions {
+		transitions[transition] = count
+	}
+	return MetricsSnapshot{
+		State:        c.state,
+		StateSince:   c.stateSince,
+		Transitions:  transitions,
+		LockIdentity: c.lockIdentity,
+	}
+}
+
+func (c *Coordinator) recordLockIdentity(file *os.File) error {
+	if c == nil || file == nil {
+		return fmt.Errorf("ctld HA lock file is required")
+	}
+	var stat unix.Stat_t
+	if err := unix.Fstat(int(file.Fd()), &stat); err != nil {
+		return fmt.Errorf("stat ctld primary lock: %w", err)
+	}
+	c.mu.Lock()
+	c.lockIdentity = LockIdentity{Device: uint64(stat.Dev), Inode: stat.Ino, Known: true}
+	c.mu.Unlock()
+	return nil
 }
 
 func (c *Coordinator) WaitForPrimary(ctx context.Context) (*PrimaryLease, error) {
@@ -126,6 +193,10 @@ func (c *Coordinator) WaitForPrimary(ctx context.Context) (*PrimaryLease, error)
 	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("open ctld primary lock: %w", err)
+	}
+	if err := c.recordLockIdentity(lockFile); err != nil {
+		_ = lockFile.Close()
+		return nil, err
 	}
 	var standby *standbyState
 	for {

--- a/ctld/internal/ctld/ha/metrics_linux.go
+++ b/ctld/internal/ctld/ha/metrics_linux.go
@@ -1,0 +1,237 @@
+//go:build linux
+
+package ha
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+const metricsShutdownTimeout = 5 * time.Second
+
+type metricsCollector struct {
+	coordinator *Coordinator
+	node        string
+	slot        string
+
+	primary         *prometheus.Desc
+	role            *prometheus.Desc
+	epoch           *prometheus.Desc
+	synchronized    *prometheus.Desc
+	standbys        *prometheus.Desc
+	stateDuration   *prometheus.Desc
+	roleTransitions *prometheus.Desc
+	lockInfo        *prometheus.Desc
+}
+
+func newMetricsCollector(coordinator *Coordinator, node, slot string) (*metricsCollector, error) {
+	if coordinator == nil {
+		return nil, fmt.Errorf("ctld HA coordinator is required")
+	}
+	labels := []string{"node", "slot"}
+	return &metricsCollector{
+		coordinator: coordinator,
+		node:        strings.TrimSpace(node),
+		slot:        strings.TrimSpace(slot),
+		primary: prometheus.NewDesc(
+			"ctld_ha_primary",
+			"Whether this ctld peer currently owns the node-local primary lock",
+			labels,
+			nil,
+		),
+		role: prometheus.NewDesc(
+			"ctld_ha_role",
+			"Current ctld HA role as a one-hot labeled gauge",
+			append(labels, "role"),
+			nil,
+		),
+		epoch: prometheus.NewDesc(
+			"ctld_ha_epoch",
+			"Current node-local ctld HA election epoch",
+			labels,
+			nil,
+		),
+		synchronized: prometheus.NewDesc(
+			"ctld_ha_synchronized",
+			"Whether the ctld peer has a synchronized HA counterpart",
+			labels,
+			nil,
+		),
+		standbys: prometheus.NewDesc(
+			"ctld_ha_standbys",
+			"Number of synchronized standbys connected to this primary",
+			labels,
+			nil,
+		),
+		stateDuration: prometheus.NewDesc(
+			"ctld_ha_state_duration_seconds",
+			"Seconds since the current ctld HA role was entered",
+			labels,
+			nil,
+		),
+		roleTransitions: prometheus.NewDesc(
+			"ctld_ha_role_transitions_total",
+			"Ctld HA role changes since process start",
+			append(labels, "from", "to"),
+			nil,
+		),
+		lockInfo: prometheus.NewDesc(
+			"ctld_ha_lock_info",
+			"Identity of the node-local filesystem object used for ctld primary election",
+			append(labels, "device", "inode"),
+			nil,
+		),
+	}, nil
+}
+
+func (c *metricsCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.primary
+	ch <- c.role
+	ch <- c.epoch
+	ch <- c.synchronized
+	ch <- c.standbys
+	ch <- c.stateDuration
+	ch <- c.roleTransitions
+	ch <- c.lockInfo
+}
+
+func (c *metricsCollector) Collect(ch chan<- prometheus.Metric) {
+	snapshot := c.coordinator.MetricsSnapshot()
+	role := snapshot.State.Role
+	if role == "" {
+		role = RoleStarting
+	}
+	primary := 0.0
+	if role == RolePrimary {
+		primary = 1
+	}
+	synchronized := 0.0
+	if snapshot.State.Synchronized {
+		synchronized = 1
+	}
+	stateDuration := time.Since(snapshot.StateSince).Seconds()
+	if snapshot.StateSince.IsZero() || stateDuration < 0 {
+		stateDuration = 0
+	}
+	baseLabels := []string{c.node, c.slot}
+	ch <- prometheus.MustNewConstMetric(c.primary, prometheus.GaugeValue, primary, baseLabels...)
+	ch <- prometheus.MustNewConstMetric(c.role, prometheus.GaugeValue, 1, c.node, c.slot, string(role))
+	ch <- prometheus.MustNewConstMetric(c.epoch, prometheus.GaugeValue, float64(snapshot.State.Epoch), baseLabels...)
+	ch <- prometheus.MustNewConstMetric(c.synchronized, prometheus.GaugeValue, synchronized, baseLabels...)
+	ch <- prometheus.MustNewConstMetric(c.standbys, prometheus.GaugeValue, float64(snapshot.State.Standbys), baseLabels...)
+	ch <- prometheus.MustNewConstMetric(c.stateDuration, prometheus.GaugeValue, stateDuration, baseLabels...)
+	for transition, count := range snapshot.Transitions {
+		ch <- prometheus.MustNewConstMetric(
+			c.roleTransitions,
+			prometheus.CounterValue,
+			float64(count),
+			c.node,
+			c.slot,
+			string(transition.From),
+			string(transition.To),
+		)
+	}
+	if snapshot.LockIdentity.Known {
+		ch <- prometheus.MustNewConstMetric(
+			c.lockInfo,
+			prometheus.GaugeValue,
+			1,
+			c.node,
+			c.slot,
+			strconv.FormatUint(snapshot.LockIdentity.Device, 10),
+			strconv.FormatUint(snapshot.LockIdentity.Inode, 10),
+		)
+	}
+}
+
+// MetricsServer exposes election metrics for both primary and standby peers.
+type MetricsServer struct {
+	listener  net.Listener
+	server    *http.Server
+	errors    chan error
+	closeOnce sync.Once
+}
+
+// StartMetricsServer starts a dedicated pre-election Prometheus endpoint.
+func StartMetricsServer(ctx context.Context, addr string, coordinator *Coordinator, node, slot string) (*MetricsServer, error) {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return nil, nil
+	}
+	collector, err := newMetricsCollector(coordinator, node, slot)
+	if err != nil {
+		return nil, err
+	}
+	registry := prometheus.NewRegistry()
+	if err := registry.Register(collector); err != nil {
+		return nil, fmt.Errorf("register ctld HA metrics: %w", err)
+	}
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("listen for ctld HA metrics: %w", err)
+	}
+	metricsServer := &MetricsServer{
+		listener: listener,
+		server: &http.Server{
+			Addr:              addr,
+			Handler:           mux,
+			ReadHeaderTimeout: 5 * time.Second,
+		},
+		errors: make(chan error, 1),
+	}
+	go func() {
+		if err := metricsServer.server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			metricsServer.errors <- err
+		}
+	}()
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), metricsShutdownTimeout)
+		defer cancel()
+		_ = metricsServer.server.Shutdown(shutdownCtx)
+	}()
+	return metricsServer, nil
+}
+
+// Addr returns the bound listener address.
+func (s *MetricsServer) Addr() string {
+	if s == nil || s.listener == nil {
+		return ""
+	}
+	return s.listener.Addr().String()
+}
+
+// Errors reports unexpected serving failures.
+func (s *MetricsServer) Errors() <-chan error {
+	if s == nil {
+		return nil
+	}
+	return s.errors
+}
+
+// Close gracefully stops the metrics endpoint.
+func (s *MetricsServer) Close() error {
+	if s == nil {
+		return nil
+	}
+	var closeErr error
+	s.closeOnce.Do(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), metricsShutdownTimeout)
+		defer cancel()
+		closeErr = s.server.Shutdown(shutdownCtx)
+	})
+	return closeErr
+}

--- a/ctld/internal/ctld/ha/metrics_linux_test.go
+++ b/ctld/internal/ctld/ha/metrics_linux_test.go
@@ -1,0 +1,136 @@
+//go:build linux
+
+package ha
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"golang.org/x/sys/unix"
+)
+
+func TestMetricsCollectorReportsElectionStateAndTransitions(t *testing.T) {
+	coordinator := newTestCoordinator(t, t.TempDir(), "a")
+	coordinator.setState(func(state *State) {
+		*state = State{Role: RoleStandby, Epoch: 3, Synchronized: true}
+	})
+	coordinator.setState(func(state *State) {
+		*state = State{Role: RolePrimary, Epoch: 4, Synchronized: true, Standbys: 1}
+	})
+	coordinator.setState(func(state *State) {
+		state.Standbys = 2
+	})
+
+	collector, err := newMetricsCollector(coordinator, "node-a", "a")
+	if err != nil {
+		t.Fatalf("newMetricsCollector() error = %v", err)
+	}
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(collector)
+	want := `
+# HELP ctld_ha_epoch Current node-local ctld HA election epoch
+# TYPE ctld_ha_epoch gauge
+ctld_ha_epoch{node="node-a",slot="a"} 4
+# HELP ctld_ha_primary Whether this ctld peer currently owns the node-local primary lock
+# TYPE ctld_ha_primary gauge
+ctld_ha_primary{node="node-a",slot="a"} 1
+# HELP ctld_ha_role Current ctld HA role as a one-hot labeled gauge
+# TYPE ctld_ha_role gauge
+ctld_ha_role{node="node-a",role="primary",slot="a"} 1
+# HELP ctld_ha_role_transitions_total Ctld HA role changes since process start
+# TYPE ctld_ha_role_transitions_total counter
+ctld_ha_role_transitions_total{from="standby",node="node-a",slot="a",to="primary"} 1
+ctld_ha_role_transitions_total{from="starting",node="node-a",slot="a",to="standby"} 1
+# HELP ctld_ha_standbys Number of synchronized standbys connected to this primary
+# TYPE ctld_ha_standbys gauge
+ctld_ha_standbys{node="node-a",slot="a"} 2
+# HELP ctld_ha_synchronized Whether the ctld peer has a synchronized HA counterpart
+# TYPE ctld_ha_synchronized gauge
+ctld_ha_synchronized{node="node-a",slot="a"} 1
+`
+	if err := testutil.GatherAndCompare(
+		registry,
+		strings.NewReader(want),
+		"ctld_ha_epoch",
+		"ctld_ha_primary",
+		"ctld_ha_role",
+		"ctld_ha_role_transitions_total",
+		"ctld_ha_standbys",
+		"ctld_ha_synchronized",
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCoordinatorRecordsSharedLockIdentity(t *testing.T) {
+	root := t.TempDir()
+	coordinator := newTestCoordinator(t, root, "a")
+	lease, err := coordinator.WaitForPrimary(context.Background())
+	if err != nil {
+		t.Fatalf("WaitForPrimary() error = %v", err)
+	}
+	defer lease.Close()
+
+	snapshot := coordinator.MetricsSnapshot()
+	if !snapshot.LockIdentity.Known {
+		t.Fatal("lock identity is not known after opening the primary lock")
+	}
+	var stat unix.Stat_t
+	if err := unix.Stat(filepath.Join(root, "ha", "primary.lock"), &stat); err != nil {
+		t.Fatalf("stat primary lock: %v", err)
+	}
+	if snapshot.LockIdentity.Device != uint64(stat.Dev) || snapshot.LockIdentity.Inode != stat.Ino {
+		t.Fatalf("lock identity = %#v, want device=%d inode=%d", snapshot.LockIdentity, stat.Dev, stat.Ino)
+	}
+}
+
+func TestMetricsServerExposesStartingPeerBeforeElection(t *testing.T) {
+	coordinator := newTestCoordinator(t, t.TempDir(), "b")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	server, err := StartMetricsServer(ctx, "127.0.0.1:0", coordinator, "node-b", "b")
+	if err != nil {
+		t.Fatalf("StartMetricsServer() error = %v", err)
+	}
+	defer server.Close()
+
+	response, err := http.Get("http://" + server.Addr() + "/metrics")
+	if err != nil {
+		t.Fatalf("GET HA metrics: %v", err)
+	}
+	defer response.Body.Close()
+	payload, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read HA metrics: %v", err)
+	}
+	metrics := string(payload)
+	for _, want := range []string{
+		`ctld_ha_primary{node="node-b",slot="b"} 0`,
+		`ctld_ha_role{node="node-b",role="starting",slot="b"} 1`,
+	} {
+		if !strings.Contains(metrics, want) {
+			t.Fatalf("HA metrics missing %q:\n%s", want, metrics)
+		}
+	}
+}
+
+func TestRecordLockIdentityRejectsClosedFile(t *testing.T) {
+	coordinator := newTestCoordinator(t, t.TempDir(), "a")
+	file, err := os.CreateTemp(t.TempDir(), "closed-lock-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := coordinator.recordLockIdentity(file); err == nil {
+		t.Fatal("recordLockIdentity() error = nil for a closed file")
+	}
+}

--- a/docs/self-hosted/observability/page.mdx
+++ b/docs/self-hosted/observability/page.mdx
@@ -36,6 +36,16 @@ For rootfs checkpoint and resume diagnosis, collect these ctld metrics:
 
 Manager also records `apply_rootfs_checkpoint`, `bind_volume_portals`, `bind_webhook_state_portal`, `activate_runtime`, and `resume_total` in `manager_sandbox_claim_phase_duration_seconds`. ctld emits a structured warning when a rootfs operation takes at least 10 seconds or handles a checkpoint of at least 512 MiB.
 
+Each sandbox node runs two ctld peers, but exactly one peer on that node should own the primary lock. More than one `ctld_ha_primary` across the whole cluster is normal when the cluster has multiple sandbox nodes. Scrape the `ha-metrics` port on both ctld Pods and group HA checks by the `node` label:
+
+- `ctld_ha_primary` identifies the elected peer; alert when `sum by (node) (ctld_ha_primary) != 1` remains true
+- `ctld_ha_role`, `ctld_ha_epoch`, and `ctld_ha_role_transitions_total` show election and failover history
+- `ctld_ha_synchronized` and `ctld_ha_standbys` show whether failover state has reached the peer
+- `ctld_ha_state_duration_seconds` shows how long the peer has held its current role
+- `ctld_ha_lock_info` exposes the shared lock device and inode; the two peers on one node should report the same identity
+
+Slot A exposes this pre-election endpoint on port `9192`; slot B uses `9193`. These endpoints stay available on both primary and standby peers, unlike the primary-only ctld service endpoint.
+
 ### Managed Collector
 
 Use `managedCollector` when Sandbox0 should install OpenTelemetry Collectors and export to your OTLP endpoint.

--- a/infra-operator/internal/controller/services/ctld/ctld.go
+++ b/infra-operator/internal/controller/services/ctld/ctld.go
@@ -52,6 +52,8 @@ const (
 	ctldKubeletCSIEndpoint         = "/var/lib/kubelet/plugins/" + volumeportal.DriverName + "/csi.sock"
 	ctldRolloutRevisionAnnotation  = "infra.sandbox0.ai/ctld-rollout-revision"
 	networkMetricsServiceSuffix    = "-ctld-network-metrics"
+	ctldHAMetricsPortA             = int32(9192)
+	ctldHAMetricsPortB             = int32(9193)
 )
 
 func NewReconciler(resources *common.ResourceManager) *Reconciler {
@@ -390,10 +392,12 @@ func buildCtldDaemonSet(cfg ctldDaemonSetConfig) *appsv1.DaemonSet {
 		labels[key] = value
 	}
 	labels[dataplane.CtldHASlotLabel] = cfg.Slot
+	haMetricsPort := ctldHAMetricsPort(cfg.Slot)
 	args := append([]string(nil), cfg.Args...)
 	args = append(args,
 		"-ha-slot="+cfg.Slot,
 		"-ha-probe-socket="+ctldHAProbeSocket,
+		fmt.Sprintf("-ha-metrics-addr=:%d", haMetricsPort),
 		"-kubelet-registration-socket="+ctldKubeletRegistrationSocket,
 		"-kubelet-registration-endpoint="+ctldKubeletCSIEndpoint,
 	)
@@ -451,6 +455,11 @@ func buildCtldDaemonSet(cfg ctldDaemonSetConfig) *appsv1.DaemonSet {
 		SecurityContext: &corev1.SecurityContext{Privileged: common.BoolPtr(true)},
 		Resources:       corev1.ResourceRequirements{Requests: requests},
 		VolumeMounts:    cfg.VolumeMounts,
+		Ports: []corev1.ContainerPort{{
+			Name:          "ha-metrics",
+			ContainerPort: haMetricsPort,
+			Protocol:      corev1.ProtocolTCP,
+		}},
 	}
 	if cfg.NetdEnabled {
 		ctldContainer.Env = append(ctldContainer.Env,
@@ -487,6 +496,13 @@ func buildCtldDaemonSet(cfg ctldDaemonSetConfig) *appsv1.DaemonSet {
 			},
 		},
 	}
+}
+
+func ctldHAMetricsPort(slot string) int32 {
+	if slot == dataplane.CtldHASlotB {
+		return ctldHAMetricsPortB
+	}
+	return ctldHAMetricsPortA
 }
 
 func appendUniqueVolumes(existing []corev1.Volume, additions ...corev1.Volume) []corev1.Volume {

--- a/infra-operator/internal/controller/services/ctld/ctld_test.go
+++ b/infra-operator/internal/controller/services/ctld/ctld_test.go
@@ -2,6 +2,7 @@ package ctld
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -83,11 +84,8 @@ func TestReconcileConfiguresNetworkRuntimeInBothHASlots(t *testing.T) {
 			t.Fatalf("%s embedded memory request = %s, want 384Mi", ds.Name, got.String())
 		}
 	}
-	for _, ds := range []*appsv1.DaemonSet{primary, standby} {
-		if len(ds.Spec.Template.Spec.Containers[0].Ports) != 0 {
-			t.Fatalf("%s reserves host-network runtime ports: %#v", ds.Name, ds.Spec.Template.Spec.Containers[0].Ports)
-		}
-	}
+	assertHAMetricsEndpoint(t, primary.Spec.Template.Spec.Containers[0], dataplane.CtldHASlotA, ctldHAMetricsPortA)
+	assertHAMetricsEndpoint(t, standby.Spec.Template.Spec.Containers[0], dataplane.CtldHASlotB, ctldHAMetricsPortB)
 	metricsService := &corev1.Service{}
 	if err := client.Get(context.Background(), types.NamespacedName{Name: infra.Name + networkMetricsServiceSuffix, Namespace: infra.Namespace}, metricsService); err != nil {
 		t.Fatalf("get ctld network metrics service: %v", err)
@@ -478,11 +476,8 @@ func reconcileCtldResources(t *testing.T, infra *infrav1alpha1.Sandbox0Infra, ex
 	if ds.Spec.Template.Labels[dataplane.CtldHASlotLabel] != dataplane.CtldHASlotA || standby.Spec.Template.Labels[dataplane.CtldHASlotLabel] != dataplane.CtldHASlotB {
 		t.Fatalf("unexpected ctld HA slot labels: slot A=%q slot B=%q", ds.Spec.Template.Labels[dataplane.CtldHASlotLabel], standby.Spec.Template.Labels[dataplane.CtldHASlotLabel])
 	}
-	for _, workload := range []*appsv1.DaemonSet{ds, standby} {
-		if !infrav1alpha1.IsNetworkEnabled(infra) && len(workload.Spec.Template.Spec.Containers[0].Ports) != 0 {
-			t.Fatalf("ctld hostNetwork pod %s reserves node ports: %#v", workload.Name, workload.Spec.Template.Spec.Containers[0].Ports)
-		}
-	}
+	assertHAMetricsEndpoint(t, ds.Spec.Template.Spec.Containers[0], dataplane.CtldHASlotA, ctldHAMetricsPortA)
+	assertHAMetricsEndpoint(t, standby.Spec.Template.Spec.Containers[0], dataplane.CtldHASlotB, ctldHAMetricsPortB)
 	assertCtldRollingUpdate(t, ds, 1, 0)
 	assertCtldRollingUpdate(t, standby, 1, 0)
 	if len(ds.Spec.Template.Spec.Containers[0].VolumeMounts) < 7 {
@@ -801,6 +796,18 @@ func assertContainsArg(t *testing.T, args []string, want string) {
 		}
 	}
 	t.Fatalf("expected args to contain %q, got %#v", want, args)
+}
+
+func assertHAMetricsEndpoint(t *testing.T, container corev1.Container, slot string, port int32) {
+	t.Helper()
+	assertContainsArg(t, container.Args, "-ha-metrics-addr=:"+fmt.Sprint(port))
+	if len(container.Ports) != 1 {
+		t.Fatalf("ctld slot %s ports = %#v, want one HA metrics port", slot, container.Ports)
+	}
+	got := container.Ports[0]
+	if got.Name != "ha-metrics" || got.ContainerPort != port || got.Protocol != corev1.ProtocolTCP || got.HostPort != 0 {
+		t.Fatalf("ctld slot %s HA metrics port = %#v, want named container port %d without hostPort", slot, got, port)
+	}
 }
 
 func assertNotContainsArgPrefix(t *testing.T, args []string, prefix string) {


### PR DESCRIPTION
## Summary

- expose HA election state from both ctld slots on dedicated pre-election metrics ports
- report per-node role, epoch, synchronization, standby count, transition counters, state duration, and lock identity
- configure slot A on 9192 and slot B on 9193, with operator coverage and self-hosted observability docs

## Why

The existing primary-only metrics endpoint disappears with the active process and cannot distinguish healthy per-node primaries from a same-node split-brain condition. Keeping the HA endpoint independent from the elected runtime makes both slots observable throughout failover.

## Validation

- `go test ./ctld/internal/ctld/ha ./ctld/cmd/ctld ./infra-operator/internal/controller/services/ctld`
- `go test -race ./ctld/internal/ctld/ha ./ctld/cmd/ctld ./infra-operator/internal/controller/services/ctld`
- `go vet ./ctld/internal/ctld/ha ./ctld/cmd/ctld ./infra-operator/internal/controller/services/ctld`
- `go test ./ctld/... ./infra-operator/...`
- `helm lint infra-operator/chart`
- two-node kind canary: exactly one primary per node, matching epoch and lock identity across A/B
- deleted the active ctld slot on a node hosting a sandbox: peer took over (epoch 4 -> 5), recreated slot returned as standby, sandbox UID stayed stable and restart count remained 0

## Follow-up

A separate infrastructure PR will add discovery/scraping and alerts for these ports. This PR only adds the component signal and operator wiring.