### PR TITLE
fix(manager): reconcile missing sandbox runtimes

### DIFF
--- a/.github/actions/prepare-infra/action.yml
+++ b/.github/actions/prepare-infra/action.yml
@@ -232,7 +232,18 @@ runs:
         archive="${RUNNER_TEMP}/infra-image-cache/infra-image-e2e-openssh-server-68b605929e83.tar"
         source="lscr.io/linuxserver/openssh-server@sha256:68b605929e83b2efe000da09269688f6d82a44579e8a18e2d9e8c8d272917cf7"
         image="sandbox0ai/e2e-openssh-server:68b605929e83"
-        docker pull "${source}"
+        for attempt in 1 2 3; do
+          if docker pull "${source}"; then
+            break
+          fi
+          if (( attempt == 3 )); then
+            echo "Failed to pull SSH fixture image after ${attempt} attempts." >&2
+            exit 1
+          fi
+          delay=$((attempt * 5))
+          echo "Retrying SSH fixture image pull in ${delay}s (attempt ${attempt}/3 failed)."
+          sleep "${delay}"
+        done
         docker tag "${source}" "${image}"
         docker save -o "${archive}" "${image}"
         docker image rm "${image}" "${source}" 2>/dev/null || true

--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -55,6 +55,8 @@ Sandbox0 uses the durable pause flow to replace a failed runtime.
 | `procd` exits unexpectedly, including OOM | Manager starts a non-cancelable recovery pause; ctld checkpoints the terminated containerd snapshot, then manager atomically commits the new rootfs head and paused state before deleting the old pod |
 | Runtime liveness failure is transient | The existing runtime is not replaced |
 | Runtime liveness fails continuously for 90 seconds | Manager starts the same durable pause flow and reconstructs the sandbox with a new `runtime_generation` |
