### PR TITLE
fix(manager): retry transient deletion webhooks

### DIFF
--- a/manager/pkg/service/sandbox_webhook_state.go
+++ b/manager/pkg/service/sandbox_webhook_state.go
@@ -21,8 +21,10 @@ import (
 )
 
 const (
-	webhookStateMountPoint = volumeportal.WebhookStateMountPath
-	webhookStateVolumeKind = "webhook-state"
+	webhookStateMountPoint           = volumeportal.WebhookStateMountPath
+	webhookStateVolumeKind           = "webhook-state"
+	deletionWebhookMaxAttempts       = 3
+	deletionWebhookRetryInitialDelay = 100 * time.Millisecond
 )
 
 var ErrVolumePortalBindConflict = errors.New("volume portal bind conflict")
@@ -457,23 +459,49 @@ func (e *HTTPSandboxDeletionWebhookEmitter) EmitSandboxDeleted(ctx context.Conte
 	if err != nil {
 		return err
 	}
+	var lastErr error
+	for attempt := 0; attempt < deletionWebhookMaxAttempts; attempt++ {
+		retryable, err := e.postSandboxDeleted(ctx, url, info.WebhookSecret, body)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !retryable || attempt == deletionWebhookMaxAttempts-1 {
+			return err
+		}
+		delay := deletionWebhookRetryInitialDelay << attempt
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+	return lastErr
+}
+
+func (e *HTTPSandboxDeletionWebhookEmitter) postSandboxDeleted(ctx context.Context, url, secret string, body []byte) (bool, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
-		return err
+		return false, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	if info.WebhookSecret != "" {
-		req.Header.Set("X-Sandbox0-Signature", signWebhookPayload(info.WebhookSecret, body))
+	if secret != "" {
+		req.Header.Set("X-Sandbox0-Signature", signWebhookPayload(secret, body))
 	}
 	resp, err := e.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("emit sandbox.deleted webhook: %w", err)
+		retryable := ctx.Err() == nil && !errors.Is(err, context.DeadlineExceeded)
+		return retryable, fmt.Errorf("emit sandbox.deleted webhook: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("emit sandbox.deleted webhook failed with status %d", resp.StatusCode)
+		retryable := resp.StatusCode == http.StatusRequestTimeout ||
+			resp.StatusCode == http.StatusTooEarly ||
+			resp.StatusCode == http.StatusTooManyRequests ||
+			resp.StatusCode >= http.StatusInternalServerError
+		return retryable, fmt.Errorf("emit sandbox.deleted webhook failed with status %d", resp.StatusCode)
 	}
-	return nil
+	return false, nil
 }
 
 func signWebhookPayload(secret string, payload []byte) string {

--- a/manager/pkg/service/sandbox_webhook_state_test.go
+++ b/manager/pkg/service/sandbox_webhook_state_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
+	"sync"
 	"testing"
 
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
@@ -70,6 +73,72 @@ func TestPrepareWebhookStateVolumeReusesDurableVolume(t *testing.T) {
 	}
 	if len(volumeClient.created) != 0 {
 		t.Fatalf("created volumes = %#v, want none", volumeClient.created)
+	}
+}
+
+func TestHTTPSandboxDeletionWebhookEmitterRetriesTransientFailure(t *testing.T) {
+	var mu sync.Mutex
+	var bodies [][]byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+			http.Error(w, "read request", http.StatusInternalServerError)
+			return
+		}
+		mu.Lock()
+		bodies = append(bodies, body)
+		attempt := len(bodies)
+		mu.Unlock()
+		if attempt < deletionWebhookMaxAttempts {
+			http.Error(w, "try again", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	emitter := NewHTTPSandboxDeletionWebhookEmitter(server.Client())
+	err := emitter.EmitSandboxDeleted(t.Context(), SandboxLifecycleInfo{
+		SandboxID:     "sandbox-1",
+		TeamID:        "team-1",
+		WebhookURL:    server.URL,
+		WebhookSecret: "secret",
+	})
+	if err != nil {
+		t.Fatalf("EmitSandboxDeleted() error = %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(bodies) != deletionWebhookMaxAttempts {
+		t.Fatalf("request count = %d, want %d", len(bodies), deletionWebhookMaxAttempts)
+	}
+	for i := 1; i < len(bodies); i++ {
+		if !slices.Equal(bodies[0], bodies[i]) {
+			t.Fatalf("retry body %d differs from the first attempt", i+1)
+		}
+	}
+}
+
+func TestHTTPSandboxDeletionWebhookEmitterDoesNotRetryPermanentFailure(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		http.Error(w, "invalid", http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	emitter := NewHTTPSandboxDeletionWebhookEmitter(server.Client())
+	err := emitter.EmitSandboxDeleted(t.Context(), SandboxLifecycleInfo{
+		SandboxID:  "sandbox-1",
+		TeamID:     "team-1",
+		WebhookURL: server.URL,
+	})
+	if err == nil {
+		t.Fatal("EmitSandboxDeleted() error = nil, want permanent failure")
+	}
+	if calls != 1 {
+		t.Fatalf("request count = %d, want 1", calls)
 	}
 }
 

--- a/manager/procd/pkg/process/process.go
+++ b/manager/procd/pkg/process/process.go
@@ -535,7 +535,7 @@ func (bp *BaseProcess) closeInput(timeout time.Duration) error {
 			bp.input = nil
 		}
 		bp.mu.Unlock()
-		return input.Close()
+		return closeInputStream(input)
 	default:
 	}
 	timer := time.NewTimer(timeout)
@@ -570,7 +570,7 @@ func (bp *BaseProcess) forceCloseInput() error {
 	if input == nil {
 		return nil
 	}
-	return input.Close()
+	return closeInputStream(input)
 }
 
 // ResizePTY resizes the attached PTY, if present.
@@ -684,12 +684,20 @@ func (bp *BaseProcess) startInputWriter(input io.WriteCloser) {
 }
 
 func (bp *BaseProcess) closeInputWriter(input io.WriteCloser) error {
-	err := input.Close()
+	err := closeInputStream(input)
 	bp.mu.Lock()
 	if bp.input == input {
 		bp.input = nil
 	}
 	bp.mu.Unlock()
+	return err
+}
+
+func closeInputStream(input io.WriteCloser) error {
+	err := input.Close()
+	if errors.Is(err, os.ErrClosed) || errors.Is(err, io.ErrClosedPipe) {
+		return nil
+	}
 	return err
 }
 

--- a/manager/procd/pkg/process/process_test.go
+++ b/manager/procd/pkg/process/process_test.go
@@ -533,6 +533,24 @@ func TestBaseProcess_CloseInputBeforeReadyIsBounded(t *testing.T) {
 	}
 }
 
+func TestBaseProcess_CloseInputAfterProcessCleanupIsIdempotent(t *testing.T) {
+	bp := NewBaseProcess("finished", ProcessTypeCMD, ProcessConfig{Type: ProcessTypeCMD})
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	bp.SetInput(w)
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	bp.stopInputWriter()
+	if err := bp.CloseInput(); err != nil {
+		t.Fatalf("CloseInput() after process cleanup error = %v, want nil", err)
+	}
+}
+
 // BenchmarkBaseProcess_StateRead benchmarks concurrent state reading.
 func BenchmarkBaseProcess_StateRead(b *testing.B) {
 	config := ProcessConfig{

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -674,6 +674,12 @@ data:
         def do_POST(self):
             length = int(self.headers.get("content-length", "0"))
             body = self.rfile.read(length)
+            reject_delete_once = Path("/data/reject-delete-once")
+            if b'"event_type":"sandbox.deleted"' in body and not reject_delete_once.exists():
+                reject_delete_once.touch()
+                self.send_response(503)
+                self.end_headers()
+                return
             with events.open("ab") as f:
                 f.write(body + b"\n")
             self.send_response(204)

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -551,12 +551,16 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 	})
 }
 
-func runTemplateLifecycleAssertions(env *framework.ScenarioEnv, session *e2eutils.Session, templateNamePrefix string) {
-	templates, err := session.ListTemplates(env.TestCtx.Context, GinkgoT())
+func getDefaultTemplate(env *framework.ScenarioEnv, session *e2eutils.Session) apispec.Template {
+	GinkgoHelper()
+	template, err := session.GetTemplate(env.TestCtx.Context, GinkgoT(), "default")
 	Expect(err).NotTo(HaveOccurred())
-	Expect(templates).NotTo(BeEmpty())
+	Expect(template).NotTo(BeNil())
+	return *template
+}
 
-	base := templates[0]
+func runTemplateLifecycleAssertions(env *framework.ScenarioEnv, session *e2eutils.Session, templateNamePrefix string) {
+	base := getDefaultTemplate(env, session)
 	name := fmt.Sprintf("%s-%d", templateNamePrefix, time.Now().UnixNano())
 	newTemplate := e2eutils.CloneTemplateForCreate(base, name)
 
@@ -771,12 +775,7 @@ func readWebhookReceiverEvents(env *framework.ScenarioEnv, name string) string {
 }
 
 func assertTemplateStatusCountersEventually(env *framework.ScenarioEnv, session *e2eutils.Session) {
-	templates, err := session.ListTemplates(env.TestCtx.Context, GinkgoT())
-	Expect(err).NotTo(HaveOccurred())
-	Expect(templates).NotTo(BeEmpty())
-
-	templateID := templates[0].TemplateId
-	Expect(templateID).NotTo(BeEmpty())
+	templateID := getDefaultTemplate(env, session).TemplateId
 
 	Eventually(func() error {
 		tpl, getErr := session.GetTemplate(env.TestCtx.Context, GinkgoT(), templateID)
@@ -803,12 +802,8 @@ func assertTemplateStatusCountersEventually(env *framework.ScenarioEnv, session 
 }
 
 func assertTemplatePoolReadinessGate(env *framework.ScenarioEnv, session *e2eutils.Session, templateNamePrefix string) {
-	templates, err := session.ListTemplates(env.TestCtx.Context, GinkgoT())
-	Expect(err).NotTo(HaveOccurred())
-	Expect(templates).NotTo(BeEmpty())
-
 	name := fmt.Sprintf("%s-ready-gate-%d", templateNamePrefix, time.Now().UnixNano())
-	templateReq := e2eutils.CloneTemplateForCreate(templates[0], name)
+	templateReq := e2eutils.CloneTemplateForCreate(getDefaultTemplate(env, session), name)
 	Expect(templateReq.Spec.Pool).NotTo(BeNil())
 	Expect(templateReq.Spec.MainContainer).NotTo(BeNil())
 	templateReq.Spec.MainContainer.Resources = apispec.ResourceQuota{
@@ -880,12 +875,8 @@ func assertTemplatePoolReadinessGate(env *framework.ScenarioEnv, session *e2euti
 }
 
 func assertTemplateRolloutClaimFallsBackToColdStart(env *framework.ScenarioEnv, session *e2eutils.Session, templateNamePrefix string) {
-	templates, err := session.ListTemplates(env.TestCtx.Context, GinkgoT())
-	Expect(err).NotTo(HaveOccurred())
-	Expect(templates).NotTo(BeEmpty())
-
 	name := fmt.Sprintf("%s-rc-%d", templateNamePrefix, time.Now().UnixNano()%1_000_000_000)
-	templateReq := e2eutils.CloneTemplateForCreate(templates[0], name)
+	templateReq := e2eutils.CloneTemplateForCreate(getDefaultTemplate(env, session), name)
 	Expect(templateReq.Spec.Pool).NotTo(BeNil())
 	Expect(templateReq.Spec.MainContainer).NotTo(BeNil())
 	templateReq.Spec.MainContainer.Resources = apispec.ResourceQuota{
@@ -1033,12 +1024,8 @@ func podHasCondition(pod e2ePod, conditionType, status string) bool {
 }
 
 func assertTemplateNamespaceIngressBaselineLifecycle(env *framework.ScenarioEnv, session *e2eutils.Session, templateNamePrefix string) {
-	templates, err := session.ListTemplates(env.TestCtx.Context, GinkgoT())
-	Expect(err).NotTo(HaveOccurred())
-	Expect(templates).NotTo(BeEmpty())
-
 	name := fmt.Sprintf("%s-baseline-%d", templateNamePrefix, time.Now().UnixNano())
-	templateReq := e2eutils.CloneTemplateForCreate(templates[0], name)
+	templateReq := e2eutils.CloneTemplateForCreate(getDefaultTemplate(env, session), name)
 
 	created, err := session.CreateTemplate(env.TestCtx.Context, GinkgoT(), templateReq)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary

- retry manager-owned `sandbox.deleted` delivery on transient HTTP and transport failures
- keep the event body and stable event ID identical across attempts
- keep permanent 4xx failures single-shot so sandbox deletion is not held by invalid webhook configuration
- make the lifecycle E2E receiver reject the first deletion event so retry coverage is deterministic
- use the built-in `default` template for template lifecycle tests instead of the nondeterministic first list result
- make process stdin close idempotent when EOF races with child-process cleanup

## Root causes

The full E2E lifecycle test deletes a claimed Pod directly and expects the manager finalizer to deliver `sandbox.deleted`. The manager HTTP emitter made exactly one request, while cleanup intentionally treats delivery errors as non-fatal and removes the finalizer. A transient request failure therefore became a permanent event loss. This reproduced on main runs 30798421719, 30757992232, and 30738554010.

After that failure was fixed, main run 30802336071 exposed an independent arm64 test instability. Template lifecycle helpers cloned `ListTemplates()[0]`; that run selected the `browser` template. A cold claim landed on another worker and pulled the 1.35 GB `steel-browser:latest` image for 32.69 seconds, exceeding the client timeout. The affected tests now explicitly clone `default`, whose fixture image is preloaded on every Kind node.

PR Quick Check run 30804790874 then exposed a process stdin close race. A child can consume the submitted line and exit while the queued EOF operation is closing the same pipe. Process cleanup had already closed the descriptor, so the valid EOF request occasionally surfaced `file already closed`. Closing an already closed stdin is now treated as the successful idempotent state it represents.

## Impact

Transient connection failures, HTTP 408/425/429 responses, and 5xx responses now receive three total attempts with short exponential backoff. Context cancellation, request timeout, and permanent HTTP failures remain bounded and do not indefinitely block Pod deletion.

Template lifecycle E2E coverage no longer depends on API list order, a heavyweight unrelated template, or which Kind worker already happens to cache its image. Explicit EOF is also stable when process exit and stdin cleanup happen concurrently.

## Validation

- `make proto`
- `go test ./manager/... -count=1`
- `go test ./tests/e2e/cases ./manager/pkg/service -count=1`
- `go test -race ./manager/pkg/service -run TestHTTPSandboxDeletionWebhookEmitter -count=1`
- `go test -race ./manager/procd/pkg/process ./manager/procd/pkg/session -count=1`
- `go test -race ./manager/procd/pkg/session -run TestSupervisorPipeInputReplayAndDeduplication -count=100`
- `git diff --check`