### PR TITLE
fix(manager): persist transient deletion webhook retries

### DIFF
--- a/manager/pkg/service/sandbox_lifecycle_controller.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller.go
@@ -397,9 +397,11 @@ func (s *SandboxService) cleanupDeletedSandbox(ctx context.Context, info Sandbox
 
 	var errs []error
 	if !runtimeOnly && s.deletionWebhookEmitter != nil && strings.TrimSpace(info.WebhookURL) != "" {
-		_ = s.runSandboxDeleteCleanupPhase(ctx, info, scope, "emit_deletion_webhook", func() error {
+		if err := s.runSandboxDeleteCleanupPhase(ctx, info, scope, "emit_deletion_webhook", func() error {
 			return s.deletionWebhookEmitter.EmitSandboxDeleted(ctx, info)
-		})
+		}); isRetryableSandboxDeletionWebhookError(err) {
+			errs = append(errs, fmt.Errorf("emit deletion webhook: %w", err))
+		}
 	}
 	if s.networkProvider != nil && info.Namespace != "" {
 		if err := s.runSandboxDeleteCleanupPhase(ctx, info, scope, "remove_network_policy", func() error {

--- a/manager/pkg/service/sandbox_lifecycle_controller_test.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller_test.go
@@ -414,6 +414,35 @@ func TestSandboxServiceCleanupDeletedSandboxDoesNotBlockOnDeletionWebhookFailure
 	}
 }
 
+func TestSandboxServiceCleanupDeletedSandboxRetriesAfterTransientWebhookFailure(t *testing.T) {
+	volumeClient := &recordingSystemVolumeClient{}
+	emitter := &recordingDeletionWebhookEmitter{err: &retryableSandboxDeletionWebhookError{err: errors.New("webhook unavailable")}}
+	svc := &SandboxService{
+		webhookStateVolumes:    volumeClient,
+		deletionWebhookEmitter: emitter,
+		logger:                 zap.NewNop(),
+	}
+
+	err := svc.CleanupDeletedSandbox(context.Background(), SandboxLifecycleInfo{
+		Namespace:            "ns-a",
+		PodName:              "sandbox-a",
+		SandboxID:            "sandbox-a",
+		TeamID:               "team-a",
+		UserID:               "user-a",
+		WebhookURL:           "https://example.test/webhook",
+		WebhookStateVolumeID: "volume-a",
+	})
+	if err == nil || !isRetryableSandboxDeletionWebhookError(err) {
+		t.Fatalf("CleanupDeletedSandbox() error = %v, want retryable webhook failure", err)
+	}
+	if len(emitter.calls) != 1 {
+		t.Fatalf("webhook calls = %d, want 1", len(emitter.calls))
+	}
+	if len(volumeClient.marked) != 1 || volumeClient.marked[0] != "sandbox-a:sandbox_deleted" {
+		t.Fatalf("marked volumes = %#v, want sandbox-a:sandbox_deleted", volumeClient.marked)
+	}
+}
+
 func TestSandboxServiceCleanupDeletedSandboxPreservesDurableStateForPausingRuntime(t *testing.T) {
 	removed := make([]string, 0, 1)
 	store := &deleteRecordingBindingStore{}

--- a/manager/pkg/service/sandbox_webhook_state.go
+++ b/manager/pkg/service/sandbox_webhook_state.go
@@ -433,6 +433,29 @@ type HTTPSandboxDeletionWebhookEmitter struct {
 	httpClient *http.Client
 }
 
+type retryableSandboxDeletionWebhookError struct {
+	err error
+}
+
+func (e *retryableSandboxDeletionWebhookError) Error() string {
+	if e == nil || e.err == nil {
+		return "sandbox deletion webhook delivery failed"
+	}
+	return e.err.Error()
+}
+
+func (e *retryableSandboxDeletionWebhookError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+func isRetryableSandboxDeletionWebhookError(err error) bool {
+	var retryableErr *retryableSandboxDeletionWebhookError
+	return errors.As(err, &retryableErr)
+}
+
 func NewHTTPSandboxDeletionWebhookEmitter(httpClient *http.Client) *HTTPSandboxDeletionWebhookEmitter {
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 10 * time.Second}
@@ -467,6 +490,9 @@ func (e *HTTPSandboxDeletionWebhookEmitter) EmitSandboxDeleted(ctx context.Conte
 		}
 		lastErr = err
 		if !retryable || attempt == deletionWebhookMaxAttempts-1 {
+			if retryable {
+				return &retryableSandboxDeletionWebhookError{err: err}
+			}
 			return err
 		}
 		delay := deletionWebhookRetryInitialDelay << attempt
@@ -490,7 +516,9 @@ func (e *HTTPSandboxDeletionWebhookEmitter) postSandboxDeleted(ctx context.Conte
 	}
 	resp, err := e.httpClient.Do(req)
 	if err != nil {
-		retryable := ctx.Err() == nil && !errors.Is(err, context.DeadlineExceeded)
+		// A client-level timeout is transient as long as the lifecycle
+		// controller context itself is still active.
+		retryable := ctx.Err() == nil
 		return retryable, fmt.Errorf("emit sandbox.deleted webhook: %w", err)
 	}
 	defer resp.Body.Close()

--- a/manager/pkg/service/sandbox_webhook_state_test.go
+++ b/manager/pkg/service/sandbox_webhook_state_test.go
@@ -15,6 +15,12 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 )
 
+type webhookRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f webhookRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
 func TestManagerStorageVolumeClientDefaultsClusterID(t *testing.T) {
 	var gotClusterID string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -139,6 +145,56 @@ func TestHTTPSandboxDeletionWebhookEmitterDoesNotRetryPermanentFailure(t *testin
 	}
 	if calls != 1 {
 		t.Fatalf("request count = %d, want 1", calls)
+	}
+	if isRetryableSandboxDeletionWebhookError(err) {
+		t.Fatalf("EmitSandboxDeleted() error = %v, want permanent failure", err)
+	}
+}
+
+func TestHTTPSandboxDeletionWebhookEmitterClassifiesExhaustedTransientFailure(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		http.Error(w, "try again", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	emitter := NewHTTPSandboxDeletionWebhookEmitter(server.Client())
+	err := emitter.EmitSandboxDeleted(t.Context(), SandboxLifecycleInfo{
+		SandboxID:  "sandbox-1",
+		TeamID:     "team-1",
+		WebhookURL: server.URL,
+	})
+	if err == nil {
+		t.Fatal("EmitSandboxDeleted() error = nil, want transient failure")
+	}
+	if !isRetryableSandboxDeletionWebhookError(err) {
+		t.Fatalf("EmitSandboxDeleted() error = %v, want retryable failure", err)
+	}
+	if calls != deletionWebhookMaxAttempts {
+		t.Fatalf("request count = %d, want %d", calls, deletionWebhookMaxAttempts)
+	}
+}
+
+func TestHTTPSandboxDeletionWebhookEmitterClassifiesClientTimeoutAsRetryable(t *testing.T) {
+	calls := 0
+	emitter := NewHTTPSandboxDeletionWebhookEmitter(&http.Client{Transport: webhookRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return nil, context.DeadlineExceeded
+	})})
+	err := emitter.EmitSandboxDeleted(t.Context(), SandboxLifecycleInfo{
+		SandboxID:  "sandbox-1",
+		TeamID:     "team-1",
+		WebhookURL: "https://example.test/webhook",
+	})
+	if err == nil {
+		t.Fatal("EmitSandboxDeleted() error = nil, want timeout")
+	}
+	if !isRetryableSandboxDeletionWebhookError(err) {
+		t.Fatalf("EmitSandboxDeleted() error = %v, want retryable failure", err)
+	}
+	if calls != deletionWebhookMaxAttempts {
+		t.Fatalf("request count = %d, want %d", calls, deletionWebhookMaxAttempts)
 	}
 }
 

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -663,7 +663,7 @@ metadata:
   namespace: %[2]s
 data:
   server.py: |
-    from http.server import BaseHTTPRequestHandler, HTTPServer
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
     from pathlib import Path
 
     events = Path("/data/events.jsonl")
@@ -673,6 +673,14 @@ data:
     class Handler(BaseHTTPRequestHandler):
         deleted_requests = 0
 
+        def respond(self, status):
+            self.send_response(status)
+            self.send_header("Content-Length", "0")
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.flush()
+            self.close_connection = True
+
         def do_POST(self):
             length = int(self.headers.get("content-length", "0"))
             body = self.rfile.read(length)
@@ -681,18 +689,16 @@ data:
                 with delete_attempts.open("ab") as f:
                     f.write(body + b"\n")
                 if Handler.deleted_requests <= %[3]d:
-                    self.send_response(503)
-                    self.end_headers()
+                    self.respond(503)
                     return
             with events.open("ab") as f:
                 f.write(body + b"\n")
-            self.send_response(204)
-            self.end_headers()
+            self.respond(204)
 
         def log_message(self, fmt, *args):
             return
 
-    HTTPServer(("0.0.0.0", 8080), Handler).serve_forever()
+    ThreadingHTTPServer(("0.0.0.0", 8080), Handler).serve_forever()
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -592,7 +592,8 @@ func runTemplateLifecycleAssertions(env *framework.ScenarioEnv, session *e2eutil
 
 func assertSandboxWebhookDurabilityLifecycle(env *framework.ScenarioEnv, session *e2eutils.Session) {
 	receiverName := "sandbox0-e2e-webhook"
-	cleanup := setupWebhookReceiver(env, receiverName)
+	const rejectedDeletionAttempts = 3
+	cleanup := setupWebhookReceiver(env, receiverName, rejectedDeletionAttempts)
 	defer cleanup()
 
 	webhookURL := fmt.Sprintf("http://%s.%s.svc.cluster.local:8080/events", receiverName, env.Infra.Namespace)
@@ -638,16 +639,7 @@ func assertSandboxWebhookDurabilityLifecycle(env *framework.ScenarioEnv, session
 		return nil
 	}).WithTimeout(90 * time.Second).WithPolling(3 * time.Second).Should(Succeed())
 
-	Expect(framework.Kubectl(
-		env.TestCtx.Context,
-		env.Config.Kubeconfig,
-		"delete",
-		"pod",
-		claimResp.PodName,
-		"--namespace",
-		sandboxNamespace,
-		"--wait=true",
-	)).To(Succeed())
+	Expect(session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)).To(Succeed())
 	sandboxID = ""
 
 	Eventually(func() error {
@@ -657,9 +649,12 @@ func assertSandboxWebhookDurabilityLifecycle(env *framework.ScenarioEnv, session
 		}
 		return nil
 	}).WithTimeout(90 * time.Second).WithPolling(3 * time.Second).Should(Succeed())
+
+	attempts := readWebhookReceiverFile(env, receiverName, "delete-attempts.jsonl")
+	Expect(strings.Count(attempts, `"event_type":"sandbox.deleted"`)).To(BeNumerically(">=", rejectedDeletionAttempts+1))
 }
 
-func setupWebhookReceiver(env *framework.ScenarioEnv, name string) func() {
+func setupWebhookReceiver(env *framework.ScenarioEnv, name string, rejectedDeletionAttempts int) func() {
 	manifest := fmt.Sprintf(`
 apiVersion: v1
 kind: ConfigMap
@@ -672,18 +667,23 @@ data:
     from pathlib import Path
 
     events = Path("/data/events.jsonl")
+    delete_attempts = Path("/data/delete-attempts.jsonl")
     events.parent.mkdir(parents=True, exist_ok=True)
 
     class Handler(BaseHTTPRequestHandler):
+        deleted_requests = 0
+
         def do_POST(self):
             length = int(self.headers.get("content-length", "0"))
             body = self.rfile.read(length)
-            reject_delete_once = Path("/data/reject-delete-once")
-            if b'"event_type":"sandbox.deleted"' in body and not reject_delete_once.exists():
-                reject_delete_once.touch()
-                self.send_response(503)
-                self.end_headers()
-                return
+            if b'"event_type":"sandbox.deleted"' in body:
+                Handler.deleted_requests += 1
+                with delete_attempts.open("ab") as f:
+                    f.write(body + b"\n")
+                if Handler.deleted_requests <= %[3]d:
+                    self.send_response(503)
+                    self.end_headers()
+                    return
             with events.open("ab") as f:
                 f.write(body + b"\n")
             self.send_response(204)
@@ -741,7 +741,7 @@ spec:
     - name: http
       port: 8080
       targetPort: 8080
-`, name, env.Infra.Namespace)
+`, name, env.Infra.Namespace, rejectedDeletionAttempts)
 	Expect(framework.ApplyManifestContent(env.TestCtx.Context, env.Config.Kubeconfig, "sandbox0-e2e-webhook-", manifest)).To(Succeed())
 	Expect(framework.WaitForDeployment(env.TestCtx.Context, env.Config.Kubeconfig, env.Infra.Namespace, name, "3m")).To(Succeed())
 	return func() {
@@ -752,6 +752,10 @@ spec:
 }
 
 func readWebhookReceiverEvents(env *framework.ScenarioEnv, name string) string {
+	return readWebhookReceiverFile(env, name, "events.jsonl")
+}
+
+func readWebhookReceiverFile(env *framework.ScenarioEnv, name, filename string) string {
 	podName, err := framework.KubectlGetJSONPath(
 		env.TestCtx.Context,
 		env.Config.Kubeconfig,
@@ -768,7 +772,7 @@ func readWebhookReceiverEvents(env *framework.ScenarioEnv, name string) string {
 		strings.TrimSpace(podName),
 		"sh",
 		"-c",
-		"cat /data/events.jsonl 2>/dev/null || true",
+		"cat /data/"+filename+" 2>/dev/null || true",
 	)
 	Expect(err).NotTo(HaveOccurred())
 	return output


### PR DESCRIPTION
## Summary
- classify client-level deletion webhook timeouts as transient
- retain the sandbox cleanup finalizer after exhausted transient delivery attempts so the lifecycle controller retries
- keep permanent webhook failures non-blocking
- make the full E2E exercise the public sandbox deletion API and require a controller-level retry after three forced 503 responses

## Validation
- go test ./manager/pkg/service -count=1
- go test -race ./manager/pkg/service -count=1
- go test ./tests/e2e/cases -count=1
- git diff --check