+| Runtime Pod disappears, including while manager is restarting | Manager confirms the absence through the Kubernetes API and reconstructs the same sandbox identity from its last committed rootfs head. A periodic anti-entropy scan covers missed Pod events |
+| Kubernetes API is unavailable | Manager waits and retries; API unavailability is never treated as proof that a runtime is missing |
 | Runtime cannot produce a checkpoint within the bounded attempt | Recovery keeps the last committed rootfs head and replaces the stuck runtime |
 | Explicit delete or `hard_ttl` occurs | Deletion takes precedence over crash recovery |
 

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -444,6 +444,7 @@ func main() {
 
 	// Create services
 	cfgForSandbox := service.SandboxServiceConfig{
+		ClusterID:                           naming.ClusterIDOrDefault(&cfg.DefaultClusterId),
 		DefaultTTL:                          cfg.DefaultSandboxTTL.Duration,
 		SandboxMemoryPerCPU:                 cfg.TeamTemplateMemoryPerCPU,
 		SandboxMaxMemory:                    cfg.SandboxMaxMemory,
@@ -535,6 +536,14 @@ func main() {
 	sandboxService.SetPauseEnqueuer(sandboxPauseController)
 	sandboxCrashRecoveryController := service.NewSandboxCrashRecoveryController(k8sClient, podLister, sandboxService, logger)
 	podInformer.Informer().AddEventHandler(sandboxCrashRecoveryController.ResourceEventHandler())
+	sandboxRuntimeReconciler := service.NewSandboxRuntimeReconciler(
+		naming.ClusterIDOrDefault(&cfg.DefaultClusterId),
+		sandboxStore,
+		podLister,
+		sandboxService,
+		logger,
+	)
+	podInformer.Informer().AddEventHandler(sandboxRuntimeReconciler.ResourceEventHandler())
 	sandboxLogWorker := buildSandboxObservabilityLogWorker(cfg, internalAuthGen, obsProvider, logger)
 	staticAuth := make([]egressauthruntime.StaticAuthConfig, 0, len(cfg.EgressAuthStaticAuth))
 	for _, entry := range cfg.EgressAuthStaticAuth {
@@ -725,6 +734,11 @@ func main() {
 		go func() {
 			if err := sandboxCrashRecoveryController.Run(controllerCtx, 2); err != nil && !errors.Is(err, context.Canceled) {
 				logger.Error("Sandbox crash recovery controller failed", zap.Error(err))
+			}
+		}()
+		go func() {
+			if err := sandboxRuntimeReconciler.Run(controllerCtx, 2); err != nil && !errors.Is(err, context.Canceled) {
+				logger.Error("Sandbox runtime reconciler failed", zap.Error(err))
 			}
 		}()
 

--- a/manager/pkg/service/sandbox_lifecycle_controller.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller.go
@@ -492,30 +492,20 @@ func (s *SandboxService) runtimeDeletionDisposition(ctx context.Context, info Sa
 	return runtimeOnly, runtimeOnly && record != nil && record.Status == SandboxStatusPaused, nil
 }
 
-// SandboxRecordDeletionIsRuntimeOnly reports whether a runtime pod deletion should
-// be treated as pause/stale runtime cleanup instead of sandbox deletion.
-func SandboxRecordDeletionIsRuntimeOnly(record *SandboxRecord, namespace, podName string, runtimeGeneration int64) bool {
+// SandboxRecordDeletionIsRuntimeOnly reports whether Pod deletion is limited to
+// runtime-scoped cleanup. For a tracked sandbox, only durable
+// terminating/deleted intent authorizes sandbox-wide cleanup; untracked legacy
+// Pods retain the existing sandbox-wide cleanup behavior.
+func SandboxRecordDeletionIsRuntimeOnly(record *SandboxRecord, _ string, _ string, _ int64) bool {
 	if record == nil {
 		return false
 	}
 	switch record.Status {
-	case SandboxStatusPaused:
-		return true
-	case SandboxStatusDeleted:
+	case SandboxStatusTerminating, SandboxStatusDeleted:
 		return false
-	}
-	if runtimeGeneration > 0 && record.RuntimeGeneration > runtimeGeneration {
+	default:
 		return true
 	}
-	podName = strings.TrimSpace(podName)
-	namespace = strings.TrimSpace(namespace)
-	if podName != "" && strings.TrimSpace(record.CurrentPodName) != "" && record.CurrentPodName != podName {
-		return true
-	}
-	if namespace != "" && strings.TrimSpace(record.CurrentPodNamespace) != "" && record.CurrentPodNamespace != namespace {
-		return true
-	}
-	return false
 }
 
 func (s *SandboxService) unbindDeletedSandboxVolumePortals(ctx context.Context, info SandboxLifecycleInfo, retainHot bool) error {

--- a/manager/pkg/service/sandbox_pause_controller.go
+++ b/manager/pkg/service/sandbox_pause_controller.go
@@ -152,7 +152,7 @@ func (c *SandboxPauseController) enqueuePausingSandboxes(ctx context.Context) {
 }
 
 func sandboxLifecycleSourceReconstructsRuntime(source string) bool {
-	return source == SandboxLifecycleSourceCrash || source == SandboxLifecycleSourceHealth
+	return source == SandboxLifecycleSourceCrash || source == SandboxLifecycleSourceHealth || source == SandboxLifecycleSourceLost
 }
 
 func (c *SandboxPauseController) runWorker(ctx context.Context) {

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -42,11 +42,19 @@ type memorySandboxStoreTx struct {
 	store *memorySandboxStore
 }
 
+func (t memorySandboxStoreTx) SaveSandbox(_ context.Context, record *SandboxRecord) error {
+	return t.store.UpsertSandbox(context.Background(), record)
+}
+
 func (s *memorySandboxStore) UpsertSandbox(_ context.Context, record *SandboxRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.records == nil {
 		s.records = make(map[string]*SandboxRecord)
+	}
+	if existing := s.records[record.ID]; existing != nil &&
+		(existing.Status == SandboxStatusTerminating || existing.Status == SandboxStatusDeleted || !existing.DeletedAt.IsZero()) {
+		return nil
 	}
 	s.records[record.ID] = cloneSandboxRecord(record)
 	return nil
@@ -293,7 +301,7 @@ func (t memorySandboxStoreTx) SaveRuntime(_ context.Context, sandboxID, namespac
 	t.store.mu.Lock()
 	defer t.store.mu.Unlock()
 	record := t.store.records[sandboxID]
-	if record == nil || !record.DeletedAt.IsZero() {
+	if record == nil || record.Status == SandboxStatusTerminating || !record.DeletedAt.IsZero() {
 		return ErrSandboxRecordNotFound
 	}
 	record.CurrentPodNamespace = namespace
@@ -316,7 +324,7 @@ func (t memorySandboxStoreTx) MarkRuntimePaused(_ context.Context, sandboxID str
 	t.store.mu.Lock()
 	defer t.store.mu.Unlock()
 	record := t.store.records[sandboxID]
-	if record == nil || !record.DeletedAt.IsZero() {
+	if record == nil || record.Status == SandboxStatusTerminating || !record.DeletedAt.IsZero() {
 		return ErrSandboxRecordNotFound
 	}
 	record.CurrentPodNamespace = ""
@@ -326,6 +334,17 @@ func (t memorySandboxStoreTx) MarkRuntimePaused(_ context.Context, sandboxID str
 		record.RuntimeGeneration = generation
 	}
 	t.store.pauses++
+	return nil
+}
+
+func (t memorySandboxStoreTx) MarkRuntimeTerminating(_ context.Context, sandboxID string) error {
+	t.store.mu.Lock()
+	defer t.store.mu.Unlock()
+	record := t.store.records[sandboxID]
+	if record == nil || !record.DeletedAt.IsZero() {
+		return ErrSandboxRecordNotFound
+	}
+	record.Status = SandboxStatusTerminating
 	return nil
 }
 
@@ -1372,7 +1391,7 @@ func TestCompletePausingSandboxRuntimeAbortsCanceledAutoPause(t *testing.T) {
 	}
 }
 
-func TestResumePausedSandboxRuntimeDoesNotCreateRuntimeForRunningRecordWithoutPod(t *testing.T) {
+func TestResumePausedSandboxRuntimeStartsRecoveryForRunningRecordWithoutPod(t *testing.T) {
 	store := &memorySandboxStore{records: map[string]*SandboxRecord{
 		"sandbox-a": {
 			ID:                "sandbox-a",
@@ -1387,16 +1406,30 @@ func TestResumePausedSandboxRuntimeDoesNotCreateRuntimeForRunningRecordWithoutPo
 		},
 	}}
 	client := fake.NewSimpleClientset()
+	enqueuer := &recordingPauseEnqueuer{}
 	svc := &SandboxService{
-		k8sClient:    client,
-		podLister:    runtimeIdentityPodLister(t),
-		sandboxStore: store,
-		logger:       zap.NewNop(),
+		k8sClient:     client,
+		podLister:     runtimeIdentityPodLister(t),
+		sandboxStore:  store,
+		pauseEnqueuer: enqueuer,
+		logger:        zap.NewNop(),
 	}
 
-	_, err := svc.ResumePausedSandboxRuntime(context.Background(), "sandbox-a")
-	if !k8serrors.IsConflict(err) {
-		t.Fatalf("ResumePausedSandboxRuntime() error = %v, want conflict", err)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := svc.ResumePausedSandboxRuntime(ctx, "sandbox-a")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("ResumePausedSandboxRuntime() error = %v, want deadline while recovery remains queued", err)
+	}
+	txn, getErr := store.GetActiveLifecycleTxn(context.Background(), "sandbox-a")
+	if getErr != nil {
+		t.Fatalf("GetActiveLifecycleTxn() error = %v", getErr)
+	}
+	if txn == nil || txn.Kind != SandboxLifecycleKindPause || txn.Source != SandboxLifecycleSourceLost {
+		t.Fatalf("lifecycle txn = %+v, want lost-runtime pause", txn)
+	}
+	if len(enqueuer.recoveryCalls) != 1 || enqueuer.recoveryCalls[0] != "sandbox-a" {
+		t.Fatalf("recovery calls = %#v, want sandbox-a", enqueuer.recoveryCalls)
 	}
 	for _, action := range client.Actions() {
 		if action.GetVerb() == "create" && action.GetResource().Resource == "pods" {
@@ -1457,6 +1490,7 @@ func TestTerminatePausedSandboxRecordRunsPersistentCleanup(t *testing.T) {
 	volumes := &recordingSystemVolumeClient{}
 	emitter := &recordingDeletionWebhookEmitter{}
 	svc := &SandboxService{
+		k8sClient:              fake.NewSimpleClientset(),
 		podLister:              runtimeIdentityPodLister(t),
 		credentialStore:        bindings,
 		webhookStateVolumes:    volumes,

--- a/manager/pkg/service/sandbox_runtime_reconciler.go
+++ b/manager/pkg/service/sandbox_runtime_reconciler.go
@@ -1,0 +1,216 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+const (
+	defaultSandboxRuntimeReconcilePeriod   = 30 * time.Second
+	defaultSandboxRuntimeReconcilePageSize = 500
+)
+
+type sandboxRuntimeReconcileStore interface {
+	ListRuntimeReconcileCandidates(ctx context.Context, clusterID, afterSandboxID string, limit int) ([]SandboxRuntimeReconcileCandidate, error)
+}
+
+type sandboxRuntimeStateReconciler interface {
+	ReconcileSandboxRuntime(ctx context.Context, sandboxID string) error
+}
+
+// SandboxRuntimeReconciler repairs drift between durable sandbox intent and
+// the disposable Kubernetes runtime. Informer events are the fast path; the
+// paginated store scan supplies anti-entropy after missed events or restarts.
+type SandboxRuntimeReconciler struct {
+	clusterID    string
+	store        sandboxRuntimeReconcileStore
+	podLister    corelisters.PodLister
+	reconciler   sandboxRuntimeStateReconciler
+	logger       *zap.Logger
+	queue        workqueue.TypedRateLimitingInterface[string]
+	resyncPeriod time.Duration
+	pageSize     int
+}
+
+func NewSandboxRuntimeReconciler(
+	clusterID string,
+	store sandboxRuntimeReconcileStore,
+	podLister corelisters.PodLister,
+	reconciler sandboxRuntimeStateReconciler,
+	logger *zap.Logger,
+) *SandboxRuntimeReconciler {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &SandboxRuntimeReconciler{
+		clusterID:    strings.TrimSpace(clusterID),
+		store:        store,
+		podLister:    podLister,
+		reconciler:   reconciler,
+		logger:       logger,
+		queue:        workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+		resyncPeriod: defaultSandboxRuntimeReconcilePeriod,
+		pageSize:     defaultSandboxRuntimeReconcilePageSize,
+	}
+}
+
+func (c *SandboxRuntimeReconciler) ResourceEventHandler() cache.ResourceEventHandlerFuncs {
+	if c == nil {
+		return cache.ResourceEventHandlerFuncs{}
+	}
+	return cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(oldObj, newObj any) {
+			oldPod := extractPod(oldObj)
+			newPod := extractPod(newObj)
+			if newPod != nil && newPod.DeletionTimestamp != nil && (oldPod == nil || oldPod.DeletionTimestamp == nil) {
+				c.enqueuePod(newPod)
+			}
+		},
+		DeleteFunc: c.enqueuePod,
+	}
+}
+
+func (c *SandboxRuntimeReconciler) Run(ctx context.Context, workers int) error {
+	if c == nil {
+		return nil
+	}
+	if workers <= 0 {
+		workers = 1
+	}
+	if c.pageSize <= 0 {
+		c.pageSize = defaultSandboxRuntimeReconcilePageSize
+	}
+	if c.resyncPeriod <= 0 {
+		c.resyncPeriod = defaultSandboxRuntimeReconcilePeriod
+	}
+	defer runtime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	c.logger.Info("Starting sandbox runtime reconciler", zap.Int("workers", workers), zap.String("clusterID", c.clusterID))
+	c.enqueueDriftCandidates(ctx)
+	for i := 0; i < workers; i++ {
+		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
+	}
+
+	ticker := time.NewTicker(c.resyncPeriod)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			c.logger.Info("Sandbox runtime reconciler stopped")
+			return ctx.Err()
+		case <-ticker.C:
+			c.enqueueDriftCandidates(ctx)
+		}
+	}
+}
+
+func (c *SandboxRuntimeReconciler) enqueuePod(obj any) {
+	if c == nil || c.queue == nil {
+		return
+	}
+	pod := extractPod(obj)
+	if pod == nil || !sandboxRuntimePodOwnedBySandbox(pod) {
+		return
+	}
+	c.enqueueSandbox(sandboxIDFromPod(pod))
+}
+
+func (c *SandboxRuntimeReconciler) enqueueSandbox(sandboxID string) {
+	if c == nil || c.queue == nil {
+		return
+	}
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID != "" {
+		c.queue.Add(sandboxID)
+	}
+}
+
+func (c *SandboxRuntimeReconciler) enqueueDriftCandidates(ctx context.Context) {
+	if c == nil || c.store == nil {
+		return
+	}
+	afterSandboxID := ""
+	for {
+		candidates, err := c.store.ListRuntimeReconcileCandidates(ctx, c.clusterID, afterSandboxID, c.pageSize)
+		if err != nil {
+			c.logger.Warn("Failed to list sandbox runtime reconcile candidates", zap.Error(err))
+			return
+		}
+		for _, candidate := range candidates {
+			if c.candidateNeedsReconcile(candidate) {
+				c.enqueueSandbox(candidate.SandboxID)
+			}
+		}
+		if len(candidates) < c.pageSize {
+			return
+		}
+		next := strings.TrimSpace(candidates[len(candidates)-1].SandboxID)
+		if next == "" || next <= afterSandboxID {
+			c.logger.Error("Sandbox runtime reconcile pagination did not advance", zap.String("afterSandboxID", afterSandboxID), zap.String("nextSandboxID", next))
+			return
+		}
+		afterSandboxID = next
+	}
+}
+
+func (c *SandboxRuntimeReconciler) candidateNeedsReconcile(candidate SandboxRuntimeReconcileCandidate) bool {
+	if candidate.Status == SandboxStatusTerminating {
+		return true
+	}
+	if strings.TrimSpace(candidate.PodNamespace) == "" || strings.TrimSpace(candidate.PodName) == "" || c.podLister == nil {
+		return true
+	}
+	pod, err := c.podLister.Pods(candidate.PodNamespace).Get(candidate.PodName)
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			c.logger.Warn("Failed to inspect cached sandbox runtime", zap.String("sandboxID", candidate.SandboxID), zap.Error(err))
+		}
+		return true
+	}
+	return pod.DeletionTimestamp != nil ||
+		!sandboxRuntimePodOwnedBySandbox(pod) ||
+		sandboxIDFromPod(pod) != candidate.SandboxID ||
+		runtimeGenerationFromPod(pod) != candidate.RuntimeGeneration
+}
+
+func (c *SandboxRuntimeReconciler) runWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *SandboxRuntimeReconciler) processNextWorkItem(ctx context.Context) bool {
+	sandboxID, shutdown := c.queue.Get()
+	if shutdown {
+		return false
+	}
+	defer c.queue.Done(sandboxID)
+	if c.reconciler == nil {
+		c.queue.Forget(sandboxID)
+		return true
+	}
+	if err := c.reconciler.ReconcileSandboxRuntime(ctx, sandboxID); err != nil {
+		c.logger.Warn("Sandbox runtime reconcile failed, requeueing", zap.String("sandboxID", sandboxID), zap.Error(err))
+		c.queue.AddRateLimited(sandboxID)
+		return true
+	}
+	c.queue.Forget(sandboxID)
+	return true
+}
+
+func sandboxRuntimePodOwnedBySandbox(pod *corev1.Pod) bool {
+	return pod != nil && controller.IsClaimedSandboxPod(pod) && strings.TrimSpace(sandboxIDFromPod(pod)) != ""
+}
+
+var _ sandboxRuntimeStateReconciler = (*SandboxService)(nil)

--- a/manager/pkg/service/sandbox_runtime_recovery.go
+++ b/manager/pkg/service/sandbox_runtime_recovery.go
@@ -1,0 +1,400 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func runtimeReconcileConflict(sandboxID, message string) error {
+	return fmt.Errorf("sandbox %s runtime reconciliation conflict: %s", sandboxID, message)
+}
+
+// ReconcileSandboxRuntime repairs one durable-runtime mismatch. Absence is
+// confirmed through the Kubernetes API before any lifecycle state is changed;
+// an unavailable API is therefore never interpreted as a missing runtime.
+func (s *SandboxService) ReconcileSandboxRuntime(ctx context.Context, sandboxID string) error {
+	if s == nil || s.sandboxStore == nil {
+		return nil
+	}
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return nil
+	}
+	pods, err := s.listSandboxRuntimePodsStrong(ctx, sandboxID)
+	if err != nil {
+		return fmt.Errorf("confirm sandbox runtime state: %w", err)
+	}
+
+	var record *SandboxRecord
+	var stalePods []*corev1.Pod
+	var finishTermination bool
+	var enqueuePause bool
+	var enqueueRecovery bool
+	var cleanupLostRuntime bool
+	var resumeTxn *SandboxLifecycleTxn
+	err = s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, locked *SandboxRecord) error {
+		if locked == nil || locked.Status == SandboxStatusDeleted || !locked.DeletedAt.IsZero() || !s.sandboxRecordBelongsToCluster(locked) {
+			return nil
+		}
+		record = cloneSandboxRecordForLifecycle(locked)
+		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sandboxID)
+		if err != nil {
+			return err
+		}
+
+		if locked.Status == SandboxStatusTerminating || sandboxHardExpired(locked.HardExpiresAt, s.now()) {
+			if activeTxn != nil {
+				if err := tx.AbortLifecycleTxn(lockCtx, activeTxn.ID, "sandbox termination requested"); err != nil {
+					return err
+				}
+			}
+			if locked.Status != SandboxStatusTerminating {
+				if err := tx.MarkRuntimeTerminating(lockCtx, sandboxID); err != nil {
+					return err
+				}
+				record.Status = SandboxStatusTerminating
+			}
+			finishTermination = true
+			return nil
+		}
+
+		if activeTxn != nil {
+			switch activeTxn.Kind {
+			case SandboxLifecycleKindPause:
+				if sandboxLifecycleSourceReconstructsRuntime(activeTxn.Source) {
+					if activeTxn.Source == SandboxLifecycleSourceLost {
+						cleanupLostRuntime = true
+						for _, pod := range pods {
+							generation := runtimeGenerationFromPod(pod)
+							switch {
+							case generation > activeTxn.FromGeneration:
+								return runtimeReconcileConflict(sandboxID, "a newer runtime exists during lost-runtime recovery")
+							case generation == activeTxn.FromGeneration:
+								if activeTxn.FromPodName != "" &&
+									(pod.Name != activeTxn.FromPodName || pod.Namespace != activeTxn.FromPodNamespace) {
+									return runtimeReconcileConflict(sandboxID, "an unexpected runtime owns the lost generation")
+								}
+								cleanupLostRuntime = false
+							default:
+								stalePods = append(stalePods, pod)
+							}
+						}
+					}
+					enqueueRecovery = true
+				} else {
+					enqueuePause = true
+				}
+				return nil
+			case SandboxLifecycleKindResume:
+				resumeTxn = cloneSandboxLifecycleTxn(activeTxn)
+				return nil
+			case SandboxLifecycleKindFork, SandboxLifecycleKindSnapshot:
+				if sandboxSourceRuntimeTxnPodAvailable(activeTxn, pods) ||
+					!sandboxLifecycleRootFSSourceCheckpointTxnStale(activeTxn, s.now()) {
+					return nil
+				}
+				if err := tx.AbortLifecycleTxn(lockCtx, activeTxn.ID, "source runtime disappeared during lifecycle transaction"); err != nil {
+					return err
+				}
+			default:
+				return nil
+			}
+		}
+
+		if locked.Status == SandboxStatusPaused {
+			stalePods = append(stalePods, pods...)
+			return nil
+		}
+
+		activePods, deletingPods := splitSandboxRuntimePods(pods)
+		matching := matchingSandboxRuntimePods(locked, activePods)
+		if len(matching) > 1 {
+			return runtimeReconcileConflict(sandboxID, "multiple active pods match the durable runtime identity")
+		}
+		if len(matching) == 1 {
+			for _, pod := range activePods {
+				if pod.UID == matching[0].UID {
+					continue
+				}
+				if runtimeGenerationFromPod(pod) >= locked.RuntimeGeneration {
+					return runtimeReconcileConflict(sandboxID, "multiple unfenced active runtime pods")
+				}
+				stalePods = append(stalePods, pod)
+			}
+			return nil
+		}
+
+		if len(activePods) == 1 && runtimeGenerationFromPod(activePods[0]) == locked.RuntimeGeneration {
+			pod := activePods[0]
+			return tx.SaveRuntime(
+				lockCtx,
+				sandboxID,
+				pod.Namespace,
+				pod.Name,
+				s.podToSandboxStatus(pod),
+				locked.RuntimeGeneration,
+				parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt),
+				parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt),
+				sandboxRuntimeMetadataFromPod(pod),
+			)
+		}
+
+		for _, pod := range activePods {
+			generation := runtimeGenerationFromPod(pod)
+			if generation >= locked.RuntimeGeneration {
+				return runtimeReconcileConflict(sandboxID, fmt.Sprintf("unowned runtime generation %d is active", generation))
+			}
+			stalePods = append(stalePods, pod)
+		}
+		for _, pod := range deletingPods {
+			if runtimeGenerationFromPod(pod) > locked.RuntimeGeneration {
+				return runtimeReconcileConflict(sandboxID, "a newer runtime is still deleting")
+			}
+		}
+
+		if err := beginLostRuntimeRecoveryTxn(lockCtx, tx, locked); err != nil {
+			return err
+		}
+		enqueueRecovery = true
+		cleanupLostRuntime = len(pods) == 0
+		return nil
+	})
+	if errors.Is(err, ErrSandboxRecordNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if len(stalePods) > 0 {
+		if err := s.deleteSandboxRuntimePods(ctx, stalePods); err != nil {
+			return err
+		}
+	}
+	if finishTermination && record != nil {
+		return s.finishTerminatingSandbox(ctx, record, pods)
+	}
+	if resumeTxn != nil && record != nil {
+		return s.recoverStaleResumeTransaction(ctx, record, resumeTxn, pods)
+	}
+	if cleanupLostRuntime && record != nil {
+		if err := s.cleanupDeletedSandbox(ctx, sandboxLifecycleInfoFromRecord(record), true, false); err != nil {
+			return fmt.Errorf("cleanup missing sandbox runtime: %w", err)
+		}
+	}
+	if enqueueRecovery {
+		if s.logger != nil {
+			s.logger.Warn("Queued missing sandbox runtime reconstruction",
+				zap.String("sandboxID", sandboxID),
+				zap.Int64("runtimeGeneration", record.RuntimeGeneration),
+			)
+		}
+		s.enqueueSandboxRecovery(sandboxID)
+	} else if enqueuePause {
+		s.enqueueSandboxPause(sandboxID)
+	}
+	return nil
+}
+
+func (s *SandboxService) recoverStaleResumeTransaction(ctx context.Context, record *SandboxRecord, txn *SandboxLifecycleTxn, pods []*corev1.Pod) error {
+	if s == nil || record == nil || txn == nil || txn.Kind != SandboxLifecycleKindResume || txn.UpdatedAt.IsZero() {
+		return nil
+	}
+	staleAfter := 2 * time.Minute
+	if s.config.RuntimeReadyTimeout > 0 {
+		staleAfter = max(staleAfter, s.config.RuntimeReadyTimeout+30*time.Second)
+	}
+	if s.now().Sub(txn.UpdatedAt) < staleAfter {
+		return nil
+	}
+
+	var target *corev1.Pod
+	for _, pod := range pods {
+		if pod == nil || runtimeGenerationFromPod(pod) != txn.ToGeneration {
+			continue
+		}
+		if txn.ToPodName != "" && (pod.Name != txn.ToPodName || pod.Namespace != txn.ToPodNamespace) {
+			continue
+		}
+		if target != nil {
+			return runtimeReconcileConflict(record.ID, "multiple pods own the stale resume generation")
+		}
+		target = pod
+	}
+
+	if target == nil || target.DeletionTimestamp != nil {
+		if err := s.abortLifecycleTxn(ctx, record.ID, txn.ID, "stale resume runtime is missing"); err != nil {
+			return err
+		}
+		_, err := s.ResumePausedSandboxRuntime(ctx, record.ID)
+		return err
+	}
+	if txn.ToPodName == "" {
+		if err := s.recordResumeLifecycleRuntime(ctx, record.ID, txn, target); err != nil {
+			return err
+		}
+		txn.ToPodNamespace = target.Namespace
+		txn.ToPodName = target.Name
+	}
+	restored, err := s.finishRestoredSandboxRuntime(ctx, target, record, "recovery")
+	if err != nil {
+		return err
+	}
+	if err := s.commitResumedSandboxRuntime(ctx, restored, record, txn); err != nil {
+		return err
+	}
+	s.enqueueHotClaimReservation(restored)
+	if s.logger != nil {
+		s.logger.Info("Recovered stale sandbox resume transaction",
+			zap.String("sandboxID", record.ID),
+			zap.String("pod", restored.Name),
+			zap.Int64("runtimeGeneration", txn.ToGeneration),
+		)
+	}
+	return nil
+}
+
+func (s *SandboxService) listSandboxRuntimePodsStrong(ctx context.Context, sandboxID string) ([]*corev1.Pod, error) {
+	if s == nil || s.k8sClient == nil {
+		return nil, fmt.Errorf("kubernetes client is not configured")
+	}
+	selector := labels.SelectorFromSet(map[string]string{controller.LabelSandboxID: sandboxID}).String()
+	list, err := s.k8sClient.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return nil, err
+	}
+	pods := make([]*corev1.Pod, 0, len(list.Items))
+	for i := range list.Items {
+		pod := &list.Items[i]
+		if sandboxIDFromPod(pod) != sandboxID || !sandboxRuntimePodOwnedBySandbox(pod) {
+			continue
+		}
+		pods = append(pods, pod.DeepCopy())
+	}
+	sort.Slice(pods, func(i, j int) bool {
+		leftGeneration := runtimeGenerationFromPod(pods[i])
+		rightGeneration := runtimeGenerationFromPod(pods[j])
+		if leftGeneration != rightGeneration {
+			return leftGeneration > rightGeneration
+		}
+		if pods[i].Namespace != pods[j].Namespace {
+			return pods[i].Namespace < pods[j].Namespace
+		}
+		return pods[i].Name < pods[j].Name
+	})
+	return pods, nil
+}
+
+func (s *SandboxService) sandboxRecordBelongsToCluster(record *SandboxRecord) bool {
+	if s == nil || record == nil {
+		return false
+	}
+	clusterID := strings.TrimSpace(s.config.ClusterID)
+	return clusterID == "" || strings.TrimSpace(record.ClusterID) == clusterID
+}
+
+func splitSandboxRuntimePods(pods []*corev1.Pod) (active, deleting []*corev1.Pod) {
+	for _, pod := range pods {
+		if pod == nil {
+			continue
+		}
+		if pod.DeletionTimestamp != nil {
+			deleting = append(deleting, pod)
+		} else {
+			active = append(active, pod)
+		}
+	}
+	return active, deleting
+}
+
+func matchingSandboxRuntimePods(record *SandboxRecord, pods []*corev1.Pod) []*corev1.Pod {
+	matching := make([]*corev1.Pod, 0, 1)
+	for _, pod := range pods {
+		if sandboxRecordReferencesPod(record, pod) {
+			matching = append(matching, pod)
+		}
+	}
+	return matching
+}
+
+func sandboxSourceRuntimeTxnPodAvailable(txn *SandboxLifecycleTxn, pods []*corev1.Pod) bool {
+	if txn == nil {
+		return false
+	}
+	for _, pod := range pods {
+		if pod == nil || pod.DeletionTimestamp != nil || runtimeGenerationFromPod(pod) != txn.FromGeneration {
+			continue
+		}
+		if txn.FromPodName != "" && (pod.Name != txn.FromPodName || pod.Namespace != txn.FromPodNamespace) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func beginLostRuntimeRecoveryTxn(ctx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
+	if tx == nil || record == nil {
+		return nil
+	}
+	return tx.BeginLifecycleTxn(ctx, &SandboxLifecycleTxn{
+		ID:               uuid.NewString(),
+		SandboxID:        record.ID,
+		Kind:             SandboxLifecycleKindPause,
+		Phase:            SandboxLifecyclePhasePreparing,
+		Source:           SandboxLifecycleSourceLost,
+		Cancelable:       false,
+		FromGeneration:   record.RuntimeGeneration,
+		FromPodNamespace: record.CurrentPodNamespace,
+		FromPodName:      record.CurrentPodName,
+	})
+}
+
+func (s *SandboxService) deleteSandboxRuntimePods(ctx context.Context, pods []*corev1.Pod) error {
+	for _, pod := range pods {
+		if pod == nil {
+			continue
+		}
+		current, err := s.ensureSandboxDeletionFinalizer(ctx, pod)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("ensure runtime cleanup finalizer on %s/%s: %w", pod.Namespace, pod.Name, err)
+		}
+		if current == nil {
+			current = pod
+		}
+		err = s.k8sClient.CoreV1().Pods(current.Namespace).Delete(ctx, current.Name, metav1.DeleteOptions{})
+		if err != nil && !k8serrors.IsNotFound(err) {
+			return fmt.Errorf("delete sandbox runtime pod %s/%s: %w", current.Namespace, current.Name, err)
+		}
+	}
+	return nil
+}
+
+func (s *SandboxService) finishTerminatingSandbox(ctx context.Context, record *SandboxRecord, pods []*corev1.Pod) error {
+	if s == nil || record == nil || s.sandboxStore == nil {
+		return nil
+	}
+	if len(pods) == 0 {
+		if err := s.cleanupDeletedSandbox(ctx, sandboxLifecycleInfoFromRecord(record), false, false); err != nil {
+			return fmt.Errorf("cleanup terminating sandbox without runtime: %w", err)
+		}
+	} else if err := s.deleteSandboxRuntimePods(ctx, pods); err != nil {
+		return err
+	}
+	return s.sandboxStore.MarkSandboxDeleted(ctx, record.ID, s.now())
+}

--- a/manager/pkg/service/sandbox_runtime_recovery_test.go
+++ b/manager/pkg/service/sandbox_runtime_recovery_test.go
@@ -1,0 +1,636 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func TestReconcileSandboxRuntimeCreatesDurableLostRecoveryAfterStrongAbsence(t *testing.T) {
+	store := runtimeRecoveryStore("sandbox-1", "pod-1", 3, SandboxStatusRunning)
+	enqueuer := &recordingPauseEnqueuer{}
+	svc := &SandboxService{
+		k8sClient:     fake.NewSimpleClientset(),
+		sandboxStore:  store,
+		pauseEnqueuer: enqueuer,
+		config:        SandboxServiceConfig{ClusterID: "cluster-a"},
+		logger:        zap.NewNop(),
+	}
+
+	require.NoError(t, svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1"))
+	txn := activeLifecycleTxnForTest(store, "sandbox-1")
+	require.NotNil(t, txn)
+	assert.Equal(t, SandboxLifecycleKindPause, txn.Kind)
+	assert.Equal(t, SandboxLifecycleSourceLost, txn.Source)
+	assert.Equal(t, int64(3), txn.FromGeneration)
+	assert.Equal(t, "default", txn.FromPodNamespace)
+	assert.Equal(t, "pod-1", txn.FromPodName)
+	assert.Equal(t, []string{"sandbox-1"}, enqueuer.recoveryCalls)
+	assert.Equal(t, SandboxStatusRunning, store.records["sandbox-1"].Status)
+
+	require.NoError(t, svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1"))
+	assert.Len(t, store.lifecycleTxns, 1, "duplicate reconcile must reuse the active recovery transaction")
+}
+
+func TestReconcileSandboxRuntimeDoesNotTreatKubernetesFailureAsAbsence(t *testing.T) {
+	store := runtimeRecoveryStore("sandbox-1", "pod-1", 3, SandboxStatusRunning)
+	client := fake.NewSimpleClientset()
+	client.PrependReactor("list", "pods", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("apiserver unavailable")
+	})
+	svc := &SandboxService{
+		k8sClient:    client,
+		sandboxStore: store,
+		config:       SandboxServiceConfig{ClusterID: "cluster-a"},
+		logger:       zap.NewNop(),
+	}
+
+	err := svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1")
+	require.ErrorContains(t, err, "apiserver unavailable")
+	assert.Nil(t, activeLifecycleTxnForTest(store, "sandbox-1"))
+	assert.Equal(t, SandboxStatusRunning, store.records["sandbox-1"].Status)
+}
+
+func TestReconcileSandboxRuntimeRepairsSameGenerationProjectionFromKubernetes(t *testing.T) {
+	pod := runtimeRecoveryPod("pod-new", "sandbox-1", 3)
+	store := runtimeRecoveryStore("sandbox-1", "pod-old", 3, SandboxStatusRunning)
+	svc := &SandboxService{
+		k8sClient:    fake.NewSimpleClientset(pod),
+		sandboxStore: store,
+		config:       SandboxServiceConfig{ClusterID: "cluster-a"},
+		logger:       zap.NewNop(),
+	}
+
+	require.NoError(t, svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1"))
+	record := store.records["sandbox-1"]
+	assert.Equal(t, "pod-new", record.CurrentPodName)
+	assert.Equal(t, "default", record.CurrentPodNamespace)
+	assert.Equal(t, int64(3), record.RuntimeGeneration)
+	assert.Nil(t, activeLifecycleTxnForTest(store, "sandbox-1"))
+}
+
+func TestReconcileSandboxRuntimeRejectsUnownedNewerGeneration(t *testing.T) {
+	pod := runtimeRecoveryPod("pod-new", "sandbox-1", 4)
+	store := runtimeRecoveryStore("sandbox-1", "pod-old", 3, SandboxStatusRunning)
+	svc := &SandboxService{
+		k8sClient:    fake.NewSimpleClientset(pod),
+		sandboxStore: store,
+		config:       SandboxServiceConfig{ClusterID: "cluster-a"},
+		logger:       zap.NewNop(),
+	}
+
+	err := svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1")
+	require.ErrorContains(t, err, "unowned runtime generation 4")
+	assert.Equal(t, "pod-old", store.records["sandbox-1"].CurrentPodName)
+	assert.Nil(t, activeLifecycleTxnForTest(store, "sandbox-1"))
+}
+
+func TestReconcileSandboxRuntimeRejectsAmbiguousSameGenerationPods(t *testing.T) {
+	first := runtimeRecoveryPod("pod-a", "sandbox-1", 3)
+	second := runtimeRecoveryPod("pod-b", "sandbox-1", 3)
+	store := runtimeRecoveryStore("sandbox-1", "pod-old", 3, SandboxStatusRunning)
+	svc := &SandboxService{
+		k8sClient:    fake.NewSimpleClientset(first, second),
+		sandboxStore: store,
+		config:       SandboxServiceConfig{ClusterID: "cluster-a"},
+		logger:       zap.NewNop(),
+	}
+
+	err := svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1")
+	require.ErrorContains(t, err, "unowned runtime generation 3")
+	assert.Equal(t, "pod-old", store.records["sandbox-1"].CurrentPodName)
+	assert.Nil(t, activeLifecycleTxnForTest(store, "sandbox-1"))
+}
+
+func TestReconcileSandboxRuntimeDeletesOlderRuntimeBeforeRecovery(t *testing.T) {
+	stale := runtimeRecoveryPod("pod-stale", "sandbox-1", 2)
+	store := runtimeRecoveryStore("sandbox-1", "pod-missing", 3, SandboxStatusRunning)
+	enqueuer := &recordingPauseEnqueuer{}
+	client := fake.NewSimpleClientset(stale)
+	svc := &SandboxService{
+		k8sClient:     client,
+		sandboxStore:  store,
+		pauseEnqueuer: enqueuer,
+		config:        SandboxServiceConfig{ClusterID: "cluster-a"},
+		logger:        zap.NewNop(),
+	}
+
+	require.NoError(t, svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1"))
+	assert.True(t, hasPodAction(client.Actions(), "delete", "pod-stale"))
+	txn := activeLifecycleTxnForTest(store, "sandbox-1")
+	require.NotNil(t, txn)
+	assert.Equal(t, SandboxLifecycleSourceLost, txn.Source)
+	assert.Equal(t, []string{"sandbox-1"}, enqueuer.recoveryCalls)
+}
+
+func TestReconcileLostRuntimeRecoveryRetriesOlderRuntimeDeletion(t *testing.T) {
+	stale := runtimeRecoveryPod("pod-stale", "sandbox-1", 2)
+	store := runtimeRecoveryStore("sandbox-1", "pod-missing", 3, SandboxStatusRunning)
+	store.lifecycleTxns = map[string]*SandboxLifecycleTxn{
+		"txn-lost": {
+			ID:               "txn-lost",
+			SandboxID:        "sandbox-1",
+			Kind:             SandboxLifecycleKindPause,
+			Phase:            SandboxLifecyclePhasePreparing,
+			Source:           SandboxLifecycleSourceLost,
+			FromGeneration:   3,
+			FromPodNamespace: "default",
+			FromPodName:      "pod-missing",
+		},
+	}
+	enqueuer := &recordingPauseEnqueuer{}
+	client := fake.NewSimpleClientset(stale)
+	deleteAttempts := 0
+	client.PrependReactor("delete", "pods", func(ktesting.Action) (bool, runtime.Object, error) {
+		deleteAttempts++
+		if deleteAttempts == 1 {
+			return true, nil, errors.New("transient delete failure")
+		}
+		return false, nil, nil
+	})
+	svc := &SandboxService{
+		k8sClient:     client,
+		sandboxStore:  store,
+		pauseEnqueuer: enqueuer,
+		config:        SandboxServiceConfig{ClusterID: "cluster-a"},
+		logger:        zap.NewNop(),
+	}
+
+	err := svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1")
+	require.ErrorContains(t, err, "transient delete failure")
+	assert.Empty(t, enqueuer.recoveryCalls)
+
+	require.NoError(t, svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1"))
+	assert.Equal(t, 2, deleteAttempts)
+	assert.Equal(t, []string{"sandbox-1"}, enqueuer.recoveryCalls)
+	assert.Equal(t, "txn-lost", activeLifecycleTxnID(store, "sandbox-1"))
+}
+
+func TestReconcileLostRuntimeRecoveryRejectsUnexpectedSameGenerationPod(t *testing.T) {
+	unexpected := runtimeRecoveryPod("pod-unexpected", "sandbox-1", 3)
+	store := runtimeRecoveryStore("sandbox-1", "pod-missing", 3, SandboxStatusRunning)
+	store.lifecycleTxns = map[string]*SandboxLifecycleTxn{
+		"txn-lost": {
+			ID:               "txn-lost",
+			SandboxID:        "sandbox-1",
+			Kind:             SandboxLifecycleKindPause,
+			Phase:            SandboxLifecyclePhasePreparing,
+			Source:           SandboxLifecycleSourceLost,
+			FromGeneration:   3,
+			FromPodNamespace: "default",
+			FromPodName:      "pod-missing",
+		},
+	}
+	enqueuer := &recordingPauseEnqueuer{}
+	svc := &SandboxService{
+		k8sClient:     fake.NewSimpleClientset(unexpected),
+		sandboxStore:  store,
+		pauseEnqueuer: enqueuer,
+		config:        SandboxServiceConfig{ClusterID: "cluster-a"},
+		logger:        zap.NewNop(),
+	}
+
+	err := svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1")
+	require.ErrorContains(t, err, "unexpected runtime owns the lost generation")
+	assert.Empty(t, enqueuer.recoveryCalls)
+	assert.Equal(t, "txn-lost", activeLifecycleTxnID(store, "sandbox-1"))
+}
+
+func TestReconcileSandboxRuntimeDoesNotAdoptUnclaimedPod(t *testing.T) {
+	unclaimed := runtimeRecoveryPod("pod-idle", "sandbox-1", 3)
+	unclaimed.Labels[controller.LabelPoolType] = controller.PoolTypeIdle
+	store := runtimeRecoveryStore("sandbox-1", "pod-missing", 3, SandboxStatusRunning)
+	enqueuer := &recordingPauseEnqueuer{}
+	svc := &SandboxService{
+		k8sClient:     fake.NewSimpleClientset(unclaimed),
+		sandboxStore:  store,
+		pauseEnqueuer: enqueuer,
+		config:        SandboxServiceConfig{ClusterID: "cluster-a"},
+		logger:        zap.NewNop(),
+	}
+
+	require.NoError(t, svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1"))
+	assert.Equal(t, "pod-missing", store.records["sandbox-1"].CurrentPodName)
+	txn := activeLifecycleTxnForTest(store, "sandbox-1")
+	require.NotNil(t, txn)
+	assert.Equal(t, SandboxLifecycleSourceLost, txn.Source)
+	assert.Equal(t, []string{"sandbox-1"}, enqueuer.recoveryCalls)
+}
+
+func TestReconcileSandboxRuntimeIgnoresAnotherCluster(t *testing.T) {
+	store := runtimeRecoveryStore("sandbox-1", "pod-1", 3, SandboxStatusRunning)
+	store.records["sandbox-1"].ClusterID = "cluster-b"
+	svc := &SandboxService{
+		k8sClient:    fake.NewSimpleClientset(),
+		sandboxStore: store,
+		config:       SandboxServiceConfig{ClusterID: "cluster-a"},
+		logger:       zap.NewNop(),
+	}
+
+	require.NoError(t, svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1"))
+	assert.Nil(t, activeLifecycleTxnForTest(store, "sandbox-1"))
+}
+
+func TestReconcileSandboxRuntimeHardExpiryDeletesInsteadOfRecovering(t *testing.T) {
+	now := time.Date(2026, time.August, 3, 8, 0, 0, 0, time.UTC)
+	store := runtimeRecoveryStore("sandbox-1", "pod-1", 3, SandboxStatusRunning)
+	store.records["sandbox-1"].HardExpiresAt = now.Add(-time.Second)
+	svc := &SandboxService{
+		k8sClient:    fake.NewSimpleClientset(),
+		sandboxStore: store,
+		clock:        fixedClock{now: now},
+		config:       SandboxServiceConfig{ClusterID: "cluster-a"},
+		logger:       zap.NewNop(),
+	}
+
+	require.NoError(t, svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1"))
+	assert.Equal(t, SandboxStatusDeleted, store.records["sandbox-1"].Status)
+	assert.Nil(t, activeLifecycleTxnForTest(store, "sandbox-1"))
+}
+
+func TestReconcilePausedSandboxDeletesStalePodWithoutRecovery(t *testing.T) {
+	pod := runtimeRecoveryPod("pod-1", "sandbox-1", 3)
+	store := runtimeRecoveryStore("sandbox-1", "", 3, SandboxStatusPaused)
+	client := fake.NewSimpleClientset(pod)
+	svc := &SandboxService{
+		k8sClient:    client,
+		sandboxStore: store,
+		config:       SandboxServiceConfig{ClusterID: "cluster-a"},
+		logger:       zap.NewNop(),
+	}
+
+	require.NoError(t, svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1"))
+	assert.Equal(t, SandboxStatusPaused, store.records["sandbox-1"].Status)
+	assert.Nil(t, activeLifecycleTxnForTest(store, "sandbox-1"))
+	assert.True(t, hasPodAction(client.Actions(), "delete", "pod-1"))
+}
+
+func TestReconcileSandboxRuntimeDoesNotRaceFreshResumeTransaction(t *testing.T) {
+	now := time.Date(2026, time.August, 3, 8, 0, 0, 0, time.UTC)
+	store := runtimeRecoveryStore("sandbox-1", "", 3, SandboxStatusPaused)
+	store.lifecycleTxns = map[string]*SandboxLifecycleTxn{
+		"txn-resume": {
+			ID:             "txn-resume",
+			SandboxID:      "sandbox-1",
+			Kind:           SandboxLifecycleKindResume,
+			Phase:          SandboxLifecyclePhasePreparing,
+			FromGeneration: 3,
+			ToGeneration:   4,
+			UpdatedAt:      now,
+		},
+	}
+	svc := &SandboxService{
+		k8sClient:    fake.NewSimpleClientset(),
+		sandboxStore: store,
+		clock:        fixedClock{now: now.Add(time.Minute)},
+		config:       SandboxServiceConfig{ClusterID: "cluster-a"},
+		logger:       zap.NewNop(),
+	}
+
+	require.NoError(t, svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1"))
+	txn := activeLifecycleTxnForTest(store, "sandbox-1")
+	require.NotNil(t, txn)
+	assert.Equal(t, "txn-resume", txn.ID)
+	assert.Equal(t, SandboxLifecyclePhasePreparing, txn.Phase)
+}
+
+func TestReconcileSandboxRuntimeAbortsStaleResumeWithMissingTarget(t *testing.T) {
+	now := time.Date(2026, time.August, 3, 8, 0, 0, 0, time.UTC)
+	store := runtimeRecoveryStore("sandbox-1", "", 3, SandboxStatusPaused)
+	store.records["sandbox-1"].TemplateID = "default"
+	store.records["sandbox-1"].TemplateName = "default"
+	store.records["sandbox-1"].TemplateNamespace = "tpl-default"
+	store.lifecycleTxns = map[string]*SandboxLifecycleTxn{
+		"txn-resume": {
+			ID:             "txn-resume",
+			SandboxID:      "sandbox-1",
+			Kind:           SandboxLifecycleKindResume,
+			Phase:          SandboxLifecyclePhasePreparing,
+			FromGeneration: 3,
+			ToGeneration:   4,
+			UpdatedAt:      now.Add(-3 * time.Minute),
+		},
+	}
+	svc := &SandboxService{
+		k8sClient:    fake.NewSimpleClientset(),
+		podLister:    runtimeIdentityPodLister(t),
+		sandboxStore: store,
+		clock:        fixedClock{now: now},
+		config:       SandboxServiceConfig{ClusterID: "cluster-a"},
+		logger:       zap.NewNop(),
+	}
+
+	err := svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1")
+	require.Error(t, err, "replacement creation is expected to fail in the unit fixture")
+	assert.Equal(t, SandboxLifecyclePhaseAborted, store.lifecycleTxns["txn-resume"].Phase)
+	assert.NotEqual(t, "txn-resume", activeLifecycleTxnID(store, "sandbox-1"))
+}
+
+func TestReconcileSandboxRuntimeWaitsForFreshSourceCheckpointTransaction(t *testing.T) {
+	now := time.Date(2026, time.August, 3, 8, 0, 0, 0, time.UTC)
+	store := runtimeRecoveryStore("sandbox-1", "pod-missing", 3, SandboxStatusRunning)
+	store.lifecycleTxns = map[string]*SandboxLifecycleTxn{
+		"txn-snapshot": {
+			ID:               "txn-snapshot",
+			SandboxID:        "sandbox-1",
+			Kind:             SandboxLifecycleKindSnapshot,
+			Phase:            SandboxLifecyclePhasePublishing,
+			FromGeneration:   3,
+			FromPodNamespace: "default",
+			FromPodName:      "pod-missing",
+			UpdatedAt:        now,
+		},
+	}
+	enqueuer := &recordingPauseEnqueuer{}
+	svc := &SandboxService{
+		k8sClient:     fake.NewSimpleClientset(),
+		sandboxStore:  store,
+		pauseEnqueuer: enqueuer,
+		clock:         fixedClock{now: now.Add(time.Minute)},
+		config:        SandboxServiceConfig{ClusterID: "cluster-a"},
+		logger:        zap.NewNop(),
+	}
+
+	require.NoError(t, svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1"))
+	txn := activeLifecycleTxnForTest(store, "sandbox-1")
+	require.NotNil(t, txn)
+	assert.Equal(t, "txn-snapshot", txn.ID)
+	assert.Empty(t, enqueuer.recoveryCalls)
+}
+
+func TestReconcileSandboxRuntimeRecoversAfterStaleSourceCheckpointTransaction(t *testing.T) {
+	now := time.Date(2026, time.August, 3, 8, 0, 0, 0, time.UTC)
+	store := runtimeRecoveryStore("sandbox-1", "pod-missing", 3, SandboxStatusRunning)
+	store.lifecycleTxns = map[string]*SandboxLifecycleTxn{
+		"txn-fork": {
+			ID:               "txn-fork",
+			SandboxID:        "sandbox-1",
+			Kind:             SandboxLifecycleKindFork,
+			Phase:            SandboxLifecyclePhasePublishing,
+			FromGeneration:   3,
+			FromPodNamespace: "default",
+			FromPodName:      "pod-missing",
+			UpdatedAt:        now.Add(-sandboxRootFSSourceCheckpointLifecycleStaleAfter - time.Second),
+		},
+	}
+	enqueuer := &recordingPauseEnqueuer{}
+	svc := &SandboxService{
+		k8sClient:     fake.NewSimpleClientset(),
+		sandboxStore:  store,
+		pauseEnqueuer: enqueuer,
+		clock:         fixedClock{now: now},
+		config:        SandboxServiceConfig{ClusterID: "cluster-a"},
+		logger:        zap.NewNop(),
+	}
+
+	require.NoError(t, svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1"))
+	assert.Equal(t, SandboxLifecyclePhaseAborted, store.lifecycleTxns["txn-fork"].Phase)
+	txn := activeLifecycleTxnForTest(store, "sandbox-1")
+	require.NotNil(t, txn)
+	assert.Equal(t, SandboxLifecycleKindPause, txn.Kind)
+	assert.Equal(t, SandboxLifecycleSourceLost, txn.Source)
+	assert.Equal(t, []string{"sandbox-1"}, enqueuer.recoveryCalls)
+}
+
+func TestReconcileTerminatingSandboxAbortsResumeAndNeverRecovers(t *testing.T) {
+	store := runtimeRecoveryStore("sandbox-1", "pod-missing", 3, SandboxStatusTerminating)
+	store.lifecycleTxns = map[string]*SandboxLifecycleTxn{
+		"txn-resume": {
+			ID:             "txn-resume",
+			SandboxID:      "sandbox-1",
+			Kind:           SandboxLifecycleKindResume,
+			Phase:          SandboxLifecyclePhasePreparing,
+			FromGeneration: 3,
+			ToGeneration:   4,
+		},
+	}
+	enqueuer := &recordingPauseEnqueuer{}
+	svc := &SandboxService{
+		k8sClient:     fake.NewSimpleClientset(),
+		sandboxStore:  store,
+		pauseEnqueuer: enqueuer,
+		clock:         systemTime{},
+		config:        SandboxServiceConfig{ClusterID: "cluster-a"},
+		logger:        zap.NewNop(),
+	}
+
+	require.NoError(t, svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1"))
+	assert.Equal(t, SandboxStatusDeleted, store.records["sandbox-1"].Status)
+	assert.Equal(t, SandboxLifecyclePhaseAborted, store.lifecycleTxns["txn-resume"].Phase)
+	assert.Empty(t, enqueuer.recoveryCalls)
+}
+
+func TestCompleteLostRecoveryPreservesLastCommittedHeadWhenPodIsGone(t *testing.T) {
+	store := runtimeRecoveryStore("sandbox-1", "pod-1", 3, SandboxStatusRunning)
+	store.rootFSStates = map[string]*SandboxRootFSState{
+		"sandbox-1": {SandboxID: "sandbox-1", LayerID: "committed-head", RuntimeGeneration: 2},
+	}
+	store.lifecycleTxns = map[string]*SandboxLifecycleTxn{
+		"txn-lost": {
+			ID:               "txn-lost",
+			SandboxID:        "sandbox-1",
+			Kind:             SandboxLifecycleKindPause,
+			Phase:            SandboxLifecyclePhasePreparing,
+			Source:           SandboxLifecycleSourceLost,
+			FromGeneration:   3,
+			FromPodNamespace: "default",
+			FromPodName:      "pod-1",
+		},
+	}
+	svc := &SandboxService{
+		k8sClient:    fake.NewSimpleClientset(),
+		podLister:    runtimeIdentityPodLister(t),
+		sandboxStore: store,
+		clock:        systemTime{},
+		logger:       zap.NewNop(),
+	}
+
+	require.NoError(t, svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"))
+	assert.Equal(t, SandboxStatusPaused, store.records["sandbox-1"].Status)
+	assert.Equal(t, "committed-head", store.rootFSStates["sandbox-1"].LayerID)
+	assert.Equal(t, SandboxLifecyclePhaseCommitted, store.lifecycleTxns["txn-lost"].Phase)
+}
+
+func TestTerminateSandboxPersistsIntentBeforePodDeletion(t *testing.T) {
+	pod := runtimeRecoveryPod("pod-1", "sandbox-1", 3)
+	store := runtimeRecoveryStore("sandbox-1", "pod-1", 3, SandboxStatusRunning)
+	client := fake.NewSimpleClientset(pod)
+	statusAtDelete := ""
+	client.PrependReactor("delete", "pods", func(ktesting.Action) (bool, runtime.Object, error) {
+		record, err := store.GetSandbox(context.Background(), "sandbox-1")
+		require.NoError(t, err)
+		statusAtDelete = record.Status
+		return false, nil, nil
+	})
+	svc := &SandboxService{
+		k8sClient:    client,
+		podLister:    runtimeIdentityPodLister(t, pod),
+		sandboxStore: store,
+		clock:        systemTime{},
+		config:       SandboxServiceConfig{ClusterID: "cluster-a"},
+		logger:       zap.NewNop(),
+	}
+
+	require.NoError(t, svc.TerminateSandbox(context.Background(), "sandbox-1"))
+	assert.Equal(t, SandboxStatusTerminating, statusAtDelete)
+	assert.Equal(t, SandboxStatusDeleted, store.records["sandbox-1"].Status)
+}
+
+func TestSandboxRecordDeletionScopeRequiresDurableDeleteIntent(t *testing.T) {
+	record := &SandboxRecord{
+		ID:                  "sandbox-1",
+		Status:              SandboxStatusRunning,
+		CurrentPodNamespace: "default",
+		CurrentPodName:      "pod-1",
+		RuntimeGeneration:   3,
+	}
+	assert.True(t, SandboxRecordDeletionIsRuntimeOnly(record, "default", "pod-1", 3))
+	record.Status = SandboxStatusTerminating
+	assert.False(t, SandboxRecordDeletionIsRuntimeOnly(record, "default", "pod-1", 3))
+	record.Status = SandboxStatusDeleted
+	assert.False(t, SandboxRecordDeletionIsRuntimeOnly(record, "default", "pod-1", 3))
+}
+
+func TestUnexpectedCurrentPodDeletionPreservesSandboxExternalState(t *testing.T) {
+	bindings := &deleteRecordingBindingStore{}
+	volumes := &recordingSystemVolumeClient{}
+	emitter := &recordingDeletionWebhookEmitter{}
+	store := runtimeRecoveryStore("sandbox-1", "pod-1", 3, SandboxStatusRunning)
+	svc := &SandboxService{
+		sandboxStore:           store,
+		credentialStore:        bindings,
+		webhookStateVolumes:    volumes,
+		deletionWebhookEmitter: emitter,
+		logger:                 zap.NewNop(),
+	}
+
+	require.NoError(t, svc.CleanupDeletedSandbox(context.Background(), SandboxLifecycleInfo{
+		SandboxID:            "sandbox-1",
+		Namespace:            "default",
+		PodName:              "pod-1",
+		RuntimeGeneration:    3,
+		TeamID:               "team-1",
+		WebhookURL:           "https://example.test/webhook",
+		WebhookStateVolumeID: "webhook-volume-1",
+	}))
+	assert.Zero(t, bindings.deleteCalls)
+	assert.Empty(t, volumes.marked)
+	assert.Empty(t, emitter.calls)
+	assert.Equal(t, SandboxStatusRunning, store.records["sandbox-1"].Status)
+}
+
+func TestSandboxRuntimeReconcilerDeleteEventQueuesSandbox(t *testing.T) {
+	reconciler := NewSandboxRuntimeReconciler("cluster-a", nil, nil, nil, zap.NewNop())
+	pod := runtimeRecoveryPod("pod-1", "sandbox-1", 3)
+	reconciler.ResourceEventHandler().DeleteFunc(pod)
+	require.Equal(t, 1, reconciler.queue.Len())
+	item, shutdown := reconciler.queue.Get()
+	require.False(t, shutdown)
+	reconciler.queue.Done(item)
+	reconciler.queue.Forget(item)
+	assert.Equal(t, "sandbox-1", item)
+}
+
+func TestSandboxRuntimeReconcilerScansPagesAndQueuesOnlyDrift(t *testing.T) {
+	healthy := runtimeRecoveryPod("pod-a", "sandbox-a", 1)
+	store := &runtimeReconcileMemoryStore{candidates: []SandboxRuntimeReconcileCandidate{
+		{SandboxID: "sandbox-a", Status: SandboxStatusRunning, PodNamespace: "default", PodName: "pod-a", RuntimeGeneration: 1},
+		{SandboxID: "sandbox-b", Status: SandboxStatusRunning, PodNamespace: "default", PodName: "pod-b", RuntimeGeneration: 1},
+		{SandboxID: "sandbox-c", Status: SandboxStatusTerminating},
+	}}
+	reconciler := NewSandboxRuntimeReconciler("cluster-a", store, runtimeIdentityPodLister(t, healthy), nil, zap.NewNop())
+	reconciler.pageSize = 2
+
+	reconciler.enqueueDriftCandidates(context.Background())
+	assert.Equal(t, []string{"", "sandbox-b"}, store.afterCalls)
+	assert.Equal(t, 2, reconciler.queue.Len())
+	got := map[string]bool{}
+	for reconciler.queue.Len() > 0 {
+		item, shutdown := reconciler.queue.Get()
+		require.False(t, shutdown)
+		got[item] = true
+		reconciler.queue.Done(item)
+		reconciler.queue.Forget(item)
+	}
+	assert.Equal(t, map[string]bool{"sandbox-b": true, "sandbox-c": true}, got)
+}
+
+type runtimeReconcileMemoryStore struct {
+	candidates []SandboxRuntimeReconcileCandidate
+	afterCalls []string
+}
+
+func (s *runtimeReconcileMemoryStore) ListRuntimeReconcileCandidates(_ context.Context, _ string, after string, limit int) ([]SandboxRuntimeReconcileCandidate, error) {
+	s.afterCalls = append(s.afterCalls, after)
+	page := make([]SandboxRuntimeReconcileCandidate, 0, limit)
+	for _, candidate := range s.candidates {
+		if candidate.SandboxID <= after {
+			continue
+		}
+		page = append(page, candidate)
+		if len(page) == limit {
+			break
+		}
+	}
+	return page, nil
+}
+
+func runtimeRecoveryStore(sandboxID, podName string, generation int64, status string) *memorySandboxStore {
+	namespace := "default"
+	if podName == "" {
+		namespace = ""
+	}
+	return &memorySandboxStore{records: map[string]*SandboxRecord{
+		sandboxID: {
+			ID:                  sandboxID,
+			TeamID:              "team-1",
+			UserID:              "user-1",
+			ClusterID:           "cluster-a",
+			Status:              status,
+			CurrentPodNamespace: namespace,
+			CurrentPodName:      podName,
+			RuntimeGeneration:   generation,
+		},
+	}}
+}
+
+func runtimeRecoveryPod(name, sandboxID string, generation int64) *corev1.Pod {
+	pod := rootFSTestPod(name, sandboxID, "team-1")
+	pod.UID = types.UID(name + "-uid")
+	pod.Annotations[controller.AnnotationRuntimeGeneration] = strconv.FormatInt(generation, 10)
+	pod.Finalizers = []string{sandboxCleanupFinalizer}
+	pod.CreationTimestamp = metav1.NewTime(time.Now().UTC())
+	return pod
+}
+
+func hasPodAction(actions []ktesting.Action, verb, name string) bool {
+	for _, action := range actions {
+		if action.GetVerb() == verb && action.GetResource().Resource == "pods" {
+			if named, ok := action.(interface{ GetName() string }); ok && named.GetName() == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func activeLifecycleTxnID(store *memorySandboxStore, sandboxID string) string {
+	txn := activeLifecycleTxnForTest(store, sandboxID)
+	if txn == nil {
+		return ""
+	}
+	return txn.ID
+}

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -84,6 +84,7 @@ var claimIdlePodBackoff = wait.Backoff{
 
 // SandboxServiceConfig handles configuration for SandboxService
 type SandboxServiceConfig struct {
+	ClusterID                           string
 	DefaultTTL                          time.Duration
 	SandboxMemoryPerCPU                 string
 	SandboxMaxMemory                    string

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -24,53 +24,66 @@ import (
 // TerminateSandbox terminates a sandbox
 func (s *SandboxService) TerminateSandbox(ctx context.Context, sandboxID string) error {
 	s.logger.Info("Terminating sandbox", zap.String("sandboxID", sandboxID))
+	if s.sandboxStore == nil {
+		return s.terminateSandboxWithoutStore(ctx, sandboxID)
+	}
 
-	// Find the pod by sandbox ID
+	alreadyDeleted := false
+	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
+		if record == nil || record.Status == SandboxStatusDeleted || !record.DeletedAt.IsZero() {
+			alreadyDeleted = true
+			return nil
+		}
+		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sandboxID)
+		if err != nil {
+			return err
+		}
+		if activeTxn != nil {
+			if err := tx.AbortLifecycleTxn(lockCtx, activeTxn.ID, "sandbox termination requested"); err != nil {
+				return err
+			}
+		}
+		if record.Status == SandboxStatusTerminating {
+			return nil
+		}
+		return tx.MarkRuntimeTerminating(lockCtx, sandboxID)
+	})
+	if errors.Is(err, ErrSandboxRecordNotFound) {
+		return s.terminateSandboxWithoutStore(ctx, sandboxID)
+	}
+	if err != nil {
+		return err
+	}
+	if alreadyDeleted {
+		return nil
+	}
+
+	// The durable terminating intent is committed before Kubernetes deletion.
+	// Any manager replica or restart can now finish the operation without
+	// confusing an explicit delete with unexpected runtime loss.
+	if err := s.ReconcileSandboxRuntime(ctx, sandboxID); err != nil {
+		return err
+	}
+	s.logger.Info("Sandbox termination requested", zap.String("sandboxID", sandboxID))
+	return nil
+}
+
+func (s *SandboxService) terminateSandboxWithoutStore(ctx context.Context, sandboxID string) error {
 	pod, err := s.getSandboxPod(ctx, sandboxID)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			s.logger.Info("Sandbox already terminated", zap.String("sandboxID", sandboxID))
-			if s.sandboxStore != nil {
-				record, getErr := s.sandboxStore.GetSandbox(ctx, sandboxID)
-				if getErr != nil {
-					return fmt.Errorf("get sandbox record: %w", getErr)
-				}
-				if record != nil && record.Status != SandboxStatusDeleted {
-					if err := s.cleanupDeletedSandbox(ctx, sandboxLifecycleInfoFromRecord(record), false, false); err != nil {
-						return fmt.Errorf("cleanup deleted sandbox record: %w", err)
-					}
-				}
-				return s.sandboxStore.MarkSandboxDeleted(ctx, sandboxID, s.clock.Now())
-			}
 			return nil
 		}
 		return fmt.Errorf("get pod: %w", err)
 	}
-
 	pod, err = s.ensureSandboxDeletionFinalizer(ctx, pod)
 	if err != nil {
 		return fmt.Errorf("ensure sandbox cleanup finalizer: %w", err)
 	}
-
 	err = s.k8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
-	if k8serrors.IsNotFound(err) {
-		s.logger.Info("Sandbox already terminated", zap.String("sandboxID", sandboxID))
-		if s.sandboxStore != nil {
-			return s.sandboxStore.MarkSandboxDeleted(ctx, sandboxID, s.clock.Now())
-		}
-		return nil
-	}
-	if err != nil {
+	if err != nil && !k8serrors.IsNotFound(err) {
 		return fmt.Errorf("delete pod: %w", err)
 	}
-
-	s.logger.Info("Sandbox termination requested", zap.String("sandboxID", sandboxID), zap.String("pod", pod.Name))
-	if s.sandboxStore != nil {
-		if err := s.sandboxStore.MarkSandboxDeleted(ctx, sandboxID, s.clock.Now()); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -125,6 +138,8 @@ func (s *SandboxService) requestPauseSandboxRuntime(ctx context.Context, sandbox
 		switch record.Status {
 		case SandboxStatusDeleted:
 			return k8serrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)
+		case SandboxStatusTerminating:
+			return k8serrors.NewConflict(schema.GroupResource{Resource: "sandbox"}, sandboxID, fmt.Errorf("sandbox termination is in progress"))
 		case SandboxStatusPaused:
 			status = SandboxStatusPaused
 			return nil
@@ -278,6 +293,8 @@ func (s *SandboxService) pauseSandboxRuntime(ctx context.Context, sandboxID stri
 			switch record.Status {
 			case SandboxStatusDeleted:
 				return k8serrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)
+			case SandboxStatusTerminating:
+				return k8serrors.NewConflict(schema.GroupResource{Resource: "sandbox"}, sandboxID, fmt.Errorf("sandbox termination is in progress"))
 			case SandboxStatusPaused:
 				return nil
 			case SandboxStatusStarting:
@@ -362,7 +379,8 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 	}
 	crashRecovery := txn.Source == SandboxLifecycleSourceCrash
 	healthRecovery := txn.Source == SandboxLifecycleSourceHealth
-	runtimeRecovery := crashRecovery || healthRecovery
+	lostRecovery := txn.Source == SandboxLifecycleSourceLost
+	runtimeRecovery := crashRecovery || healthRecovery || lostRecovery
 	abortOnError := func(completionErr error) {
 		if !runtimeRecovery && completionErr != nil {
 			_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, completionErr.Error())
@@ -376,11 +394,16 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			if runtimeRecovery && s.logger != nil {
-				s.logger.Error("Runtime disappeared before rootfs recovery",
+				fields := []zap.Field{
 					zap.String("sandboxID", sandboxID),
 					zap.Int64("runtimeGeneration", txn.FromGeneration),
 					zap.String("source", txn.Source),
-				)
+				}
+				if lostRecovery {
+					s.logger.Warn("Runtime is missing; recovering from the last committed rootfs", fields...)
+				} else {
+					s.logger.Error("Runtime disappeared before rootfs recovery", fields...)
+				}
 			}
 			_, commitErr := s.commitPausingRuntimePaused(ctx, sandboxID, txn, record.RuntimeGeneration, nil)
 			return commitErr
@@ -402,6 +425,9 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 		return nil
 	}
 	if healthRecovery && pod.DeletionTimestamp != nil {
+		return errSandboxRuntimeDeleting
+	}
+	if lostRecovery && pod.DeletionTimestamp != nil {
 		return errSandboxRuntimeDeleting
 	}
 	if crashRecovery {
@@ -609,7 +635,7 @@ func (s *SandboxService) commitPausingRuntimePaused(ctx context.Context, sandbox
 				return err
 			}
 		}
-		if err := tx.MarkRuntimePaused(lockCtx, sandboxID, generation, s.clock.Now()); err != nil {
+		if err := tx.MarkRuntimePaused(lockCtx, sandboxID, generation, s.now()); err != nil {
 			return err
 		}
 		preparedHead := ""
@@ -1119,22 +1145,6 @@ func (s *SandboxService) persistUpdatedSandboxPod(ctx context.Context, pod *core
 	if sandboxID == "" {
 		sandboxID = pod.Name
 	}
-	existing, err := s.sandboxStore.GetSandbox(ctx, sandboxID)
-	if err != nil && !errors.Is(err, ErrSandboxRecordNotFound) {
-		return fmt.Errorf("get sandbox record before pod persistence: %w", err)
-	}
-	if existing != nil {
-		if existing.Status == SandboxStatusPaused || existing.Status == SandboxStatusDeleted {
-			return nil
-		}
-		activeTxn, txnErr := s.sandboxStore.GetActiveLifecycleTxn(ctx, sandboxID)
-		if txnErr != nil {
-			return fmt.Errorf("get active sandbox lifecycle txn before pod persistence: %w", txnErr)
-		}
-		if sandboxLifecycleTxnHidesCommittedRuntime(activeTxn) {
-			return nil
-		}
-	}
 	template := s.templateForPod(pod)
 	if template == nil {
 		return nil
@@ -1161,7 +1171,31 @@ func (s *SandboxService) persistUpdatedSandboxPod(ctx context.Context, pod *core
 		OwnerKind:            ownerKindFromPod(pod),
 		CreatedAt:            pod.CreationTimestamp.Time,
 	}
-	return s.sandboxStore.UpsertSandbox(ctx, record)
+	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, locked *SandboxRecord) error {
+		if locked.Status == SandboxStatusPaused || locked.Status == SandboxStatusTerminating || locked.Status == SandboxStatusDeleted || !locked.DeletedAt.IsZero() {
+			return nil
+		}
+		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sandboxID)
+		if err != nil {
+			return err
+		}
+		if sandboxLifecycleTxnHidesCommittedRuntime(activeTxn) {
+			return nil
+		}
+		podGeneration := runtimeGenerationFromPod(pod)
+		if podGeneration < locked.RuntimeGeneration || podGeneration > locked.RuntimeGeneration {
+			return nil
+		}
+		if strings.TrimSpace(locked.CurrentPodName) != "" &&
+			(locked.CurrentPodName != pod.Name || locked.CurrentPodNamespace != pod.Namespace) {
+			return nil
+		}
+		return tx.SaveSandbox(lockCtx, record)
+	})
+	if errors.Is(err, ErrSandboxRecordNotFound) {
+		return s.sandboxStore.UpsertSandbox(ctx, record)
+	}
+	return err
 }
 
 func (s *SandboxService) getSandboxPod(ctx context.Context, sandboxID string) (*corev1.Pod, error) {

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -56,6 +56,9 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 			if locked.Status == SandboxStatusDeleted || !locked.DeletedAt.IsZero() {
 				return k8serrors.NewNotFound(corev1.Resource("sandbox"), sandboxID)
 			}
+			if locked.Status == SandboxStatusTerminating {
+				return k8serrors.NewConflict(corev1.Resource("sandbox"), sandboxID, fmt.Errorf("sandbox termination is in progress"))
+			}
 			if sandboxHardExpired(locked.HardExpiresAt, s.now()) {
 				return k8serrors.NewNotFound(corev1.Resource("sandbox"), sandboxID)
 			}
@@ -124,18 +127,9 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 			if getErr != nil && !k8serrors.IsNotFound(getErr) {
 				return fmt.Errorf("get current runtime pod: %w", getErr)
 			}
-			if locked.Status == SandboxStatusStarting {
-				// No active resume transaction owns this state. Reconcile it before
-				// creating a replacement runtime so a timed-out caller cannot leave
-				// the durable record permanently stuck in starting.
-				if err := tx.MarkRuntimePaused(lockCtx, sandboxID, locked.RuntimeGeneration, s.now()); err != nil {
-					return err
-				}
-				waitErr = errSandboxRuntimeStateReconciled
-				return nil
-			}
 			if locked.Status != SandboxStatusPaused {
-				return k8serrors.NewConflict(corev1.Resource("sandbox"), sandboxID, fmt.Errorf("sandbox runtime for status %q is not available", locked.Status))
+				waitErr = errSandboxRuntimeReconcileRequested
+				return nil
 			}
 
 			resumeTemplate, err := s.templateForSandboxRecord(locked)
@@ -205,7 +199,18 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 				return nil, err
 			}
 			continue
-		case errors.Is(err, errSandboxRuntimeStateReconciled):
+		case errors.Is(err, errSandboxRuntimeReconcileRequested):
+			if err := s.ReconcileSandboxRuntime(ctx, sandboxID); err != nil {
+				return nil, err
+			}
+			if err := s.waitForSandboxLifecycleTxnExit(ctx, sandboxID); err != nil {
+				return nil, err
+			}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(sandboxLifecycleWaitInterval):
+			}
 			continue
 		default:
 			return nil, err
@@ -347,7 +352,7 @@ var (
 	errSandboxLifecycleResuming            = errors.New("sandbox lifecycle resume is in progress")
 	errSandboxLifecycleRootFSCheckpointing = errors.New("sandbox lifecycle rootfs checkpoint is in progress")
 	errSandboxRuntimeDeleting              = errors.New("sandbox runtime pod deletion is in progress")
-	errSandboxRuntimeStateReconciled       = errors.New("sandbox runtime state was reconciled")
+	errSandboxRuntimeReconcileRequested    = errors.New("sandbox runtime state requires reconciliation")
 )
 
 type sandboxRuntimePodRef struct {

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -377,7 +377,13 @@ func (s *SandboxService) saveRestoredRuntimePod(ctx context.Context, pod *corev1
 	if sandboxID == "" {
 		return fmt.Errorf("sandbox_id is required")
 	}
-	return s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, _ *SandboxRecord) error {
+	return s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, locked *SandboxRecord) error {
+		if locked == nil || locked.Status == SandboxStatusTerminating || locked.Status == SandboxStatusDeleted || !locked.DeletedAt.IsZero() {
+			return nil
+		}
+		if runtimeGenerationFromPod(pod) < locked.RuntimeGeneration {
+			return nil
+		}
 		return tx.SaveRuntime(lockCtx, sandboxID, pod.Namespace, pod.Name, status, runtimeGenerationFromPod(pod), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt), sandboxRuntimeMetadataFromPod(pod))
 	})
 }

--- a/manager/pkg/service/sandbox_service_ttl_test.go
+++ b/manager/pkg/service/sandbox_service_ttl_test.go
@@ -228,32 +228,38 @@ func TestUpdateSandboxPausedRecordIgnoresStaleRuntimePod(t *testing.T) {
 	assert.Equal(t, "2026-03-07T12:05:00Z", stored.Annotations[controller.AnnotationExpiresAt])
 }
 
-func TestPersistUpdatedSandboxPodDoesNotOverwritePausedRecord(t *testing.T) {
-	pod := testSandboxPod()
-	pod.Annotations[controller.AnnotationConfig] = `{"ttl":0}`
+func TestPersistUpdatedSandboxPodDoesNotOverwriteDurableLifecycleState(t *testing.T) {
+	for _, status := range []string{SandboxStatusPaused, SandboxStatusTerminating, SandboxStatusDeleted} {
+		t.Run(status, func(t *testing.T) {
+			pod := testSandboxPod()
+			pod.Annotations[controller.AnnotationConfig] = `{"ttl":0}`
 
-	svc, _ := newSandboxServiceForTTLTests(t, pod, 0)
-	store := &memorySandboxStore{records: map[string]*SandboxRecord{
-		"sandbox-1": {
-			ID:                "sandbox-1",
-			TeamID:            "team-1",
-			UserID:            "user-1",
-			TemplateID:        "default",
-			TemplateName:      "default",
-			TemplateNamespace: "tpl-default",
-			Status:            SandboxStatusPaused,
-			Config:            SandboxConfig{TTL: int32Ptr(300)},
-			RuntimeGeneration: 3,
-		},
-	}}
-	svc.sandboxStore = store
+			svc, _ := newSandboxServiceForTTLTests(t, pod, 0)
+			store := &memorySandboxStore{records: map[string]*SandboxRecord{
+				"sandbox-1": {
+					ID:                  "sandbox-1",
+					TeamID:              "team-1",
+					UserID:              "user-1",
+					TemplateID:          "default",
+					TemplateName:        "default",
+					TemplateNamespace:   "tpl-default",
+					Status:              status,
+					Config:              SandboxConfig{TTL: int32Ptr(300)},
+					CurrentPodName:      pod.Name,
+					CurrentPodNamespace: pod.Namespace,
+					RuntimeGeneration:   3,
+				},
+			}}
+			svc.sandboxStore = store
 
-	require.NoError(t, svc.persistUpdatedSandboxPod(context.Background(), pod))
-	record, err := store.GetSandbox(context.Background(), "sandbox-1")
-	require.NoError(t, err)
-	require.NotNil(t, record.Config.TTL)
-	assert.Equal(t, SandboxStatusPaused, record.Status)
-	assert.Equal(t, int32(300), *record.Config.TTL)
+			require.NoError(t, svc.persistUpdatedSandboxPod(context.Background(), pod))
+			record, err := store.GetSandbox(context.Background(), "sandbox-1")
+			require.NoError(t, err)
+			require.NotNil(t, record.Config.TTL)
+			assert.Equal(t, status, record.Status)
+			assert.Equal(t, int32(300), *record.Config.TTL)
+		})
+	}
 }
 
 func TestPersistUpdatedSandboxPodStoresRuntimeMetadata(t *testing.T) {

--- a/manager/pkg/service/sandbox_store.go
+++ b/manager/pkg/service/sandbox_store.go
@@ -116,6 +116,7 @@ const (
 	SandboxLifecycleSourceAuto   = "auto"
 	SandboxLifecycleSourceCrash  = "crash"
 	SandboxLifecycleSourceHealth = "health"
+	SandboxLifecycleSourceLost   = "lost"
 
 	SandboxLifecyclePhasePreparing  = "preparing"
 	SandboxLifecyclePhaseBarriered  = "barriered"
@@ -158,6 +159,17 @@ type SandboxRuntimeMetadata struct {
 	OwnerKind            string
 }
 
+// SandboxRuntimeReconcileCandidate is the durable runtime projection used by
+// the anti-entropy controller. Pod fields are hints only; Kubernetes remains
+// authoritative for whether the referenced runtime currently exists.
+type SandboxRuntimeReconcileCandidate struct {
+	SandboxID         string
+	Status            string
+	PodNamespace      string
+	PodName           string
+	RuntimeGeneration int64
+}
+
 // SandboxStore persists sandbox identities independently of runtime pods.
 type SandboxStore interface {
 	UpsertSandbox(ctx context.Context, record *SandboxRecord) error
@@ -174,8 +186,10 @@ type SandboxStore interface {
 
 // SandboxStoreTx is a locked sandbox store transaction.
 type SandboxStoreTx interface {
+	SaveSandbox(ctx context.Context, record *SandboxRecord) error
 	SaveRuntime(ctx context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time, metadata SandboxRuntimeMetadata) error
 	MarkRuntimePaused(ctx context.Context, sandboxID string, generation int64, pausedAt time.Time) error
+	MarkRuntimeTerminating(ctx context.Context, sandboxID string) error
 	SaveRootFSState(ctx context.Context, state *SandboxRootFSState) error
 	GetActiveLifecycleTxn(ctx context.Context, sandboxID string) (*SandboxLifecycleTxn, error)
 	BeginLifecycleTxn(ctx context.Context, txn *SandboxLifecycleTxn) error
@@ -263,11 +277,14 @@ func upsertSandboxRecord(ctx context.Context, exec rootFSStateExecutor, record *
 			hard_expires_at = EXCLUDED.hard_expires_at,
 			deleted_at = EXCLUDED.deleted_at,
 			updated_at = NOW()
+		WHERE manager.sandboxes.deleted_at IS NULL
+			AND manager.sandboxes.status NOT IN ($23, $24)
 	`, record.ID, record.TeamID, record.UserID, record.TemplateID, record.TemplateName, record.TemplateNamespace,
 		record.ClusterID, record.Status, configJSON, mountsJSON, specJSON,
 		record.CurrentPodName, record.CurrentPodNamespace, record.RuntimeGeneration, record.LifecycleEpoch,
 		strings.TrimSpace(record.WebhookStateVolumeID), strings.TrimSpace(record.OwnerKind),
-		nullableTime(record.ClaimedAt), nullableTime(record.ExpiresAt), nullableTime(record.HardExpiresAt), nullableTime(record.DeletedAt), nullableTime(record.CreatedAt))
+		nullableTime(record.ClaimedAt), nullableTime(record.ExpiresAt), nullableTime(record.HardExpiresAt), nullableTime(record.DeletedAt), nullableTime(record.CreatedAt),
+		SandboxStatusTerminating, SandboxStatusDeleted)
 	if err != nil {
 		return fmt.Errorf("upsert sandbox: %w", err)
 	}
@@ -383,15 +400,16 @@ func (s *PGSandboxStore) ListPendingRuntimeRecoverySandboxIDs(ctx context.Contex
 			WHERE s.deleted_at IS NULL
 				AND s.status = $2
 				AND latest.kind = $3
-				AND latest.source IN ($4, $5)
+				AND latest.source IN ($4, $5, $6)
 			ORDER BY s.updated_at ASC
-			LIMIT $6
+			LIMIT $7
 		`,
 		SandboxLifecyclePhaseCommitted,
 		SandboxStatusPaused,
 		SandboxLifecycleKindPause,
 		SandboxLifecycleSourceCrash,
 		SandboxLifecycleSourceHealth,
+		SandboxLifecycleSourceLost,
 		limit,
 	)
 	if err != nil {
@@ -410,6 +428,60 @@ func (s *PGSandboxStore) ListPendingRuntimeRecoverySandboxIDs(ctx context.Contex
 		return nil, fmt.Errorf("iterate pending runtime recovery sandboxes: %w", err)
 	}
 	return sandboxIDs, nil
+}
+
+// ListRuntimeReconcileCandidates returns a stable page of sandboxes whose
+// durable state expects either an active runtime or completion of deletion.
+// The controller compares these projections with its synced Pod cache before
+// performing a strong Kubernetes API read for suspected mismatches.
+func (s *PGSandboxStore) ListRuntimeReconcileCandidates(ctx context.Context, clusterID, afterSandboxID string, limit int) ([]SandboxRuntimeReconcileCandidate, error) {
+	if s == nil || s.pool == nil {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 500
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT sandbox_id, status, current_pod_namespace, current_pod_name, runtime_generation
+		FROM manager.sandboxes
+		WHERE deleted_at IS NULL
+			AND (
+				status IN ($1, $2, $3, $4)
+				OR EXISTS (
+					SELECT 1
+					FROM manager.sandbox_lifecycle_txns txn
+					WHERE txn.sandbox_id = manager.sandboxes.sandbox_id
+						AND txn.kind = $5
+						AND txn.phase IN ('preparing', 'barriered', 'publishing', 'committing')
+				)
+			)
+			AND cluster_id = $6
+			AND sandbox_id > $7
+		ORDER BY sandbox_id ASC
+		LIMIT $8
+	`, SandboxStatusStarting, SandboxStatusRunning, SandboxStatusFailed, SandboxStatusTerminating, SandboxLifecycleKindResume, strings.TrimSpace(clusterID), strings.TrimSpace(afterSandboxID), limit)
+	if err != nil {
+		return nil, fmt.Errorf("list sandbox runtime reconcile candidates: %w", err)
+	}
+	defer rows.Close()
+	candidates := make([]SandboxRuntimeReconcileCandidate, 0, limit)
+	for rows.Next() {
+		var candidate SandboxRuntimeReconcileCandidate
+		if err := rows.Scan(
+			&candidate.SandboxID,
+			&candidate.Status,
+			&candidate.PodNamespace,
+			&candidate.PodName,
+			&candidate.RuntimeGeneration,
+		); err != nil {
+			return nil, fmt.Errorf("scan sandbox runtime reconcile candidate: %w", err)
+		}
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate sandbox runtime reconcile candidates: %w", err)
+	}
+	return candidates, nil
 }
 
 func (s *PGSandboxStore) GetActiveLifecycleTxn(ctx context.Context, sandboxID string) (*SandboxLifecycleTxn, error) {
@@ -629,6 +701,10 @@ type sandboxStoreTx struct {
 	tx pgx.Tx
 }
 
+func (t sandboxStoreTx) SaveSandbox(ctx context.Context, record *SandboxRecord) error {
+	return upsertSandboxRecord(ctx, t.tx, record)
+}
+
 func (t sandboxStoreTx) SaveRuntime(ctx context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time, metadata SandboxRuntimeMetadata) error {
 	tag, err := t.tx.Exec(ctx, `
 		UPDATE manager.sandboxes
@@ -644,7 +720,8 @@ func (t sandboxStoreTx) SaveRuntime(ctx context.Context, sandboxID, namespace, p
 			updated_at = NOW()
 		WHERE sandbox_id = $1
 			AND deleted_at IS NULL
-	`, sandboxID, status, namespace, podName, generation, nullableTime(expiresAt), nullableTime(hardExpiresAt), strings.TrimSpace(metadata.WebhookStateVolumeID), strings.TrimSpace(metadata.OwnerKind))
+			AND status NOT IN ($10, $11)
+	`, sandboxID, status, namespace, podName, generation, nullableTime(expiresAt), nullableTime(hardExpiresAt), strings.TrimSpace(metadata.WebhookStateVolumeID), strings.TrimSpace(metadata.OwnerKind), SandboxStatusTerminating, SandboxStatusDeleted)
 	if err != nil {
 		return fmt.Errorf("save sandbox runtime: %w", err)
 	}
@@ -665,9 +742,27 @@ func (t sandboxStoreTx) MarkRuntimePaused(ctx context.Context, sandboxID string,
 			updated_at = NOW()
 		WHERE sandbox_id = $1
 			AND deleted_at IS NULL
-	`, sandboxID, SandboxStatusPaused, generation)
+			AND status NOT IN ($4, $5)
+	`, sandboxID, SandboxStatusPaused, generation, SandboxStatusTerminating, SandboxStatusDeleted)
 	if err != nil {
 		return fmt.Errorf("mark sandbox runtime paused: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("%w: %s", ErrSandboxRecordNotFound, sandboxID)
+	}
+	return nil
+}
+
+func (t sandboxStoreTx) MarkRuntimeTerminating(ctx context.Context, sandboxID string) error {
+	tag, err := t.tx.Exec(ctx, `
+		UPDATE manager.sandboxes
+		SET status = $2,
+			updated_at = NOW()
+		WHERE sandbox_id = $1
+			AND deleted_at IS NULL
+	`, sandboxID, SandboxStatusTerminating)
+	if err != nil {
+		return fmt.Errorf("mark sandbox runtime terminating: %w", err)
 	}
 	if tag.RowsAffected() == 0 {
 		return fmt.Errorf("%w: %s", ErrSandboxRecordNotFound, sandboxID)

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/metering"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/quota"
+	"github.com/sandbox0-ai/sandbox0/pkg/runtimecontrol"
 	e2eutils "github.com/sandbox0-ai/sandbox0/tests/e2e/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
@@ -270,6 +271,10 @@ func registerApiModeSuite(envProvider func() *framework.ScenarioEnv, opts apiMod
 			if opts.includeRootFSPauseResume {
 				It("persists rootfs changes across pause and resume", func() {
 					assertSandboxRootFSPersistsAcrossPauseResume(env, session)
+				})
+
+				It("reconstructs a missing runtime without duplicating generations", Label("runtime-reconciliation"), func() {
+					assertSandboxRuntimeReconcilesUnexpectedPodDeletion(env, session)
 				})
 
 				It("keeps a SandboxVolume mounted beneath ephemeral tmp", func() {
@@ -1479,6 +1484,150 @@ test "$(cat %s)" = persistent-var-tmp
 	)
 	_, err = execInSandboxPod(env, templateNamespace, restored.PodName, verifyScript)
 	Expect(err).NotTo(HaveOccurred())
+}
+
+func assertSandboxRuntimeReconcilesUnexpectedPodDeletion(env *framework.ScenarioEnv, session *e2eutils.Session) {
+	claimResp := claimSandboxEventually(env, session, "default")
+	sandboxID := claimResp.SandboxId
+	Expect(sandboxID).NotTo(BeEmpty())
+	DeferCleanup(func() {
+		_ = session.DeleteSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
+	})
+
+	templateNamespace, err := naming.TemplateNamespaceForBuiltin("default")
+	Expect(err).NotTo(HaveOccurred())
+	current := waitForSandboxPodReadyEventually(env, session, sandboxID, templateNamespace)
+	uncommittedPath := fmt.Sprintf("/root/s0-runtime-uncommitted-%d", time.Now().UnixNano())
+	_, err = execInSandboxPod(env, templateNamespace, current.PodName, fmt.Sprintf(
+		"printf uncommitted > %s",
+		shellQuote(uncommittedPath),
+	))
+	Expect(err).NotTo(HaveOccurred())
+
+	current = forceDeleteSandboxRuntimeAndWaitForReplacement(env, session, sandboxID, templateNamespace, current)
+	_, err = execInSandboxPod(env, templateNamespace, current.PodName, fmt.Sprintf(
+		"test ! -e %s",
+		shellQuote(uncommittedPath),
+	))
+	Expect(err).NotTo(HaveOccurred(), "a runtime lost before its first checkpoint must restart from the template baseline")
+
+	marker := fmt.Sprintf("s0-runtime-reconcile-%d", time.Now().UnixNano())
+	markerPath := "/root/" + marker
+	markerContent := "last committed rootfs " + marker
+	_, err = execInSandboxPod(env, templateNamespace, current.PodName, fmt.Sprintf(
+		"printf %%s %s > %s",
+		shellQuote(markerContent),
+		shellQuote(markerPath),
+	))
+	Expect(err).NotTo(HaveOccurred())
+
+	_, status, err := session.PauseSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	waitForSandboxLifecycleStatusEventually(env, session, sandboxID, apispec.SandboxLifecycleStatusPaused)
+
+	resumeResp, status, err := session.ResumeSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(resumeResp).NotTo(BeNil())
+	Expect(resumeResp.Resumed).To(BeTrue())
+	current = waitForSandboxPodReadyEventually(env, session, sandboxID, templateNamespace)
+
+	for iteration := 0; iteration < 3; iteration++ {
+		current = forceDeleteSandboxRuntimeAndWaitForReplacement(env, session, sandboxID, templateNamespace, current)
+		_, err = execInSandboxPod(env, templateNamespace, current.PodName, fmt.Sprintf(
+			"test \"$(cat %s)\" = %s",
+			shellQuote(markerPath),
+			shellQuote(markerContent),
+		))
+		Expect(err).NotTo(HaveOccurred())
+	}
+}
+
+func forceDeleteSandboxRuntimeAndWaitForReplacement(
+	env *framework.ScenarioEnv,
+	session *e2eutils.Session,
+	sandboxID string,
+	templateNamespace string,
+	current *apispec.Sandbox,
+) *apispec.Sandbox {
+	oldPodName := current.PodName
+	oldGeneration := current.RuntimeGeneration
+	Expect(framework.Kubectl(
+		env.TestCtx.Context,
+		env.Config.Kubeconfig,
+		"-n", templateNamespace,
+		"delete", "pod", oldPodName,
+		"--force", "--grace-period=0", "--wait=false",
+	)).To(Succeed())
+
+	Eventually(func() error {
+		observed, observedStatus, err := session.GetSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
+		if err != nil {
+			return err
+		}
+		if observedStatus != http.StatusOK {
+			return fmt.Errorf("get sandbox returned status %d", observedStatus)
+		}
+		if observed == nil {
+			return fmt.Errorf("sandbox response missing")
+		}
+		if observed.Status != apispec.SandboxLifecycleStatusRunning {
+			return fmt.Errorf("sandbox status is %s", observed.Status)
+		}
+		if observed.PodName == "" || observed.PodName == oldPodName {
+			return fmt.Errorf("replacement pod is not published")
+		}
+		if observed.RuntimeGeneration <= oldGeneration {
+			return fmt.Errorf("runtime generation did not advance: old=%d current=%d", oldGeneration, observed.RuntimeGeneration)
+		}
+		current = observed
+		return nil
+	}).WithTimeout(3 * time.Minute).WithPolling(2 * time.Second).Should(Succeed())
+
+	current = waitForSandboxPodReadyEventually(env, session, sandboxID, templateNamespace)
+	Eventually(func() error {
+		podListJSON, err := framework.KubectlOutput(
+			env.TestCtx.Context,
+			env.Config.Kubeconfig,
+			"-n", templateNamespace,
+			"get", "pods",
+			"-l", "sandbox0.ai/sandbox-id="+sandboxID,
+			"-o", "json",
+		)
+		if err != nil {
+			return err
+		}
+		var podList e2ePodList
+		if err := json.Unmarshal([]byte(podListJSON), &podList); err != nil {
+			return err
+		}
+		var activePod *e2ePod
+		for _, pod := range podList.Items {
+			if pod.Metadata.DeletionTimestamp == nil {
+				if activePod != nil {
+					return fmt.Errorf("multiple active runtime pods remain")
+				}
+				pod := pod
+				activePod = &pod
+			}
+		}
+		if len(podList.Items) != 1 || activePod == nil {
+			return fmt.Errorf("runtime pod set has not converged: total=%d", len(podList.Items))
+		}
+		if activePod.Metadata.Name != current.PodName {
+			return fmt.Errorf("API pod %s does not match Kubernetes pod %s", current.PodName, activePod.Metadata.Name)
+		}
+		generation, err := strconv.ParseInt(strings.TrimSpace(activePod.Metadata.Annotations[runtimecontrol.AnnotationRuntimeGeneration]), 10, 64)
+		if err != nil {
+			return fmt.Errorf("parse runtime generation annotation: %w", err)
+		}
+		if generation != current.RuntimeGeneration {
+			return fmt.Errorf("API generation %d does not match Kubernetes generation %d", current.RuntimeGeneration, generation)
+		}
+		return nil
+	}).WithTimeout(3 * time.Minute).WithPolling(2 * time.Second).Should(Succeed())
+	return current
 }
 
 func assertSandboxVolumeUnderTmpPersistsAcrossPauseResume(env *framework.ScenarioEnv, session *e2eutils.Session) {

--- a/tests/integration/internal/tests/manager/api_test.go
+++ b/tests/integration/internal/tests/manager/api_test.go
@@ -969,6 +969,10 @@ func (s *memorySandboxStoreForManagerIntegration) UpsertSandbox(_ context.Contex
 	if record == nil || record.ID == "" {
 		return nil
 	}
+	if existing := s.records[record.ID]; existing != nil &&
+		(existing.Status == service.SandboxStatusTerminating || existing.Status == service.SandboxStatusDeleted || !existing.DeletedAt.IsZero()) {
+		return nil
+	}
 	s.records[record.ID] = cloneSandboxRecordForManagerIntegration(record)
 	return nil
 }
@@ -1230,9 +1234,15 @@ type memorySandboxStoreTxForManagerIntegration struct {
 	store *memorySandboxStoreForManagerIntegration
 }
 
+var _ service.SandboxStoreTx = memorySandboxStoreTxForManagerIntegration{}
+
+func (t memorySandboxStoreTxForManagerIntegration) SaveSandbox(ctx context.Context, record *service.SandboxRecord) error {
+	return t.store.UpsertSandbox(ctx, record)
+}
+
 func (t memorySandboxStoreTxForManagerIntegration) SaveRuntime(_ context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time, metadata service.SandboxRuntimeMetadata) error {
 	record := t.store.records[sandboxID]
-	if record == nil || !record.DeletedAt.IsZero() {
+	if record == nil || record.Status == service.SandboxStatusTerminating || record.Status == service.SandboxStatusDeleted || !record.DeletedAt.IsZero() {
 		return service.ErrSandboxRecordNotFound
 	}
 	record.CurrentPodNamespace = namespace
@@ -1252,7 +1262,7 @@ func (t memorySandboxStoreTxForManagerIntegration) SaveRuntime(_ context.Context
 
 func (t memorySandboxStoreTxForManagerIntegration) MarkRuntimePaused(_ context.Context, sandboxID string, generation int64, _ time.Time) error {
 	record := t.store.records[sandboxID]
-	if record == nil || !record.DeletedAt.IsZero() {
+	if record == nil || record.Status == service.SandboxStatusTerminating || record.Status == service.SandboxStatusDeleted || !record.DeletedAt.IsZero() {
 		return service.ErrSandboxRecordNotFound
 	}
 	record.CurrentPodNamespace = ""
@@ -1262,6 +1272,15 @@ func (t memorySandboxStoreTxForManagerIntegration) MarkRuntimePaused(_ context.C
 		record.RuntimeGeneration = generation
 	}
 	record.ExpiresAt = time.Time{}
+	return nil
+}
+
+func (t memorySandboxStoreTxForManagerIntegration) MarkRuntimeTerminating(_ context.Context, sandboxID string) error {
+	record := t.store.records[sandboxID]
+	if record == nil || !record.DeletedAt.IsZero() {
+		return service.ErrSandboxRecordNotFound
+	}
+	record.Status = service.SandboxStatusTerminating
 	return nil
 }
 
@@ -1365,6 +1384,34 @@ func (t memorySandboxStoreTxForManagerIntegration) AbortLifecycleTxn(_ context.C
 		txn.Error = reason
 	}
 	return nil
+}
+
+func TestMemorySandboxStoreTxForManagerIntegrationFencesTerminatingRuntime(t *testing.T) {
+	const sandboxID = "sandbox-terminating"
+	store := newMemorySandboxStoreForManagerIntegration(&service.SandboxRecord{
+		ID:     sandboxID,
+		Status: service.SandboxStatusRunning,
+	}, nil)
+	tx := memorySandboxStoreTxForManagerIntegration{store: store}
+
+	if err := tx.MarkRuntimeTerminating(t.Context(), sandboxID); err != nil {
+		t.Fatalf("mark runtime terminating: %v", err)
+	}
+	if got := store.records[sandboxID].Status; got != service.SandboxStatusTerminating {
+		t.Fatalf("expected terminating status, got %q", got)
+	}
+	if err := tx.MarkRuntimePaused(t.Context(), sandboxID, 2, time.Now()); !stderrors.Is(err, service.ErrSandboxRecordNotFound) {
+		t.Fatalf("expected paused write to be fenced, got %v", err)
+	}
+	if err := tx.SaveRuntime(t.Context(), sandboxID, "default", "replacement", service.SandboxStatusRunning, 2, time.Time{}, time.Time{}, service.SandboxRuntimeMetadata{}); !stderrors.Is(err, service.ErrSandboxRecordNotFound) {
+		t.Fatalf("expected runtime write to be fenced, got %v", err)
+	}
+	if err := tx.SaveSandbox(t.Context(), &service.SandboxRecord{ID: sandboxID, Status: service.SandboxStatusRunning}); err != nil {
+		t.Fatalf("save stale sandbox projection: %v", err)
+	}
+	if got := store.records[sandboxID].Status; got != service.SandboxStatusTerminating {
+		t.Fatalf("expected stale sandbox projection to remain fenced, got %q", got)
+	}
 }
 
 func cloneSandboxRecordForManagerIntegration(record *service.SandboxRecord) *service.SandboxRecord {


### PR DESCRIPTION
## Summary

- persist explicit termination intent before deleting Kubernetes runtimes
- reconcile missing runtime Pods from durable sandbox state through Pod events and a periodic anti-entropy scan
- fence recovery by cluster, lifecycle transaction, Pod identity, and runtime generation; fail closed when the Kubernetes API is unavailable or runtime identity is ambiguous
- recover from the last committed rootfs head without deleting sandbox credentials or webhook state
- document degraded recovery semantics and add unit, E2E, restart, termination-race, and node-chaos coverage

## Root cause

The manager treated its current Pod projection as lifecycle truth. If a Pod disappeared while an informer event was missed or the manager restarted, PostgreSQL could remain `running` and point at a nonexistent Pod. The deletion cleanup path could also interpret deletion of the current Pod as deletion of the sandbox, and there was no periodic controller to repair the mismatch.

## Impact

Missing runtimes now converge to one new generation of the same sandbox identity. Writes after the last committed checkpoint remain unrecoverable if the old containerd snapshot is gone; mounted Sandbox Volumes retain their independent durability. Explicit deletion and hard TTL always win and cannot be undone by stale writers.

## Validation

- `make test manager`
- `go test -race ./manager/pkg/service`
- `go vet ./manager/...`
- `go test ./tests/e2e/... -run '^$'`
- isolated 3-node Kind/fullmode E2E on a temporary Aliyun ECS: pre-checkpoint loss plus three post-checkpoint losses, including API/Kubernetes generation consistency
- chaos validation: manager-down missed event, manager restart during recovery, three terminate/delete orderings, and worker-node pause/relocation
- PostgreSQL invariants: no active lifecycle transactions after convergence and deleted sandboxes did not resurrect

The temporary ECS was deleted after validation; the existing shared remote test environment was not used.
