### PR TITLE
Fix rootfs GC layer scan

### DIFF
--- a/manager/pkg/service/rootfs_persistent_filesystem.go
+++ b/manager/pkg/service/rootfs_persistent_filesystem.go
@@ -997,12 +997,14 @@ func (s *PGSandboxStore) collectUnreferencedRootFSLayers(ctx context.Context, te
 				l.runtime_generation, l.runtime, l.runtime_handler, l.base_image_ref,
 				l.base_image_digest, l.snapshotter, l.snapshot_parent,
 				l.snapshot_parent_chain, l.diff_digest, l.diff_id, l.diff_media_type,
-				l.diff_size, l.diff_object_key, l.created_at
+				l.diff_size, l.diff_object_key, l.platform_os, l.platform_architecture,
+				l.platform_variant, l.created_at
 		)
 		SELECT layer_id, parent_layer_id, source_sandbox_id, team_id, runtime_generation,
 			runtime, runtime_handler, base_image_ref, base_image_digest, snapshotter,
 			snapshot_parent, snapshot_parent_chain, diff_digest, diff_id, diff_media_type,
-			diff_size, diff_object_key, created_at
+			diff_size, diff_object_key, platform_os, platform_architecture,
+			platform_variant, created_at
 		FROM deleted
 		ORDER BY created_at ASC
 	`, strings.TrimSpace(teamID), limit)

--- a/manager/pkg/service/rootfs_persistent_filesystem_integration_test.go
+++ b/manager/pkg/service/rootfs_persistent_filesystem_integration_test.go
@@ -20,7 +20,11 @@ func TestRootFSFilesystemPersistenceIntegration(t *testing.T) {
 
 	require.NoError(t, store.UpsertSandbox(ctx, rootFSTestSandboxRecord("sandbox-source", "team-1")))
 	require.NoError(t, store.SaveRootFSState(ctx, rootFSTestStoreState("sandbox-source", "team-1", "layer-root", "", 1, "root")))
-	require.NoError(t, store.SaveRootFSState(ctx, rootFSTestStoreState("sandbox-source", "team-1", "layer-child", "layer-root", 2, "child")))
+	childState := rootFSTestStoreState("sandbox-source", "team-1", "layer-child", "layer-root", 2, "child")
+	childState.PlatformOS = "linux"
+	childState.PlatformArchitecture = "arm64"
+	childState.PlatformVariant = "v8"
+	require.NoError(t, store.SaveRootFSState(ctx, childState))
 
 	latest, err := store.GetLatestRootFSState(ctx, "sandbox-source")
 	require.NoError(t, err)
@@ -52,6 +56,9 @@ func TestRootFSFilesystemPersistenceIntegration(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, gcResult.Layers, 1)
 	assert.Equal(t, "layer-child", gcResult.Layers[0].ID)
+	assert.Equal(t, "linux", gcResult.Layers[0].PlatformOS)
+	assert.Equal(t, "arm64", gcResult.Layers[0].PlatformArchitecture)
+	assert.Equal(t, "v8", gcResult.Layers[0].PlatformVariant)
 	assert.Equal(t, []string{"rootfs/child.tar"}, gcResult.DeletedObjectKeys)
 	gcResult, err = store.GarbageCollectRootFSFilesystem(ctx, deleter, "team-1", 10)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- return rootfs platform columns from the GC delete query so it matches the shared 21-field scanner
- verify GC preserves platform metadata in PostgreSQL integration coverage

## Production impact

- stops manager rootfs maintenance from failing every minute with `number of field descriptions must equal number of destinations, got 18 and 21`
- restores unreferenced rootfs layer and object cleanup

## Verification

- `go test ./manager/...`
- `go vet ./manager/...`
- `INTEGRATION_DATABASE_URL=... go test ./manager/pkg/service -run "^TestRootFS" -count=1 -v`