### PR TITLE
refactor(manager): separate desired and observed sandbox state

### DIFF
--- a/docs/sandbox/page.mdx
+++ b/docs/sandbox/page.mdx
@@ -32,6 +32,10 @@ Sandbox0 Cloud clients should use `https://api.sandbox0.ai`. Set `SANDBOX0_BASE_
 | `failed` | Sandbox encountered an error |
 
 <Callout variant="info">
+`starting`, `running`, and `failed` reflect the current runtime Pod observed through manager's Kubernetes informer cache. Durable sandbox intent is stored separately, so a manager restart does not need to copy Pod readiness back into PostgreSQL. If an active sandbox temporarily has no cached runtime while recovery is in progress, its status is `starting`.
+</Callout>
+
+<Callout variant="info">
 Pause and resume use internal lifecycle transactions, but `pausing` and `resuming` are not caller-visible statuses. Use the `paused` boolean as a convenience for `status == "paused"`. Pause does not preserve running processes, memory, sockets, PID state, or live REPL sessions.
 </Callout>
 

--- a/docs/sandbox/pause-resume/page.mdx
+++ b/docs/sandbox/pause-resume/page.mdx
@@ -168,7 +168,7 @@ console.log("Resume requested");`
 
 After requesting a pause or resume, fetch sandbox details to check the lifecycle status.
 
-During asynchronous pause, `paused` remains `false` and `status` continues to reflect the last committed runtime state, usually `running`. It becomes `true` only after checkpoint upload has completed, the runtime pod has been released, and the sandbox is safe to resume from durable state.
+During asynchronous pause, `paused` remains `false` and `status` continues to reflect the cached runtime Pod state, usually `running`. It becomes `true` only after checkpoint upload has completed, the runtime pod has been released, and the sandbox is safe to resume from durable state.
 
 During resume, callers may wait while Sandbox0 creates and initializes a new runtime generation. After the resume transaction commits, `status` is `running`, `paused` is `false`, and `runtime_generation` has advanced. If an automatic pause is canceled before commit, `status` remains `running`, `paused` remains `false`, and `runtime_generation` does not change.
 

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -81,7 +81,7 @@ const (
 
 	HotClaimReservationStateInitializing = "initializing"
 	HotClaimReservationStateReady        = "ready"
-	HotClaimCompletionProtocolRecordV1   = "record-status-v1"
+	HotClaimCompletionProtocolRecordV2   = "record-completion-v2"
 
 	unhealthyIdlePodRepairGracePeriod = 2 * time.Minute
 	warmPoolRolloutRequeueAfter       = 10 * time.Second

--- a/manager/pkg/service/hot_claim_reservation.go
+++ b/manager/pkg/service/hot_claim_reservation.go
@@ -9,7 +9,7 @@ import (
 )
 
 // completeHotClaimReservation durably records successful sandbox
-// initialization. The reservation controller uses this record transition to
+// initialization. The reservation controller uses this workflow marker to
 // detach the Pod, so the request path does not need a second Pod patch.
 func (s *SandboxService) completeHotClaimReservation(
 	ctx context.Context,
@@ -22,7 +22,7 @@ func (s *SandboxService) completeHotClaimReservation(
 		return nil
 	}
 	record := sandboxRecordForClaimedPod(s, pod, template, req)
-	record.Status = SandboxStatusRunning
+	record.HotClaimCompletedAt = s.clock.Now().UTC()
 	return s.sandboxStore.UpsertSandbox(ctx, record)
 }
 
@@ -30,7 +30,7 @@ func hotClaimUsesRecordCompletion(pod *corev1.Pod) bool {
 	return pod != nil &&
 		controller.IsHotClaimReservedPod(pod) &&
 		pod.Annotations[controller.AnnotationHotClaimCompletionProtocol] ==
-			controller.HotClaimCompletionProtocolRecordV1
+			controller.HotClaimCompletionProtocolRecordV2
 }
 
 func (s *SandboxService) enqueueHotClaimReservation(pod *corev1.Pod) {

--- a/manager/pkg/service/hot_claim_reservation_controller.go
+++ b/manager/pkg/service/hot_claim_reservation_controller.go
@@ -325,8 +325,8 @@ func hotClaimReservationReadyTime(pod *corev1.Pod, record *SandboxRecord) (time.
 	if pod == nil {
 		return time.Time{}, false
 	}
-	if hotClaimUsesRecordCompletion(pod) && record != nil && !record.UpdatedAt.IsZero() {
-		return record.UpdatedAt, true
+	if hotClaimUsesRecordCompletion(pod) && record != nil && !record.HotClaimCompletedAt.IsZero() {
+		return record.HotClaimCompletedAt, true
 	}
 	for _, key := range []string{
 		controller.AnnotationHotClaimReadyAt,
@@ -462,7 +462,7 @@ func hotClaimReservationMatchesRecord(pod *corev1.Pod, record *SandboxRecord) bo
 	if pod == nil || record == nil || !record.DeletedAt.IsZero() {
 		return false
 	}
-	if record.Status != SandboxStatusStarting && record.Status != SandboxStatusRunning {
+	if record.DesiredState != SandboxDesiredStateActive {
 		return false
 	}
 	if record.ID != sandboxIDFromPod(pod) ||
@@ -484,5 +484,5 @@ func hotClaimReservationCompleted(pod *corev1.Pod, record *SandboxRecord) bool {
 	}
 	return state == controller.HotClaimReservationStateInitializing &&
 		hotClaimUsesRecordCompletion(pod) &&
-		record.Status == SandboxStatusRunning
+		!record.HotClaimCompletedAt.IsZero()
 }

--- a/manager/pkg/service/hot_claim_reservation_controller_test.go
+++ b/manager/pkg/service/hot_claim_reservation_controller_test.go
@@ -17,10 +17,10 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func TestCompleteHotClaimReservationPersistsRunningRecordWithoutPodPatch(t *testing.T) {
+func TestCompleteHotClaimReservationPersistsCompletionMarkerWithoutPodPatch(t *testing.T) {
 	now := time.Date(2026, time.July, 26, 12, 0, 0, 0, time.UTC)
 	pod := newHotClaimReservationTestPod(now, controller.HotClaimReservationStateInitializing)
-	pod.Annotations[controller.AnnotationHotClaimCompletionProtocol] = controller.HotClaimCompletionProtocolRecordV1
+	pod.Annotations[controller.AnnotationHotClaimCompletionProtocol] = controller.HotClaimCompletionProtocolRecordV2
 	client := fake.NewSimpleClientset(pod.DeepCopy())
 	store := &memorySandboxStore{records: map[string]*SandboxRecord{}}
 	service := &SandboxService{
@@ -46,8 +46,8 @@ func TestCompleteHotClaimReservationPersistsRunningRecordWithoutPodPatch(t *test
 	if err != nil {
 		t.Fatalf("GetSandbox() error = %v", err)
 	}
-	if record == nil || record.Status != SandboxStatusRunning {
-		t.Fatalf("sandbox record = %#v, want running", record)
+	if record == nil || record.DesiredState != SandboxDesiredStateActive || !record.HotClaimCompletedAt.Equal(now) {
+		t.Fatalf("sandbox record = %#v, want active with a completion marker", record)
 	}
 	if actions := client.Actions(); len(actions) != 0 {
 		t.Fatalf("Kubernetes actions = %v, want none on completion path", actions)
@@ -57,10 +57,10 @@ func TestCompleteHotClaimReservationPersistsRunningRecordWithoutPodPatch(t *test
 	}
 }
 
-func TestSandboxRecordForRecordCompletedHotClaimStartsInitializing(t *testing.T) {
+func TestSandboxRecordForHotClaimStartsActiveWithoutCompletionMarker(t *testing.T) {
 	now := time.Date(2026, time.July, 26, 12, 0, 0, 0, time.UTC)
 	pod := newHotClaimReservationTestPod(now, controller.HotClaimReservationStateInitializing)
-	pod.Annotations[controller.AnnotationHotClaimCompletionProtocol] = controller.HotClaimCompletionProtocolRecordV1
+	pod.Annotations[controller.AnnotationHotClaimCompletionProtocol] = controller.HotClaimCompletionProtocolRecordV2
 	service := &SandboxService{clock: fixedClock{now: now}}
 	template := &v1alpha1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: pod.Namespace},
@@ -73,17 +73,17 @@ func TestSandboxRecordForRecordCompletedHotClaimStartsInitializing(t *testing.T)
 		UserID:            "user-a",
 		RuntimeGeneration: 1,
 	})
-	if record.Status != SandboxStatusStarting {
-		t.Fatalf("sandbox record status = %q, want starting", record.Status)
+	if record.DesiredState != SandboxDesiredStateActive || !record.HotClaimCompletedAt.IsZero() {
+		t.Fatalf("sandbox record = %#v, want active without a completion marker", record)
 	}
 }
 
 func TestHotClaimReservationControllerFinalizesRecordCompletedClaim(t *testing.T) {
 	now := time.Date(2026, time.July, 26, 12, 0, 0, 0, time.UTC)
 	pod := newHotClaimReservationTestPod(now, controller.HotClaimReservationStateInitializing)
-	pod.Annotations[controller.AnnotationHotClaimCompletionProtocol] = controller.HotClaimCompletionProtocolRecordV1
+	pod.Annotations[controller.AnnotationHotClaimCompletionProtocol] = controller.HotClaimCompletionProtocolRecordV2
 	record := hotClaimReservationTestRecord(pod)
-	record.UpdatedAt = now
+	record.HotClaimCompletedAt = now
 	store := &memorySandboxStore{records: map[string]*SandboxRecord{"sandbox-a": record}}
 	client := fake.NewSimpleClientset(pod.DeepCopy())
 	reconciler := NewHotClaimReservationController(client, newClaimTestPodLister(t, pod), store, nil)
@@ -112,18 +112,17 @@ func TestHotClaimReservationControllerFinalizesRecordCompletedClaim(t *testing.T
 func TestHotClaimReservationControllerDoesNotCompleteUnsafeInitializingClaim(t *testing.T) {
 	now := time.Date(2026, time.July, 26, 12, 0, 0, 0, time.UTC)
 	tests := []struct {
-		name     string
-		protocol string
-		status   string
+		name      string
+		protocol  string
+		completed bool
 	}{
 		{
-			name:   "legacy running record lacks completion protocol",
-			status: SandboxStatusRunning,
+			name:      "completion marker lacks completion protocol",
+			completed: true,
 		},
 		{
-			name:     "record protocol is still starting",
-			protocol: controller.HotClaimCompletionProtocolRecordV1,
-			status:   SandboxStatusStarting,
+			name:     "record protocol lacks completion marker",
+			protocol: controller.HotClaimCompletionProtocolRecordV2,
 		},
 	}
 	for _, test := range tests {
@@ -133,7 +132,9 @@ func TestHotClaimReservationControllerDoesNotCompleteUnsafeInitializingClaim(t *
 				pod.Annotations[controller.AnnotationHotClaimCompletionProtocol] = test.protocol
 			}
 			record := hotClaimReservationTestRecord(pod)
-			record.Status = test.status
+			if test.completed {
+				record.HotClaimCompletedAt = now
+			}
 			store := &memorySandboxStore{records: map[string]*SandboxRecord{"sandbox-a": record}}
 			client := fake.NewSimpleClientset(pod.DeepCopy())
 			reconciler := NewHotClaimReservationController(client, newClaimTestPodLister(t, pod), store, nil)
@@ -358,7 +359,7 @@ func TestHotClaimReservationControllerDeletesAbandonedPartialClaim(t *testing.T)
 	if err != nil {
 		t.Fatalf("GetSandbox() error = %v", err)
 	}
-	if gotRecord.Status != SandboxStatusDeleted || gotRecord.DeletedAt.IsZero() {
+	if gotRecord.DesiredState != SandboxDesiredStateDeleted || gotRecord.DeletedAt.IsZero() {
 		t.Fatalf("sandbox record = %#v, want deleted", gotRecord)
 	}
 }
@@ -370,7 +371,7 @@ func TestHotClaimReservationControllerPreservesPausedIdentityOnAbandonedResume(t
 		controller.HotClaimReservationStateInitializing,
 	)
 	record := hotClaimReservationTestRecord(pod)
-	record.Status = SandboxStatusPaused
+	record.DesiredState = SandboxDesiredStatePaused
 	record.CurrentPodName = ""
 	record.CurrentPodNamespace = ""
 	store := &memorySandboxStore{records: map[string]*SandboxRecord{"sandbox-a": record}}
@@ -390,7 +391,7 @@ func TestHotClaimReservationControllerPreservesPausedIdentityOnAbandonedResume(t
 	if err != nil {
 		t.Fatalf("GetSandbox() error = %v", err)
 	}
-	if gotRecord.Status != SandboxStatusPaused || !gotRecord.DeletedAt.IsZero() {
+	if gotRecord.DesiredState != SandboxDesiredStatePaused || !gotRecord.DeletedAt.IsZero() {
 		t.Fatalf("paused sandbox record = %#v, want preserved", gotRecord)
 	}
 }
@@ -473,7 +474,7 @@ func (p *recordingHotClaimDetachmentPacer) Wait(context.Context) error {
 func hotClaimReservationTestRecord(pod *corev1.Pod) *SandboxRecord {
 	return &SandboxRecord{
 		ID:                  sandboxIDFromPod(pod),
-		Status:              SandboxStatusRunning,
+		DesiredState:        SandboxDesiredStateActive,
 		CurrentPodNamespace: pod.Namespace,
 		CurrentPodName:      pod.Name,
 		RuntimeGeneration:   runtimeGenerationFromPod(pod),

--- a/manager/pkg/service/idle_claim_allocator_test.go
+++ b/manager/pkg/service/idle_claim_allocator_test.go
@@ -192,8 +192,8 @@ func TestClaimIdlePodAvoidsDuplicateCandidatesWithStaleInformer(t *testing.T) {
 			t.Fatalf("Pod %q was claimed more than once", pod.Name)
 		}
 		selected[pod.Name] = struct{}{}
-		if got := pod.Annotations[controller.AnnotationHotClaimCompletionProtocol]; got != controller.HotClaimCompletionProtocolRecordV1 {
-			t.Fatalf("completion protocol = %q, want %q", got, controller.HotClaimCompletionProtocolRecordV1)
+		if got := pod.Annotations[controller.AnnotationHotClaimCompletionProtocol]; got != controller.HotClaimCompletionProtocolRecordV2 {
+			t.Fatalf("completion protocol = %q, want %q", got, controller.HotClaimCompletionProtocolRecordV2)
 		}
 	}
 	if len(selected) != count {

--- a/manager/pkg/service/migrations/00011_replace_observed_status_with_desired_state.sql
+++ b/manager/pkg/service/migrations/00011_replace_observed_status_with_desired_state.sql
@@ -1,0 +1,50 @@
+-- +goose Up
+
+ALTER TABLE manager.sandboxes
+    ADD COLUMN hot_claim_completed_at TIMESTAMPTZ;
+
+UPDATE manager.sandboxes
+SET deleted_at = COALESCE(deleted_at, updated_at)
+WHERE status = 'deleted';
+
+UPDATE manager.sandboxes
+SET status = CASE
+    WHEN deleted_at IS NOT NULL OR status = 'deleted' THEN 'deleted'
+    WHEN status = 'paused' THEN 'paused'
+    WHEN status = 'terminating' THEN 'terminating'
+    ELSE 'active'
+END;
+
+DROP INDEX IF EXISTS manager.idx_sandboxes_team_status;
+
+ALTER TABLE manager.sandboxes
+    RENAME COLUMN status TO desired_state;
+
+ALTER TABLE manager.sandboxes
+    ADD CONSTRAINT sandboxes_desired_state_check
+    CHECK (desired_state IN ('active', 'paused', 'terminating', 'deleted'));
+
+CREATE INDEX idx_sandboxes_team_desired_state
+    ON manager.sandboxes(team_id, desired_state);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS manager.idx_sandboxes_team_desired_state;
+
+ALTER TABLE manager.sandboxes
+    DROP CONSTRAINT IF EXISTS sandboxes_desired_state_check;
+
+ALTER TABLE manager.sandboxes
+    RENAME COLUMN desired_state TO status;
+
+UPDATE manager.sandboxes
+SET status = CASE
+    WHEN status = 'active' THEN 'running'
+    ELSE status
+END;
+
+CREATE INDEX idx_sandboxes_team_status
+    ON manager.sandboxes(team_id, status);
+
+ALTER TABLE manager.sandboxes
+    DROP COLUMN hot_claim_completed_at;

--- a/manager/pkg/service/power_executor_ctld_test.go
+++ b/manager/pkg/service/power_executor_ctld_test.go
@@ -36,9 +36,9 @@ func TestCheckpointPauseRequiresCtldEnabled(t *testing.T) {
 	}
 	store := &memorySandboxStore{records: map[string]*SandboxRecord{
 		"sandbox-1": {
-			ID:     "sandbox-1",
-			TeamID: "team-1",
-			Status: SandboxStatusRunning,
+			ID:           "sandbox-1",
+			TeamID:       "team-1",
+			DesiredState: SandboxDesiredStateActive,
 		},
 	}}
 	svc := &SandboxService{

--- a/manager/pkg/service/rootfs_persistent_filesystem_integration_test.go
+++ b/manager/pkg/service/rootfs_persistent_filesystem_integration_test.go
@@ -8,10 +8,85 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	servicemigrations "github.com/sandbox0-ai/sandbox0/manager/pkg/service/migrations"
 	meteringpkg "github.com/sandbox0-ai/sandbox0/pkg/metering"
+	"github.com/sandbox0-ai/sandbox0/pkg/migrate"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestSandboxDesiredStateMigrationRepairsLegacyObservedStatuses(t *testing.T) {
+	ctx := context.Background()
+	pool := newSandboxStoreIntegrationPool(t)
+	require.NoError(t, migrate.Down(ctx, pool, ".",
+		migrate.WithBaseFS(servicemigrations.FS),
+		migrate.WithLogger(noopSandboxStoreMigrateLogger{}),
+		migrate.WithSchema(sandboxStoreSchemaName),
+	))
+
+	updatedAt := time.Date(2026, time.August, 4, 10, 0, 0, 0, time.UTC)
+	legacyRows := []struct {
+		id        string
+		status    string
+		deletedAt *time.Time
+	}{
+		{id: "starting", status: SandboxStatusStarting},
+		{id: "running", status: SandboxStatusRunning},
+		{id: "failed", status: SandboxStatusFailed},
+		{id: "paused", status: SandboxStatusPaused},
+		{id: "terminating", status: SandboxStatusTerminating},
+		{id: "deleted", status: SandboxStatusRunning, deletedAt: &updatedAt},
+		{id: "deleted-status", status: "deleted"},
+	}
+	for _, row := range legacyRows {
+		_, err := pool.Exec(ctx, `
+			INSERT INTO manager.sandboxes (
+				sandbox_id, team_id, template_id, template_name, template_namespace,
+				status, deleted_at, updated_at
+			) VALUES ($1, 'team-1', 'template-1', 'template-1', 'template-default', $2, $3, $4)
+		`, row.id, row.status, row.deletedAt, updatedAt)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, RunSandboxStoreMigrations(ctx, pool, noopSandboxStoreMigrateLogger{}))
+
+	type migratedState struct {
+		desiredState string
+		completedAt  *time.Time
+		deletedAt    *time.Time
+	}
+	migrated := make(map[string]migratedState, len(legacyRows))
+	rows, err := pool.Query(ctx, `
+		SELECT sandbox_id, desired_state, hot_claim_completed_at, deleted_at
+		FROM manager.sandboxes
+	`)
+	require.NoError(t, err)
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		var state migratedState
+		require.NoError(t, rows.Scan(&id, &state.desiredState, &state.completedAt, &state.deletedAt))
+		migrated[id] = state
+	}
+	require.NoError(t, rows.Err())
+
+	for _, id := range []string{"starting", "running", "failed"} {
+		assert.Equal(t, SandboxDesiredStateActive, migrated[id].desiredState)
+		assert.Nil(t, migrated[id].completedAt)
+	}
+	assert.Equal(t, SandboxDesiredStatePaused, migrated["paused"].desiredState)
+	assert.Equal(t, SandboxDesiredStateTerminating, migrated["terminating"].desiredState)
+	assert.Equal(t, SandboxDesiredStateDeleted, migrated["deleted"].desiredState)
+	assert.Equal(t, SandboxDesiredStateDeleted, migrated["deleted-status"].desiredState)
+	assert.NotNil(t, migrated["deleted-status"].deletedAt)
+
+	_, err = pool.Exec(ctx, `UPDATE manager.sandboxes SET desired_state = 'running' WHERE sandbox_id = 'running'`)
+	require.Error(t, err, "legacy observed status must be rejected after migration")
+
+	active, err := NewPGSandboxStore(pool).CountActiveSandboxes(ctx, "team-1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), active)
+}
 
 func TestRootFSFilesystemPersistenceIntegration(t *testing.T) {
 	ctx := context.Background()
@@ -690,7 +765,7 @@ func rootFSTestSandboxRecord(sandboxID, teamID string) *SandboxRecord {
 		TemplateID:        "template-1",
 		TemplateName:      "template-1",
 		TemplateNamespace: "template-default",
-		Status:            SandboxStatusRunning,
+		DesiredState:      SandboxDesiredStateActive,
 		CreatedAt:         time.Now().UTC(),
 	}
 }

--- a/manager/pkg/service/sandbox_crash_recovery.go
+++ b/manager/pkg/service/sandbox_crash_recovery.go
@@ -32,7 +32,7 @@ func (s *SandboxService) RecoverTerminatedSandboxRuntime(ctx context.Context, po
 	enqueue := false
 	deleteStaleRuntime := false
 	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
-		if record == nil || record.Status == SandboxStatusDeleted || !record.DeletedAt.IsZero() || sandboxHardExpired(record.HardExpiresAt, s.now()) {
+		if record == nil || record.DesiredState == SandboxDesiredStateDeleted || !record.DeletedAt.IsZero() || sandboxHardExpired(record.HardExpiresAt, s.now()) {
 			return nil
 		}
 		if !sandboxRecordReferencesPod(record, pod) {
@@ -49,7 +49,7 @@ func (s *SandboxService) RecoverTerminatedSandboxRuntime(ctx context.Context, po
 			}
 			return fmt.Errorf("%w: active %s transaction %s", errSandboxCrashRecoveryBlocked, activeTxn.Kind, activeTxn.ID)
 		}
-		if record.Status == SandboxStatusPaused {
+		if record.DesiredState == SandboxDesiredStatePaused {
 			deleteStaleRuntime = true
 			return nil
 		}
@@ -120,7 +120,7 @@ func (s *SandboxService) RecoverUnhealthySandboxRuntime(ctx context.Context, pod
 	sandboxID := sandboxIDFromPod(pod)
 	enqueue := false
 	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
-		if record == nil || record.Status == SandboxStatusDeleted || !record.DeletedAt.IsZero() ||
+		if record == nil || record.DesiredState == SandboxDesiredStateDeleted || !record.DeletedAt.IsZero() ||
 			sandboxHardExpired(record.HardExpiresAt, s.now()) || !sandboxRecordReferencesPod(record, pod) {
 			return nil
 		}
@@ -135,7 +135,7 @@ func (s *SandboxService) RecoverUnhealthySandboxRuntime(ctx context.Context, pod
 			}
 			return fmt.Errorf("%w: active %s transaction %s", errSandboxCrashRecoveryBlocked, activeTxn.Kind, activeTxn.ID)
 		}
-		if record.Status == SandboxStatusPaused {
+		if record.DesiredState == SandboxDesiredStatePaused {
 			return nil
 		}
 		if err := beginHealthRecoveryTxn(lockCtx, tx, record, pod); err != nil {

--- a/manager/pkg/service/sandbox_crash_recovery_test.go
+++ b/manager/pkg/service/sandbox_crash_recovery_test.go
@@ -194,7 +194,7 @@ func TestCompleteCrashRecoveryCommitsRootFSBeforeDeletingPod(t *testing.T) {
 	client.PrependReactor("delete", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
 		record, err := store.GetSandbox(context.Background(), "sandbox-1")
 		require.NoError(t, err)
-		require.Equal(t, SandboxStatusPaused, record.Status, "runtime must be fenced before pod deletion")
+		require.Equal(t, SandboxDesiredStatePaused, record.DesiredState, "runtime must be fenced before pod deletion")
 		require.NotNil(t, store.rootFSStates["sandbox-1"], "rootfs head must commit before pod deletion")
 		deleted = true
 		return true, nil, nil
@@ -216,7 +216,7 @@ func TestCompleteCrashRecoveryCommitsRootFSBeforeDeletingPod(t *testing.T) {
 	assert.True(t, deleted)
 	assert.Equal(t, "containerd://terminated-container", preparedTarget.ContainerID)
 	assert.Equal(t, string(pod.UID), preparedTarget.PodUID)
-	assert.Equal(t, SandboxStatusPaused, store.records["sandbox-1"].Status)
+	assert.Equal(t, SandboxDesiredStatePaused, store.records["sandbox-1"].DesiredState)
 	assert.Nil(t, activeLifecycleTxnForTest(store, "sandbox-1"))
 	state := store.rootFSStates["sandbox-1"]
 	require.NotNil(t, state)
@@ -251,7 +251,7 @@ func TestCompleteCrashRecoveryRetainsPodAndTransactionOnTransientCheckpointFailu
 	err := svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-1")
 
 	require.Error(t, err)
-	assert.Equal(t, SandboxStatusRunning, store.records["sandbox-1"].Status)
+	assert.Equal(t, SandboxDesiredStateActive, store.records["sandbox-1"].DesiredState)
 	require.NotNil(t, activeLifecycleTxnForTest(store, "sandbox-1"))
 	for _, action := range client.Actions() {
 		assert.False(t, action.GetVerb() == "delete" && action.GetResource().Resource == "pods")
@@ -283,7 +283,7 @@ func TestCompleteHealthRecoveryFallsBackAndFencesBeforeDeletingPod(t *testing.T)
 	client.PrependReactor("delete", "pods", func(ktesting.Action) (bool, runtime.Object, error) {
 		record, err := store.GetSandbox(context.Background(), "sandbox-1")
 		require.NoError(t, err)
-		require.Equal(t, SandboxStatusPaused, record.Status, "runtime must be fenced before pod deletion")
+		require.Equal(t, SandboxDesiredStatePaused, record.DesiredState, "runtime must be fenced before pod deletion")
 		deleted = true
 		return true, nil, nil
 	})
@@ -302,7 +302,7 @@ func TestCompleteHealthRecoveryFallsBackAndFencesBeforeDeletingPod(t *testing.T)
 	require.NoError(t, svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"))
 
 	assert.True(t, deleted)
-	assert.Equal(t, SandboxStatusPaused, store.records["sandbox-1"].Status)
+	assert.Equal(t, SandboxDesiredStatePaused, store.records["sandbox-1"].DesiredState)
 	assert.Equal(t, "previous-head", store.rootFSStates["sandbox-1"].LayerID)
 	assert.Nil(t, activeLifecycleTxnForTest(store, "sandbox-1"))
 }
@@ -348,7 +348,7 @@ func TestCompleteCrashRecoveryFallsBackToLastCommittedHeadWhenSnapshotWasRemoved
 	require.NoError(t, svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"))
 
 	assert.True(t, deleted)
-	assert.Equal(t, SandboxStatusPaused, store.records["sandbox-1"].Status)
+	assert.Equal(t, SandboxDesiredStatePaused, store.records["sandbox-1"].DesiredState)
 	assert.Equal(t, "previous-head", store.rootFSStates["sandbox-1"].LayerID)
 	assert.Nil(t, activeLifecycleTxnForTest(store, "sandbox-1"))
 }
@@ -375,7 +375,7 @@ func TestCrashRecoveryCommitDoesNotResurrectDeletedSandbox(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.False(t, committed)
-	assert.Equal(t, SandboxStatusDeleted, store.records["sandbox-1"].Status)
+	assert.Equal(t, SandboxDesiredStateDeleted, store.records["sandbox-1"].DesiredState)
 	assert.Nil(t, store.rootFSStates["sandbox-1"])
 }
 
@@ -400,7 +400,7 @@ func TestCompleteCrashRecoveryAbortsWhenRuntimeDeletionAlreadyStarted(t *testing
 	require.NoError(t, svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"))
 
 	assert.Nil(t, activeLifecycleTxnForTest(store, "sandbox-1"))
-	assert.Equal(t, SandboxStatusRunning, store.records["sandbox-1"].Status)
+	assert.Equal(t, SandboxDesiredStateActive, store.records["sandbox-1"].DesiredState)
 	for _, action := range client.Actions() {
 		assert.False(t, action.GetVerb() == "delete" && action.GetResource().Resource == "pods")
 	}
@@ -579,9 +579,9 @@ func TestSandboxPauseControllerReconstructsHealthRecoveryRegardlessOfAutoResume(
 	autoResume := false
 	store := &memorySandboxStore{records: map[string]*SandboxRecord{
 		"sandbox-1": {
-			ID:     "sandbox-1",
-			Status: SandboxStatusRunning,
-			Config: SandboxConfig{AutoResume: &autoResume},
+			ID:           "sandbox-1",
+			DesiredState: SandboxDesiredStateActive,
+			Config:       SandboxConfig{AutoResume: &autoResume},
 		},
 	}}
 	controller := NewSandboxPauseController(&SandboxService{sandboxStore: store}, zap.NewNop())
@@ -657,7 +657,7 @@ func TestSandboxPauseControllerFindsHealthRecoveryAfterManagerRestart(t *testing
 func TestSandboxPauseControllerResumesCommittedHealthRecoveryAfterManagerRestart(t *testing.T) {
 	pod := unhealthyRecoveryTestPod(time.Now().Add(-2 * time.Minute))
 	store := crashRecoveryTestStore(pod)
-	store.records["sandbox-1"].Status = SandboxStatusPaused
+	store.records["sandbox-1"].DesiredState = SandboxDesiredStatePaused
 	store.lifecycleTxns = map[string]*SandboxLifecycleTxn{
 		"health-pause": {
 			ID:        "health-pause",
@@ -692,7 +692,7 @@ func TestSandboxPauseControllerResumesCommittedHealthRecoveryAfterManagerRestart
 func TestSandboxPauseControllerResumesCommittedCrashRecoveryAfterManagerRestart(t *testing.T) {
 	pod := crashRecoveryTestPod(corev1.PodFailed, 137, "OOMKilled")
 	store := crashRecoveryTestStore(pod)
-	store.records["sandbox-1"].Status = SandboxStatusPaused
+	store.records["sandbox-1"].DesiredState = SandboxDesiredStatePaused
 	store.lifecycleTxns = map[string]*SandboxLifecycleTxn{
 		"crash-pause": {
 			ID:        "crash-pause",
@@ -766,7 +766,7 @@ func crashRecoveryTestStore(pod *corev1.Pod) *memorySandboxStore {
 			ID:                  "sandbox-1",
 			TeamID:              "team-1",
 			UserID:              "user-1",
-			Status:              SandboxStatusRunning,
+			DesiredState:        SandboxDesiredStateActive,
 			CurrentPodNamespace: pod.Namespace,
 			CurrentPodName:      pod.Name,
 			RuntimeGeneration:   runtimeGenerationFromPod(pod),

--- a/manager/pkg/service/sandbox_lifecycle_controller.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller.go
@@ -489,7 +489,7 @@ func (s *SandboxService) runtimeDeletionDisposition(ctx context.Context, info Sa
 		return false, false, fmt.Errorf("get sandbox record for runtime deletion cleanup: %w", err)
 	}
 	runtimeOnly := SandboxRecordDeletionIsRuntimeOnly(record, info.Namespace, info.PodName, info.RuntimeGeneration)
-	return runtimeOnly, runtimeOnly && record != nil && record.Status == SandboxStatusPaused, nil
+	return runtimeOnly, runtimeOnly && record != nil && record.DesiredState == SandboxDesiredStatePaused, nil
 }
 
 // SandboxRecordDeletionIsRuntimeOnly reports whether Pod deletion is limited to
@@ -500,8 +500,8 @@ func SandboxRecordDeletionIsRuntimeOnly(record *SandboxRecord, _ string, _ strin
 	if record == nil {
 		return false
 	}
-	switch record.Status {
-	case SandboxStatusTerminating, SandboxStatusDeleted:
+	switch record.DesiredState {
+	case SandboxDesiredStateTerminating, SandboxDesiredStateDeleted:
 		return false
 	default:
 		return true

--- a/manager/pkg/service/sandbox_lifecycle_controller_test.go
+++ b/manager/pkg/service/sandbox_lifecycle_controller_test.go
@@ -457,9 +457,9 @@ func TestSandboxServiceCleanupDeletedSandboxPreservesDurableStateForPausingRunti
 		deletionWebhookEmitter: emitter,
 		sandboxStore: &memorySandboxStore{records: map[string]*SandboxRecord{
 			"sandbox-a": {
-				ID:     "sandbox-a",
-				TeamID: "team-a",
-				Status: SandboxStatusPaused,
+				ID:           "sandbox-a",
+				TeamID:       "team-a",
+				DesiredState: SandboxDesiredStatePaused,
 			},
 		}},
 		logger: zap.NewNop(),
@@ -507,7 +507,7 @@ func TestSandboxServiceCleanupDeletedSandboxPreservesDurableStateForStaleRuntime
 			"sandbox-a": {
 				ID:                  "sandbox-a",
 				TeamID:              "team-a",
-				Status:              SandboxStatusRunning,
+				DesiredState:        SandboxDesiredStateActive,
 				CurrentPodNamespace: "ns-a",
 				CurrentPodName:      "pod-new",
 				RuntimeGeneration:   2,
@@ -548,7 +548,7 @@ func TestRuntimeDeletionDispositionDoesNotCacheStaleRuntime(t *testing.T) {
 		sandboxStore: &memorySandboxStore{records: map[string]*SandboxRecord{
 			"sandbox-a": {
 				ID:                "sandbox-a",
-				Status:            SandboxStatusRunning,
+				DesiredState:      SandboxDesiredStateActive,
 				CurrentPodName:    "pod-new",
 				RuntimeGeneration: 2,
 			},
@@ -651,7 +651,7 @@ func TestSandboxServicePausedSandboxRequestsHotVolumeRetention(t *testing.T) {
 			CtldPort:    ctldPort,
 		},
 		sandboxStore: &memorySandboxStore{records: map[string]*SandboxRecord{
-			"sandbox-a": {ID: "sandbox-a", Status: SandboxStatusPaused},
+			"sandbox-a": {ID: "sandbox-a", DesiredState: SandboxDesiredStatePaused},
 		}},
 		logger: zap.NewNop(),
 	}
@@ -855,7 +855,7 @@ func TestSystemVolumeReconcilerKeepsPausedOwnedVolume(t *testing.T) {
 				ID:                   "sandbox-a",
 				TeamID:               "team-a",
 				UserID:               "user-a",
-				Status:               SandboxStatusPaused,
+				DesiredState:         SandboxDesiredStatePaused,
 				WebhookStateVolumeID: "volume-a",
 			},
 		}},

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -53,10 +53,14 @@ func (s *memorySandboxStore) UpsertSandbox(_ context.Context, record *SandboxRec
 		s.records = make(map[string]*SandboxRecord)
 	}
 	if existing := s.records[record.ID]; existing != nil &&
-		(existing.Status == SandboxStatusTerminating || existing.Status == SandboxStatusDeleted || !existing.DeletedAt.IsZero()) {
+		(existing.DesiredState == SandboxDesiredStateTerminating || existing.DesiredState == SandboxDesiredStateDeleted || !existing.DeletedAt.IsZero()) {
 		return nil
 	}
-	s.records[record.ID] = cloneSandboxRecord(record)
+	clone := cloneSandboxRecord(record)
+	if existing := s.records[record.ID]; existing != nil && clone.HotClaimCompletedAt.IsZero() {
+		clone.HotClaimCompletedAt = existing.HotClaimCompletedAt
+	}
+	s.records[record.ID] = clone
 	return nil
 }
 
@@ -88,9 +92,6 @@ func (s *memorySandboxStore) ListSandboxes(_ context.Context, req *ListSandboxes
 		}
 		if req != nil {
 			if req.TeamID != "" && record.TeamID != req.TeamID {
-				continue
-			}
-			if req.Status != "" && record.Status != req.Status {
 				continue
 			}
 			if req.TemplateID != "" && record.TemplateID != req.TemplateID {
@@ -142,7 +143,7 @@ func (s *memorySandboxStore) ListPendingRuntimeRecoverySandboxIDs(_ context.Cont
 	}
 	var sandboxIDs []string
 	for sandboxID, record := range s.records {
-		if record == nil || record.Status != SandboxStatusPaused || !record.DeletedAt.IsZero() {
+		if record == nil || record.DesiredState != SandboxDesiredStatePaused || !record.DeletedAt.IsZero() {
 			continue
 		}
 		var latest *SandboxLifecycleTxn
@@ -191,7 +192,7 @@ func (s *memorySandboxStore) MarkSandboxDeleted(_ context.Context, sandboxID str
 		record = &SandboxRecord{ID: sandboxID}
 		s.records[sandboxID] = record
 	}
-	record.Status = SandboxStatusDeleted
+	record.DesiredState = SandboxDesiredStateDeleted
 	record.DeletedAt = deletedAt
 	record.CurrentPodName = ""
 	record.CurrentPodNamespace = ""
@@ -289,24 +290,24 @@ func (s *memorySandboxStore) restore(snapshot memorySandboxStoreSnapshot) {
 	s.rootFSFilesystems = snapshot.rootFSFilesystems
 }
 
-func (s *memorySandboxStore) setSandboxStatus(sandboxID, status string) {
+func (s *memorySandboxStore) setSandboxDesiredState(sandboxID, desiredState string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if record := s.records[sandboxID]; record != nil {
-		record.Status = status
+		record.DesiredState = desiredState
 	}
 }
 
-func (t memorySandboxStoreTx) SaveRuntime(_ context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time, metadata SandboxRuntimeMetadata) error {
+func (t memorySandboxStoreTx) SaveRuntime(_ context.Context, sandboxID, namespace, podName string, generation int64, expiresAt, hardExpiresAt time.Time, metadata SandboxRuntimeMetadata) error {
 	t.store.mu.Lock()
 	defer t.store.mu.Unlock()
 	record := t.store.records[sandboxID]
-	if record == nil || record.Status == SandboxStatusTerminating || !record.DeletedAt.IsZero() {
+	if record == nil || record.DesiredState == SandboxDesiredStateTerminating || !record.DeletedAt.IsZero() {
 		return ErrSandboxRecordNotFound
 	}
 	record.CurrentPodNamespace = namespace
 	record.CurrentPodName = podName
-	record.Status = status
+	record.DesiredState = SandboxDesiredStateActive
 	record.RuntimeGeneration = generation
 	record.ExpiresAt = expiresAt
 	record.HardExpiresAt = hardExpiresAt
@@ -324,12 +325,12 @@ func (t memorySandboxStoreTx) MarkRuntimePaused(_ context.Context, sandboxID str
 	t.store.mu.Lock()
 	defer t.store.mu.Unlock()
 	record := t.store.records[sandboxID]
-	if record == nil || record.Status == SandboxStatusTerminating || !record.DeletedAt.IsZero() {
+	if record == nil || record.DesiredState == SandboxDesiredStateTerminating || !record.DeletedAt.IsZero() {
 		return ErrSandboxRecordNotFound
 	}
 	record.CurrentPodNamespace = ""
 	record.CurrentPodName = ""
-	record.Status = SandboxStatusPaused
+	record.DesiredState = SandboxDesiredStatePaused
 	if record.RuntimeGeneration < generation {
 		record.RuntimeGeneration = generation
 	}
@@ -344,7 +345,7 @@ func (t memorySandboxStoreTx) MarkRuntimeTerminating(_ context.Context, sandboxI
 	if record == nil || !record.DeletedAt.IsZero() {
 		return ErrSandboxRecordNotFound
 	}
-	record.Status = SandboxStatusTerminating
+	record.DesiredState = SandboxDesiredStateTerminating
 	return nil
 }
 
@@ -619,7 +620,7 @@ func TestResumePausedSandboxRuntimeWaitsWhileRuntimeDeleting(t *testing.T) {
 			TemplateID:        "default",
 			TemplateName:      "default",
 			TemplateNamespace: "tpl-default",
-			Status:            SandboxStatusPaused,
+			DesiredState:      SandboxDesiredStatePaused,
 			TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
 		},
 	}}
@@ -667,7 +668,7 @@ func TestResumePausedSandboxRuntimeDeletesStaleUnhealthyRuntimeBeforeIdentityChe
 			TemplateID:        "default",
 			TemplateName:      "default",
 			TemplateNamespace: "tpl-default",
-			Status:            SandboxStatusPaused,
+			DesiredState:      SandboxDesiredStatePaused,
 			RuntimeGeneration: 1,
 			TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
 		},
@@ -724,7 +725,7 @@ func TestResumePausedSandboxRuntimeReplacesFailedRuntime(t *testing.T) {
 			TemplateID:          "default",
 			TemplateName:        "default",
 			TemplateNamespace:   "tpl-default",
-			Status:              SandboxStatusRunning,
+			DesiredState:        SandboxDesiredStateActive,
 			CurrentPodName:      failedPod.Name,
 			CurrentPodNamespace: failedPod.Namespace,
 			RuntimeGeneration:   3,
@@ -741,8 +742,8 @@ func TestResumePausedSandboxRuntimeReplacesFailedRuntime(t *testing.T) {
 		record, err := store.GetSandbox(context.Background(), "sandbox-a")
 		if err != nil {
 			t.Errorf("GetSandbox() before failed pod delete error = %v", err)
-		} else if record.Status != SandboxStatusPaused {
-			t.Errorf("status before failed pod delete = %q, want paused", record.Status)
+		} else if record.DesiredState != SandboxDesiredStatePaused {
+			t.Errorf("desired state before failed pod delete = %q, want paused", record.DesiredState)
 		}
 		deletedFailedPod = true
 		if err := indexer.Delete(failedPod); err != nil {
@@ -785,8 +786,8 @@ func TestResumePausedSandboxRuntimeReplacesFailedRuntime(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetSandbox() error = %v", err)
 	}
-	if record.Status != SandboxStatusPaused {
-		t.Fatalf("status = %q, want paused before replacement claim", record.Status)
+	if record.DesiredState != SandboxDesiredStatePaused {
+		t.Fatalf("desired state = %q, want paused before replacement claim", record.DesiredState)
 	}
 	if record.CurrentPodName != "" || record.CurrentPodNamespace != "" {
 		t.Fatalf("current runtime = %s/%s, want empty", record.CurrentPodNamespace, record.CurrentPodName)
@@ -823,7 +824,7 @@ func TestResumePausedSandboxRuntimeJoinsResumingRuntime(t *testing.T) {
 				TemplateID:        "default",
 				TemplateName:      "default",
 				TemplateNamespace: "tpl-default",
-				Status:            SandboxStatusPaused,
+				DesiredState:      SandboxDesiredStatePaused,
 				RuntimeGeneration: 3,
 				TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
 			},
@@ -858,7 +859,7 @@ func TestResumePausedSandboxRuntimeJoinsResumingRuntime(t *testing.T) {
 		store.records["sandbox-a"].CurrentPodNamespace = "ns-a"
 		store.records["sandbox-a"].RuntimeGeneration = 4
 		store.mu.Unlock()
-		store.setSandboxStatus("sandbox-a", SandboxStatusRunning)
+		store.setSandboxDesiredState("sandbox-a", SandboxDesiredStateActive)
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -894,7 +895,7 @@ func TestResumePausedSandboxRuntimeReconcilesStaleStartingRecord(t *testing.T) {
 			TemplateID:          "default",
 			TemplateName:        "default",
 			TemplateNamespace:   "tpl-default",
-			Status:              SandboxStatusStarting,
+			DesiredState:        SandboxDesiredStateActive,
 			CurrentPodName:      "pod-a",
 			CurrentPodNamespace: "ns-a",
 			RuntimeGeneration:   4,
@@ -916,8 +917,8 @@ func TestResumePausedSandboxRuntimeReconcilesStaleStartingRecord(t *testing.T) {
 	if sandbox.Status != SandboxStatusRunning {
 		t.Fatalf("status = %q, want running", sandbox.Status)
 	}
-	if got := store.records["sandbox-a"].Status; got != SandboxStatusRunning {
-		t.Fatalf("stored status = %q, want running", got)
+	if got := store.records["sandbox-a"].DesiredState; got != SandboxDesiredStateActive {
+		t.Fatalf("stored desired state = %q, want active", got)
 	}
 	if store.saves != 1 {
 		t.Fatalf("store saves = %d, want 1", store.saves)
@@ -934,7 +935,7 @@ func TestResumePausedSandboxRuntimeReconcilesStaleStartingRecordWithoutPod(t *te
 			TemplateID:        "default",
 			TemplateName:      "default",
 			TemplateNamespace: "tpl-default",
-			Status:            SandboxStatusStarting,
+			DesiredState:      SandboxDesiredStateActive,
 			RuntimeGeneration: 3,
 			TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
 		},
@@ -968,8 +969,8 @@ func TestResumePausedSandboxRuntimeReconcilesStaleStartingRecordWithoutPod(t *te
 	if store.pauses != 1 {
 		t.Fatalf("runtime pause reconciliations = %d, want 1", store.pauses)
 	}
-	if got := store.records["sandbox-a"].Status; got != SandboxStatusPaused {
-		t.Fatalf("stored status after failed claim = %q, want paused", got)
+	if got := store.records["sandbox-a"].DesiredState; got != SandboxDesiredStatePaused {
+		t.Fatalf("stored desired state after failed claim = %q, want paused", got)
 	}
 }
 
@@ -987,7 +988,7 @@ func TestRequestPauseSandboxRuntimeReconcilesStaleStartingRecord(t *testing.T) {
 			TemplateID:          "default",
 			TemplateName:        "default",
 			TemplateNamespace:   "tpl-default",
-			Status:              SandboxStatusStarting,
+			DesiredState:        SandboxDesiredStateActive,
 			CurrentPodName:      "pod-a",
 			CurrentPodNamespace: "ns-a",
 			RuntimeGeneration:   4,
@@ -1016,8 +1017,8 @@ func TestRequestPauseSandboxRuntimeReconcilesStaleStartingRecord(t *testing.T) {
 	if status != SandboxStatusRunning {
 		t.Fatalf("status = %q, want running", status)
 	}
-	if got := store.records["sandbox-a"].Status; got != SandboxStatusRunning {
-		t.Fatalf("stored status = %q, want running", got)
+	if got := store.records["sandbox-a"].DesiredState; got != SandboxDesiredStateActive {
+		t.Fatalf("stored desired state = %q, want active", got)
 	}
 	active, err := store.GetActiveLifecycleTxn(context.Background(), "sandbox-a")
 	if err != nil {
@@ -1048,7 +1049,7 @@ func TestResumeSandboxSingleflightPreventsConcurrentSandboxLocks(t *testing.T) {
 				TemplateID:          "default",
 				TemplateName:        "default",
 				TemplateNamespace:   "tpl-default",
-				Status:              SandboxStatusRunning,
+				DesiredState:        SandboxDesiredStateActive,
 				CurrentPodName:      "pod-a",
 				CurrentPodNamespace: "ns-a",
 				RuntimeGeneration:   4,
@@ -1112,7 +1113,7 @@ func TestResumePausedSandboxRuntimeBeginsTransactionBeforeClaimingPod(t *testing
 			TemplateID:        "default",
 			TemplateName:      "default",
 			TemplateNamespace: "tpl-default",
-			Status:            SandboxStatusPaused,
+			DesiredState:      SandboxDesiredStatePaused,
 			RuntimeGeneration: 3,
 			TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
 		},
@@ -1189,7 +1190,7 @@ func TestResumePausedSandboxRuntimeWaitsForActivePauseTransaction(t *testing.T) 
 				TemplateID:          "default",
 				TemplateName:        "default",
 				TemplateNamespace:   "tpl-default",
-				Status:              SandboxStatusRunning,
+				DesiredState:        SandboxDesiredStateActive,
 				CurrentPodName:      "pod-a",
 				CurrentPodNamespace: "ns-a",
 				RuntimeGeneration:   4,
@@ -1244,7 +1245,7 @@ func TestResumePausedSandboxRuntimeCancelsAutoPauseTransaction(t *testing.T) {
 				TemplateID:          "default",
 				TemplateName:        "default",
 				TemplateNamespace:   "tpl-default",
-				Status:              SandboxStatusRunning,
+				DesiredState:        SandboxDesiredStateActive,
 				CurrentPodName:      "pod-a",
 				CurrentPodNamespace: "ns-a",
 				RuntimeGeneration:   4,
@@ -1343,7 +1344,7 @@ func TestCompletePausingSandboxRuntimeAbortsCanceledAutoPause(t *testing.T) {
 				TemplateID:          "default",
 				TemplateName:        "default",
 				TemplateNamespace:   "tpl-default",
-				Status:              SandboxStatusRunning,
+				DesiredState:        SandboxDesiredStateActive,
 				CurrentPodName:      "pod-a",
 				CurrentPodNamespace: "ns-a",
 				RuntimeGeneration:   4,
@@ -1381,8 +1382,8 @@ func TestCompletePausingSandboxRuntimeAbortsCanceledAutoPause(t *testing.T) {
 	if txn == nil || txn.Phase != SandboxLifecyclePhaseAborted {
 		t.Fatalf("pause txn = %+v, want aborted", txn)
 	}
-	if store.records["sandbox-a"].Status != SandboxStatusRunning {
-		t.Fatalf("record status = %q, want running", store.records["sandbox-a"].Status)
+	if store.records["sandbox-a"].DesiredState != SandboxDesiredStateActive {
+		t.Fatalf("record desired state = %q, want active", store.records["sandbox-a"].DesiredState)
 	}
 	for _, action := range client.Actions() {
 		if action.GetVerb() == "delete" && action.GetResource().Resource == "pods" {
@@ -1400,7 +1401,7 @@ func TestResumePausedSandboxRuntimeStartsRecoveryForRunningRecordWithoutPod(t *t
 			TemplateID:        "default",
 			TemplateName:      "default",
 			TemplateNamespace: "tpl-default",
-			Status:            SandboxStatusRunning,
+			DesiredState:      SandboxDesiredStateActive,
 			RuntimeGeneration: 4,
 			TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
 		},
@@ -1449,7 +1450,7 @@ func TestResumePausedSandboxRuntimeRejectsHardExpiredRecord(t *testing.T) {
 			TemplateID:        "default",
 			TemplateName:      "default",
 			TemplateNamespace: "tpl-default",
-			Status:            SandboxStatusPaused,
+			DesiredState:      SandboxDesiredStatePaused,
 			HardExpiresAt:     hardExpiresAt,
 			TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
 		},
@@ -1478,7 +1479,7 @@ func TestTerminatePausedSandboxRecordRunsPersistentCleanup(t *testing.T) {
 			ID:                   "sandbox-a",
 			TeamID:               "team-a",
 			UserID:               "user-a",
-			Status:               SandboxStatusPaused,
+			DesiredState:         SandboxDesiredStatePaused,
 			WebhookStateVolumeID: "volume-a",
 			Config: SandboxConfig{Webhook: &WebhookConfig{
 				URL:    "https://example.test/webhook",
@@ -1503,8 +1504,8 @@ func TestTerminatePausedSandboxRecordRunsPersistentCleanup(t *testing.T) {
 	if err := svc.TerminateSandbox(context.Background(), "sandbox-a"); err != nil {
 		t.Fatalf("TerminateSandbox() error = %v", err)
 	}
-	if store.records["sandbox-a"].Status != SandboxStatusDeleted {
-		t.Fatalf("status = %q, want deleted", store.records["sandbox-a"].Status)
+	if store.records["sandbox-a"].DesiredState != SandboxDesiredStateDeleted {
+		t.Fatalf("desired state = %q, want deleted", store.records["sandbox-a"].DesiredState)
 	}
 	if bindings.deleteCalls != 1 {
 		t.Fatalf("DeleteBindings calls = %d, want 1", bindings.deleteCalls)
@@ -1531,7 +1532,7 @@ func TestTerminateSandboxAbortsActivePauseTransaction(t *testing.T) {
 				TemplateID:        "default",
 				TemplateName:      "default",
 				TemplateNamespace: "tpl-default",
-				Status:            SandboxStatusRunning,
+				DesiredState:      SandboxDesiredStateActive,
 				RuntimeGeneration: 3,
 			},
 		},
@@ -1560,8 +1561,8 @@ func TestTerminateSandboxAbortsActivePauseTransaction(t *testing.T) {
 	if err := svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-a"); err != nil {
 		t.Fatalf("CompletePausingSandboxRuntime() error = %v", err)
 	}
-	if got := store.records["sandbox-a"].Status; got != SandboxStatusDeleted {
-		t.Fatalf("status = %q, want deleted", got)
+	if got := store.records["sandbox-a"].DesiredState; got != SandboxDesiredStateDeleted {
+		t.Fatalf("desired state = %q, want deleted", got)
 	}
 	if txn, err := store.GetActiveLifecycleTxn(context.Background(), "sandbox-a"); err != nil || txn != nil {
 		t.Fatalf("active txn = %+v, err = %v, want nil", txn, err)

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -34,6 +34,7 @@ type memorySandboxStore struct {
 	saves             int
 	pauses            int
 	lockCalls         int
+	activeTxnGets     int
 	lockStarted       chan struct{}
 	blockLock         chan struct{}
 }
@@ -173,6 +174,7 @@ func (s *memorySandboxStore) GetActiveLifecycleTxn(_ context.Context, sandboxID 
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.activeTxnGets++
 	for _, txn := range s.lifecycleTxns {
 		if txn != nil && txn.SandboxID == sandboxID && sandboxLifecyclePhaseActive(txn.Phase) {
 			return cloneSandboxLifecycleTxn(txn), nil

--- a/manager/pkg/service/sandbox_runtime_reconciler.go
+++ b/manager/pkg/service/sandbox_runtime_reconciler.go
@@ -166,7 +166,7 @@ func (c *SandboxRuntimeReconciler) enqueueDriftCandidates(ctx context.Context) {
 }
 
 func (c *SandboxRuntimeReconciler) candidateNeedsReconcile(candidate SandboxRuntimeReconcileCandidate) bool {
-	if candidate.Status == SandboxStatusTerminating {
+	if candidate.DesiredState == SandboxDesiredStateTerminating {
 		return true
 	}
 	if strings.TrimSpace(candidate.PodNamespace) == "" || strings.TrimSpace(candidate.PodName) == "" || c.podLister == nil {

--- a/manager/pkg/service/sandbox_runtime_recovery.go
+++ b/manager/pkg/service/sandbox_runtime_recovery.go
@@ -45,7 +45,7 @@ func (s *SandboxService) ReconcileSandboxRuntime(ctx context.Context, sandboxID 
 	var cleanupLostRuntime bool
 	var resumeTxn *SandboxLifecycleTxn
 	err = s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, locked *SandboxRecord) error {
-		if locked == nil || locked.Status == SandboxStatusDeleted || !locked.DeletedAt.IsZero() || !s.sandboxRecordBelongsToCluster(locked) {
+		if locked == nil || locked.DesiredState == SandboxDesiredStateDeleted || !locked.DeletedAt.IsZero() || !s.sandboxRecordBelongsToCluster(locked) {
 			return nil
 		}
 		record = cloneSandboxRecordForLifecycle(locked)
@@ -54,17 +54,17 @@ func (s *SandboxService) ReconcileSandboxRuntime(ctx context.Context, sandboxID 
 			return err
 		}
 
-		if locked.Status == SandboxStatusTerminating || sandboxHardExpired(locked.HardExpiresAt, s.now()) {
+		if locked.DesiredState == SandboxDesiredStateTerminating || sandboxHardExpired(locked.HardExpiresAt, s.now()) {
 			if activeTxn != nil {
 				if err := tx.AbortLifecycleTxn(lockCtx, activeTxn.ID, "sandbox termination requested"); err != nil {
 					return err
 				}
 			}
-			if locked.Status != SandboxStatusTerminating {
+			if locked.DesiredState != SandboxDesiredStateTerminating {
 				if err := tx.MarkRuntimeTerminating(lockCtx, sandboxID); err != nil {
 					return err
 				}
-				record.Status = SandboxStatusTerminating
+				record.DesiredState = SandboxDesiredStateTerminating
 			}
 			finishTermination = true
 			return nil
@@ -113,7 +113,7 @@ func (s *SandboxService) ReconcileSandboxRuntime(ctx context.Context, sandboxID 
 			}
 		}
 
-		if locked.Status == SandboxStatusPaused {
+		if locked.DesiredState == SandboxDesiredStatePaused {
 			stalePods = append(stalePods, pods...)
 			return nil
 		}
@@ -143,7 +143,6 @@ func (s *SandboxService) ReconcileSandboxRuntime(ctx context.Context, sandboxID 
 				sandboxID,
 				pod.Namespace,
 				pod.Name,
-				s.podToSandboxStatus(pod),
 				locked.RuntimeGeneration,
 				parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt),
 				parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt),

--- a/manager/pkg/service/sandbox_runtime_recovery_test.go
+++ b/manager/pkg/service/sandbox_runtime_recovery_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestReconcileSandboxRuntimeCreatesDurableLostRecoveryAfterStrongAbsence(t *testing.T) {
-	store := runtimeRecoveryStore("sandbox-1", "pod-1", 3, SandboxStatusRunning)
+	store := runtimeRecoveryStore("sandbox-1", "pod-1", 3, SandboxDesiredStateActive)
 	enqueuer := &recordingPauseEnqueuer{}
 	svc := &SandboxService{
 		k8sClient:     fake.NewSimpleClientset(),
@@ -39,14 +39,14 @@ func TestReconcileSandboxRuntimeCreatesDurableLostRecoveryAfterStrongAbsence(t *
 	assert.Equal(t, "default", txn.FromPodNamespace)
 	assert.Equal(t, "pod-1", txn.FromPodName)
 	assert.Equal(t, []string{"sandbox-1"}, enqueuer.recoveryCalls)
-	assert.Equal(t, SandboxStatusRunning, store.records["sandbox-1"].Status)
+	assert.Equal(t, SandboxDesiredStateActive, store.records["sandbox-1"].DesiredState)
 
 	require.NoError(t, svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1"))
 	assert.Len(t, store.lifecycleTxns, 1, "duplicate reconcile must reuse the active recovery transaction")
 }
 
 func TestReconcileSandboxRuntimeDoesNotTreatKubernetesFailureAsAbsence(t *testing.T) {
-	store := runtimeRecoveryStore("sandbox-1", "pod-1", 3, SandboxStatusRunning)
+	store := runtimeRecoveryStore("sandbox-1", "pod-1", 3, SandboxDesiredStateActive)
 	client := fake.NewSimpleClientset()
 	client.PrependReactor("list", "pods", func(ktesting.Action) (bool, runtime.Object, error) {
 		return true, nil, errors.New("apiserver unavailable")
@@ -61,12 +61,12 @@ func TestReconcileSandboxRuntimeDoesNotTreatKubernetesFailureAsAbsence(t *testin
 	err := svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1")
 	require.ErrorContains(t, err, "apiserver unavailable")
 	assert.Nil(t, activeLifecycleTxnForTest(store, "sandbox-1"))
-	assert.Equal(t, SandboxStatusRunning, store.records["sandbox-1"].Status)
+	assert.Equal(t, SandboxDesiredStateActive, store.records["sandbox-1"].DesiredState)
 }
 
 func TestReconcileSandboxRuntimeRepairsSameGenerationProjectionFromKubernetes(t *testing.T) {
 	pod := runtimeRecoveryPod("pod-new", "sandbox-1", 3)
-	store := runtimeRecoveryStore("sandbox-1", "pod-old", 3, SandboxStatusRunning)
+	store := runtimeRecoveryStore("sandbox-1", "pod-old", 3, SandboxDesiredStateActive)
 	svc := &SandboxService{
 		k8sClient:    fake.NewSimpleClientset(pod),
 		sandboxStore: store,
@@ -84,7 +84,7 @@ func TestReconcileSandboxRuntimeRepairsSameGenerationProjectionFromKubernetes(t 
 
 func TestReconcileSandboxRuntimeRejectsUnownedNewerGeneration(t *testing.T) {
 	pod := runtimeRecoveryPod("pod-new", "sandbox-1", 4)
-	store := runtimeRecoveryStore("sandbox-1", "pod-old", 3, SandboxStatusRunning)
+	store := runtimeRecoveryStore("sandbox-1", "pod-old", 3, SandboxDesiredStateActive)
 	svc := &SandboxService{
 		k8sClient:    fake.NewSimpleClientset(pod),
 		sandboxStore: store,
@@ -101,7 +101,7 @@ func TestReconcileSandboxRuntimeRejectsUnownedNewerGeneration(t *testing.T) {
 func TestReconcileSandboxRuntimeRejectsAmbiguousSameGenerationPods(t *testing.T) {
 	first := runtimeRecoveryPod("pod-a", "sandbox-1", 3)
 	second := runtimeRecoveryPod("pod-b", "sandbox-1", 3)
-	store := runtimeRecoveryStore("sandbox-1", "pod-old", 3, SandboxStatusRunning)
+	store := runtimeRecoveryStore("sandbox-1", "pod-old", 3, SandboxDesiredStateActive)
 	svc := &SandboxService{
 		k8sClient:    fake.NewSimpleClientset(first, second),
 		sandboxStore: store,
@@ -117,7 +117,7 @@ func TestReconcileSandboxRuntimeRejectsAmbiguousSameGenerationPods(t *testing.T)
 
 func TestReconcileSandboxRuntimeDeletesOlderRuntimeBeforeRecovery(t *testing.T) {
 	stale := runtimeRecoveryPod("pod-stale", "sandbox-1", 2)
-	store := runtimeRecoveryStore("sandbox-1", "pod-missing", 3, SandboxStatusRunning)
+	store := runtimeRecoveryStore("sandbox-1", "pod-missing", 3, SandboxDesiredStateActive)
 	enqueuer := &recordingPauseEnqueuer{}
 	client := fake.NewSimpleClientset(stale)
 	svc := &SandboxService{
@@ -138,7 +138,7 @@ func TestReconcileSandboxRuntimeDeletesOlderRuntimeBeforeRecovery(t *testing.T) 
 
 func TestReconcileLostRuntimeRecoveryRetriesOlderRuntimeDeletion(t *testing.T) {
 	stale := runtimeRecoveryPod("pod-stale", "sandbox-1", 2)
-	store := runtimeRecoveryStore("sandbox-1", "pod-missing", 3, SandboxStatusRunning)
+	store := runtimeRecoveryStore("sandbox-1", "pod-missing", 3, SandboxDesiredStateActive)
 	store.lifecycleTxns = map[string]*SandboxLifecycleTxn{
 		"txn-lost": {
 			ID:               "txn-lost",
@@ -181,7 +181,7 @@ func TestReconcileLostRuntimeRecoveryRetriesOlderRuntimeDeletion(t *testing.T) {
 
 func TestReconcileLostRuntimeRecoveryRejectsUnexpectedSameGenerationPod(t *testing.T) {
 	unexpected := runtimeRecoveryPod("pod-unexpected", "sandbox-1", 3)
-	store := runtimeRecoveryStore("sandbox-1", "pod-missing", 3, SandboxStatusRunning)
+	store := runtimeRecoveryStore("sandbox-1", "pod-missing", 3, SandboxDesiredStateActive)
 	store.lifecycleTxns = map[string]*SandboxLifecycleTxn{
 		"txn-lost": {
 			ID:               "txn-lost",
@@ -212,7 +212,7 @@ func TestReconcileLostRuntimeRecoveryRejectsUnexpectedSameGenerationPod(t *testi
 func TestReconcileSandboxRuntimeDoesNotAdoptUnclaimedPod(t *testing.T) {
 	unclaimed := runtimeRecoveryPod("pod-idle", "sandbox-1", 3)
 	unclaimed.Labels[controller.LabelPoolType] = controller.PoolTypeIdle
-	store := runtimeRecoveryStore("sandbox-1", "pod-missing", 3, SandboxStatusRunning)
+	store := runtimeRecoveryStore("sandbox-1", "pod-missing", 3, SandboxDesiredStateActive)
 	enqueuer := &recordingPauseEnqueuer{}
 	svc := &SandboxService{
 		k8sClient:     fake.NewSimpleClientset(unclaimed),
@@ -231,7 +231,7 @@ func TestReconcileSandboxRuntimeDoesNotAdoptUnclaimedPod(t *testing.T) {
 }
 
 func TestReconcileSandboxRuntimeIgnoresAnotherCluster(t *testing.T) {
-	store := runtimeRecoveryStore("sandbox-1", "pod-1", 3, SandboxStatusRunning)
+	store := runtimeRecoveryStore("sandbox-1", "pod-1", 3, SandboxDesiredStateActive)
 	store.records["sandbox-1"].ClusterID = "cluster-b"
 	svc := &SandboxService{
 		k8sClient:    fake.NewSimpleClientset(),
@@ -246,7 +246,7 @@ func TestReconcileSandboxRuntimeIgnoresAnotherCluster(t *testing.T) {
 
 func TestReconcileSandboxRuntimeHardExpiryDeletesInsteadOfRecovering(t *testing.T) {
 	now := time.Date(2026, time.August, 3, 8, 0, 0, 0, time.UTC)
-	store := runtimeRecoveryStore("sandbox-1", "pod-1", 3, SandboxStatusRunning)
+	store := runtimeRecoveryStore("sandbox-1", "pod-1", 3, SandboxDesiredStateActive)
 	store.records["sandbox-1"].HardExpiresAt = now.Add(-time.Second)
 	svc := &SandboxService{
 		k8sClient:    fake.NewSimpleClientset(),
@@ -257,13 +257,13 @@ func TestReconcileSandboxRuntimeHardExpiryDeletesInsteadOfRecovering(t *testing.
 	}
 
 	require.NoError(t, svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1"))
-	assert.Equal(t, SandboxStatusDeleted, store.records["sandbox-1"].Status)
+	assert.Equal(t, SandboxDesiredStateDeleted, store.records["sandbox-1"].DesiredState)
 	assert.Nil(t, activeLifecycleTxnForTest(store, "sandbox-1"))
 }
 
 func TestReconcilePausedSandboxDeletesStalePodWithoutRecovery(t *testing.T) {
 	pod := runtimeRecoveryPod("pod-1", "sandbox-1", 3)
-	store := runtimeRecoveryStore("sandbox-1", "", 3, SandboxStatusPaused)
+	store := runtimeRecoveryStore("sandbox-1", "", 3, SandboxDesiredStatePaused)
 	client := fake.NewSimpleClientset(pod)
 	svc := &SandboxService{
 		k8sClient:    client,
@@ -273,14 +273,14 @@ func TestReconcilePausedSandboxDeletesStalePodWithoutRecovery(t *testing.T) {
 	}
 
 	require.NoError(t, svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1"))
-	assert.Equal(t, SandboxStatusPaused, store.records["sandbox-1"].Status)
+	assert.Equal(t, SandboxDesiredStatePaused, store.records["sandbox-1"].DesiredState)
 	assert.Nil(t, activeLifecycleTxnForTest(store, "sandbox-1"))
 	assert.True(t, hasPodAction(client.Actions(), "delete", "pod-1"))
 }
 
 func TestReconcileSandboxRuntimeDoesNotRaceFreshResumeTransaction(t *testing.T) {
 	now := time.Date(2026, time.August, 3, 8, 0, 0, 0, time.UTC)
-	store := runtimeRecoveryStore("sandbox-1", "", 3, SandboxStatusPaused)
+	store := runtimeRecoveryStore("sandbox-1", "", 3, SandboxDesiredStatePaused)
 	store.lifecycleTxns = map[string]*SandboxLifecycleTxn{
 		"txn-resume": {
 			ID:             "txn-resume",
@@ -309,7 +309,7 @@ func TestReconcileSandboxRuntimeDoesNotRaceFreshResumeTransaction(t *testing.T) 
 
 func TestReconcileSandboxRuntimeAbortsStaleResumeWithMissingTarget(t *testing.T) {
 	now := time.Date(2026, time.August, 3, 8, 0, 0, 0, time.UTC)
-	store := runtimeRecoveryStore("sandbox-1", "", 3, SandboxStatusPaused)
+	store := runtimeRecoveryStore("sandbox-1", "", 3, SandboxDesiredStatePaused)
 	store.records["sandbox-1"].TemplateID = "default"
 	store.records["sandbox-1"].TemplateName = "default"
 	store.records["sandbox-1"].TemplateNamespace = "tpl-default"
@@ -341,7 +341,7 @@ func TestReconcileSandboxRuntimeAbortsStaleResumeWithMissingTarget(t *testing.T)
 
 func TestReconcileSandboxRuntimeWaitsForFreshSourceCheckpointTransaction(t *testing.T) {
 	now := time.Date(2026, time.August, 3, 8, 0, 0, 0, time.UTC)
-	store := runtimeRecoveryStore("sandbox-1", "pod-missing", 3, SandboxStatusRunning)
+	store := runtimeRecoveryStore("sandbox-1", "pod-missing", 3, SandboxDesiredStateActive)
 	store.lifecycleTxns = map[string]*SandboxLifecycleTxn{
 		"txn-snapshot": {
 			ID:               "txn-snapshot",
@@ -373,7 +373,7 @@ func TestReconcileSandboxRuntimeWaitsForFreshSourceCheckpointTransaction(t *test
 
 func TestReconcileSandboxRuntimeRecoversAfterStaleSourceCheckpointTransaction(t *testing.T) {
 	now := time.Date(2026, time.August, 3, 8, 0, 0, 0, time.UTC)
-	store := runtimeRecoveryStore("sandbox-1", "pod-missing", 3, SandboxStatusRunning)
+	store := runtimeRecoveryStore("sandbox-1", "pod-missing", 3, SandboxDesiredStateActive)
 	store.lifecycleTxns = map[string]*SandboxLifecycleTxn{
 		"txn-fork": {
 			ID:               "txn-fork",
@@ -406,7 +406,7 @@ func TestReconcileSandboxRuntimeRecoversAfterStaleSourceCheckpointTransaction(t 
 }
 
 func TestReconcileTerminatingSandboxAbortsResumeAndNeverRecovers(t *testing.T) {
-	store := runtimeRecoveryStore("sandbox-1", "pod-missing", 3, SandboxStatusTerminating)
+	store := runtimeRecoveryStore("sandbox-1", "pod-missing", 3, SandboxDesiredStateTerminating)
 	store.lifecycleTxns = map[string]*SandboxLifecycleTxn{
 		"txn-resume": {
 			ID:             "txn-resume",
@@ -428,13 +428,13 @@ func TestReconcileTerminatingSandboxAbortsResumeAndNeverRecovers(t *testing.T) {
 	}
 
 	require.NoError(t, svc.ReconcileSandboxRuntime(context.Background(), "sandbox-1"))
-	assert.Equal(t, SandboxStatusDeleted, store.records["sandbox-1"].Status)
+	assert.Equal(t, SandboxDesiredStateDeleted, store.records["sandbox-1"].DesiredState)
 	assert.Equal(t, SandboxLifecyclePhaseAborted, store.lifecycleTxns["txn-resume"].Phase)
 	assert.Empty(t, enqueuer.recoveryCalls)
 }
 
 func TestCompleteLostRecoveryPreservesLastCommittedHeadWhenPodIsGone(t *testing.T) {
-	store := runtimeRecoveryStore("sandbox-1", "pod-1", 3, SandboxStatusRunning)
+	store := runtimeRecoveryStore("sandbox-1", "pod-1", 3, SandboxDesiredStateActive)
 	store.rootFSStates = map[string]*SandboxRootFSState{
 		"sandbox-1": {SandboxID: "sandbox-1", LayerID: "committed-head", RuntimeGeneration: 2},
 	}
@@ -459,20 +459,20 @@ func TestCompleteLostRecoveryPreservesLastCommittedHeadWhenPodIsGone(t *testing.
 	}
 
 	require.NoError(t, svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"))
-	assert.Equal(t, SandboxStatusPaused, store.records["sandbox-1"].Status)
+	assert.Equal(t, SandboxDesiredStatePaused, store.records["sandbox-1"].DesiredState)
 	assert.Equal(t, "committed-head", store.rootFSStates["sandbox-1"].LayerID)
 	assert.Equal(t, SandboxLifecyclePhaseCommitted, store.lifecycleTxns["txn-lost"].Phase)
 }
 
 func TestTerminateSandboxPersistsIntentBeforePodDeletion(t *testing.T) {
 	pod := runtimeRecoveryPod("pod-1", "sandbox-1", 3)
-	store := runtimeRecoveryStore("sandbox-1", "pod-1", 3, SandboxStatusRunning)
+	store := runtimeRecoveryStore("sandbox-1", "pod-1", 3, SandboxDesiredStateActive)
 	client := fake.NewSimpleClientset(pod)
-	statusAtDelete := ""
+	desiredStateAtDelete := ""
 	client.PrependReactor("delete", "pods", func(ktesting.Action) (bool, runtime.Object, error) {
 		record, err := store.GetSandbox(context.Background(), "sandbox-1")
 		require.NoError(t, err)
-		statusAtDelete = record.Status
+		desiredStateAtDelete = record.DesiredState
 		return false, nil, nil
 	})
 	svc := &SandboxService{
@@ -485,22 +485,22 @@ func TestTerminateSandboxPersistsIntentBeforePodDeletion(t *testing.T) {
 	}
 
 	require.NoError(t, svc.TerminateSandbox(context.Background(), "sandbox-1"))
-	assert.Equal(t, SandboxStatusTerminating, statusAtDelete)
-	assert.Equal(t, SandboxStatusDeleted, store.records["sandbox-1"].Status)
+	assert.Equal(t, SandboxDesiredStateTerminating, desiredStateAtDelete)
+	assert.Equal(t, SandboxDesiredStateDeleted, store.records["sandbox-1"].DesiredState)
 }
 
 func TestSandboxRecordDeletionScopeRequiresDurableDeleteIntent(t *testing.T) {
 	record := &SandboxRecord{
 		ID:                  "sandbox-1",
-		Status:              SandboxStatusRunning,
+		DesiredState:        SandboxDesiredStateActive,
 		CurrentPodNamespace: "default",
 		CurrentPodName:      "pod-1",
 		RuntimeGeneration:   3,
 	}
 	assert.True(t, SandboxRecordDeletionIsRuntimeOnly(record, "default", "pod-1", 3))
-	record.Status = SandboxStatusTerminating
+	record.DesiredState = SandboxDesiredStateTerminating
 	assert.False(t, SandboxRecordDeletionIsRuntimeOnly(record, "default", "pod-1", 3))
-	record.Status = SandboxStatusDeleted
+	record.DesiredState = SandboxDesiredStateDeleted
 	assert.False(t, SandboxRecordDeletionIsRuntimeOnly(record, "default", "pod-1", 3))
 }
 
@@ -508,7 +508,7 @@ func TestUnexpectedCurrentPodDeletionPreservesSandboxExternalState(t *testing.T)
 	bindings := &deleteRecordingBindingStore{}
 	volumes := &recordingSystemVolumeClient{}
 	emitter := &recordingDeletionWebhookEmitter{}
-	store := runtimeRecoveryStore("sandbox-1", "pod-1", 3, SandboxStatusRunning)
+	store := runtimeRecoveryStore("sandbox-1", "pod-1", 3, SandboxDesiredStateActive)
 	svc := &SandboxService{
 		sandboxStore:           store,
 		credentialStore:        bindings,
@@ -529,7 +529,7 @@ func TestUnexpectedCurrentPodDeletionPreservesSandboxExternalState(t *testing.T)
 	assert.Zero(t, bindings.deleteCalls)
 	assert.Empty(t, volumes.marked)
 	assert.Empty(t, emitter.calls)
-	assert.Equal(t, SandboxStatusRunning, store.records["sandbox-1"].Status)
+	assert.Equal(t, SandboxDesiredStateActive, store.records["sandbox-1"].DesiredState)
 }
 
 func TestSandboxRuntimeReconcilerDeleteEventQueuesSandbox(t *testing.T) {
@@ -547,9 +547,9 @@ func TestSandboxRuntimeReconcilerDeleteEventQueuesSandbox(t *testing.T) {
 func TestSandboxRuntimeReconcilerScansPagesAndQueuesOnlyDrift(t *testing.T) {
 	healthy := runtimeRecoveryPod("pod-a", "sandbox-a", 1)
 	store := &runtimeReconcileMemoryStore{candidates: []SandboxRuntimeReconcileCandidate{
-		{SandboxID: "sandbox-a", Status: SandboxStatusRunning, PodNamespace: "default", PodName: "pod-a", RuntimeGeneration: 1},
-		{SandboxID: "sandbox-b", Status: SandboxStatusRunning, PodNamespace: "default", PodName: "pod-b", RuntimeGeneration: 1},
-		{SandboxID: "sandbox-c", Status: SandboxStatusTerminating},
+		{SandboxID: "sandbox-a", DesiredState: SandboxDesiredStateActive, PodNamespace: "default", PodName: "pod-a", RuntimeGeneration: 1},
+		{SandboxID: "sandbox-b", DesiredState: SandboxDesiredStateActive, PodNamespace: "default", PodName: "pod-b", RuntimeGeneration: 1},
+		{SandboxID: "sandbox-c", DesiredState: SandboxDesiredStateTerminating},
 	}}
 	reconciler := NewSandboxRuntimeReconciler("cluster-a", store, runtimeIdentityPodLister(t, healthy), nil, zap.NewNop())
 	reconciler.pageSize = 2
@@ -588,7 +588,7 @@ func (s *runtimeReconcileMemoryStore) ListRuntimeReconcileCandidates(_ context.C
 	return page, nil
 }
 
-func runtimeRecoveryStore(sandboxID, podName string, generation int64, status string) *memorySandboxStore {
+func runtimeRecoveryStore(sandboxID, podName string, generation int64, desiredState string) *memorySandboxStore {
 	namespace := "default"
 	if podName == "" {
 		namespace = ""
@@ -599,7 +599,7 @@ func runtimeRecoveryStore(sandboxID, podName string, generation int64, status st
 			TeamID:              "team-1",
 			UserID:              "user-1",
 			ClusterID:           "cluster-a",
-			Status:              status,
+			DesiredState:        desiredState,
 			CurrentPodNamespace: namespace,
 			CurrentPodName:      podName,
 			RuntimeGeneration:   generation,

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -711,7 +711,7 @@ func sandboxRecordForClaimedPod(s *SandboxService, pod *corev1.Pod, template *v1
 		TemplateName:         template.Name,
 		TemplateNamespace:    template.Namespace,
 		ClusterID:            naming.ClusterIDOrDefault(template.Spec.ClusterId),
-		Status:               s.podToSandboxStatus(pod),
+		DesiredState:         SandboxDesiredStateActive,
 		Config:               cfg,
 		Mounts:               mounts,
 		TemplateSpec:         template.Spec,
@@ -724,11 +724,6 @@ func sandboxRecordForClaimedPod(s *SandboxService, pod *corev1.Pod, template *v1
 		WebhookStateVolumeID: webhookStateVolumeIDFromPod(pod),
 		OwnerKind:            ownerKindFromPod(pod),
 		CreatedAt:            s.clock.Now(),
-	}
-	if hotClaimUsesRecordCompletion(pod) &&
-		pod.Annotations[controller.AnnotationHotClaimReservationState] ==
-			controller.HotClaimReservationStateInitializing {
-		record.Status = SandboxStatusStarting
 	}
 	return record
 }
@@ -770,7 +765,7 @@ func (s *SandboxService) initializeClaimRootFSFromSnapshot(ctx context.Context, 
 	if state == nil {
 		return pod, true, fmt.Errorf("%w: snapshot %s", ErrRootFSFilesystemNotFound, snapshotID)
 	}
-	pod, err = s.applySandboxRootFSCheckpointWithFallback(ctx, pod, record, template, req, state, SandboxStatusStarting)
+	pod, err = s.applySandboxRootFSCheckpointWithFallback(ctx, pod, record, template, req, state, true)
 	if err != nil {
 		return pod, true, err
 	}
@@ -1187,7 +1182,7 @@ func (s *SandboxService) claimIdlePod(ctx context.Context, template *v1alpha1.Sa
 		pod.Annotations[controller.AnnotationHotClaimReservation] = reservationToken
 		pod.Annotations[controller.AnnotationHotClaimReservationState] = controller.HotClaimReservationStateInitializing
 		pod.Annotations[controller.AnnotationHotClaimReservedAt] = s.clock.Now().UTC().Format(time.RFC3339Nano)
-		pod.Annotations[controller.AnnotationHotClaimCompletionProtocol] = controller.HotClaimCompletionProtocolRecordV1
+		pod.Annotations[controller.AnnotationHotClaimCompletionProtocol] = controller.HotClaimCompletionProtocolRecordV2
 		if stateVolume != nil {
 			pod.Annotations[controller.AnnotationWebhookStateVolumeID] = stateVolume.VolumeID
 		} else {

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -124,8 +124,8 @@ func TestClaimIdlePodClaimsReadyPod(t *testing.T) {
 	if got := pod.Annotations[controller.AnnotationHotClaimReservationState]; got != controller.HotClaimReservationStateInitializing {
 		t.Fatalf("reservation state = %q, want %q", got, controller.HotClaimReservationStateInitializing)
 	}
-	if got := pod.Annotations[controller.AnnotationHotClaimCompletionProtocol]; got != controller.HotClaimCompletionProtocolRecordV1 {
-		t.Fatalf("completion protocol = %q, want %q", got, controller.HotClaimCompletionProtocolRecordV1)
+	if got := pod.Annotations[controller.AnnotationHotClaimCompletionProtocol]; got != controller.HotClaimCompletionProtocolRecordV2 {
+		t.Fatalf("completion protocol = %q, want %q", got, controller.HotClaimCompletionProtocolRecordV2)
 	}
 	if got := pod.Annotations[testAutoscalerSafeToEvictAnnotation]; got != "false" {
 		t.Fatalf("safe-to-evict annotation = %q, want false", got)
@@ -1422,8 +1422,8 @@ func TestClaimSandboxAppliesRootFSFromSnapshotBeforeRuntimeActivation(t *testing
 		t.Fatalf("rootfs state = %+v, want layer-v1 for claimed sandbox", state)
 	}
 	record := store.records[resp.SandboxID]
-	if record == nil || record.Status != SandboxStatusRunning {
-		t.Fatalf("record = %+v, want running claimed sandbox", record)
+	if record == nil || record.DesiredState != SandboxDesiredStateActive {
+		t.Fatalf("record = %+v, want active claimed sandbox", record)
 	}
 }
 
@@ -1508,8 +1508,8 @@ func TestClaimSandboxDoesNotActivateRuntimeBeforePersistence(t *testing.T) {
 		t.Fatalf("sandbox records = %d, want 1", len(store.records))
 	}
 	for _, record := range store.records {
-		if record.Status != SandboxStatusRunning {
-			t.Fatalf("sandbox record status = %q, want running", record.Status)
+		if record.DesiredState != SandboxDesiredStateActive {
+			t.Fatalf("sandbox record desired state = %q, want active", record.DesiredState)
 		}
 	}
 }
@@ -1557,7 +1557,7 @@ func TestClaimSandboxDeletesConcurrentRecordWhenRuntimeActivationFails(t *testin
 		t.Fatalf("sandbox records = %d, want 1", len(store.records))
 	}
 	for _, record := range store.records {
-		if record.Status != SandboxStatusDeleted || record.DeletedAt.IsZero() {
+		if record.DesiredState != SandboxDesiredStateDeleted || record.DeletedAt.IsZero() {
 			t.Fatalf("sandbox record = %#v, want deleted", record)
 		}
 	}

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -30,7 +30,7 @@ func (s *SandboxService) TerminateSandbox(ctx context.Context, sandboxID string)
 
 	alreadyDeleted := false
 	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
-		if record == nil || record.Status == SandboxStatusDeleted || !record.DeletedAt.IsZero() {
+		if record == nil || record.DesiredState == SandboxDesiredStateDeleted || !record.DeletedAt.IsZero() {
 			alreadyDeleted = true
 			return nil
 		}
@@ -43,7 +43,7 @@ func (s *SandboxService) TerminateSandbox(ctx context.Context, sandboxID string)
 				return err
 			}
 		}
-		if record.Status == SandboxStatusTerminating {
+		if record.DesiredState == SandboxDesiredStateTerminating {
 			return nil
 		}
 		return tx.MarkRuntimeTerminating(lockCtx, sandboxID)
@@ -122,7 +122,7 @@ func (s *SandboxService) requestPauseSandboxRuntime(ctx context.Context, sandbox
 		return SandboxStatusPaused, nil
 	}
 
-	status := SandboxStatusRunning
+	status := SandboxStatusStarting
 	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
 		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sandboxID)
 		if err != nil {
@@ -132,15 +132,18 @@ func (s *SandboxService) requestPauseSandboxRuntime(ctx context.Context, sandbox
 			if activeTxn.Kind != SandboxLifecycleKindPause {
 				return errSandboxLifecycleResuming
 			}
-			status = record.Status
-			return nil
+			projected, err := s.projectSandboxRecordFromCache(lockCtx, record, activeTxn)
+			if projected != nil {
+				status = projected.Status
+			}
+			return err
 		}
-		switch record.Status {
-		case SandboxStatusDeleted:
+		switch record.DesiredState {
+		case SandboxDesiredStateDeleted:
 			return k8serrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)
-		case SandboxStatusTerminating:
+		case SandboxDesiredStateTerminating:
 			return k8serrors.NewConflict(schema.GroupResource{Resource: "sandbox"}, sandboxID, fmt.Errorf("sandbox termination is in progress"))
-		case SandboxStatusPaused:
+		case SandboxDesiredStatePaused:
 			status = SandboxStatusPaused
 			return nil
 		}
@@ -157,19 +160,14 @@ func (s *SandboxService) requestPauseSandboxRuntime(ctx context.Context, sandbox
 			return ErrSandboxCheckpointRequiresCtld
 		}
 		generation := runtimeGenerationFromPod(pod)
-		status = record.Status
-		if record.Status == SandboxStatusStarting {
-			// Without an active resume transaction, the Pod is authoritative for
-			// recovering a record left in starting by a timed-out resume request.
-			observedStatus := s.podToSandboxStatus(pod)
-			if observedStatus != SandboxStatusRunning {
-				return k8serrors.NewConflict(schema.GroupResource{Resource: "sandbox"}, sandboxID, fmt.Errorf("sandbox runtime is still %q", observedStatus))
-			}
-			if err := tx.SaveRuntime(lockCtx, sandboxID, pod.Namespace, pod.Name, observedStatus, generation, parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt), sandboxRuntimeMetadataFromPod(pod)); err != nil {
-				return err
-			}
-			status = observedStatus
+		observedStatus := s.podToSandboxStatus(pod)
+		if observedStatus != SandboxStatusRunning {
+			return k8serrors.NewConflict(schema.GroupResource{Resource: "sandbox"}, sandboxID, fmt.Errorf("sandbox runtime is still %q", observedStatus))
 		}
+		if err := tx.SaveRuntime(lockCtx, sandboxID, pod.Namespace, pod.Name, generation, parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt), sandboxRuntimeMetadataFromPod(pod)); err != nil {
+			return err
+		}
+		status = observedStatus
 		source := strings.TrimSpace(opts.source)
 		if source == "" {
 			source = SandboxLifecycleSourceManual
@@ -290,17 +288,13 @@ func (s *SandboxService) pauseSandboxRuntime(ctx context.Context, sandboxID stri
 	}
 	pause := func(ctx context.Context, tx SandboxStoreTx, record *SandboxRecord) error {
 		if record != nil {
-			switch record.Status {
-			case SandboxStatusDeleted:
+			switch record.DesiredState {
+			case SandboxDesiredStateDeleted:
 				return k8serrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)
-			case SandboxStatusTerminating:
+			case SandboxDesiredStateTerminating:
 				return k8serrors.NewConflict(schema.GroupResource{Resource: "sandbox"}, sandboxID, fmt.Errorf("sandbox termination is in progress"))
-			case SandboxStatusPaused:
+			case SandboxDesiredStatePaused:
 				return nil
-			case SandboxStatusStarting:
-				if saveRootFS {
-					return k8serrors.NewConflict(schema.GroupResource{Resource: "sandbox"}, sandboxID, fmt.Errorf("sandbox lifecycle operation %q is in progress", record.Status))
-				}
 			}
 		}
 		pod, err := s.getSandboxPod(ctx, sandboxID)
@@ -804,19 +798,17 @@ func (s *SandboxService) GetSandbox(ctx context.Context, sandboxID string) (*San
 			return nil, fmt.Errorf("get sandbox record: %w", storeErr)
 		}
 		if record != nil {
-			if record.Status == SandboxStatusDeleted {
+			if record.DesiredState == SandboxDesiredStateDeleted {
 				return nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)
 			}
-			if record.Status == SandboxStatusPaused {
+			if record.DesiredState == SandboxDesiredStatePaused || record.DesiredState == SandboxDesiredStateTerminating {
 				return s.recordToSandbox(record), nil
 			}
 			activeTxn, txnErr := s.sandboxStore.GetActiveLifecycleTxn(ctx, sandboxID)
 			if txnErr != nil {
 				return nil, fmt.Errorf("get active sandbox lifecycle txn: %w", txnErr)
 			}
-			if sandboxLifecycleTxnHidesCommittedRuntime(activeTxn) {
-				return s.recordToSandbox(record), nil
-			}
+			return s.projectSandboxRecordFromCache(ctx, record, activeTxn)
 		}
 	}
 	// Find the pod by sandbox ID
@@ -834,6 +826,27 @@ func (s *SandboxService) GetSandbox(ctx context.Context, sandboxID string) (*San
 	return s.podToSandbox(pod, sandboxID), nil
 }
 
+func (s *SandboxService) projectSandboxRecordFromCache(ctx context.Context, record *SandboxRecord, activeTxn *SandboxLifecycleTxn) (*Sandbox, error) {
+	projected := s.recordToSandbox(record)
+	if record == nil || record.DesiredState != SandboxDesiredStateActive || s.podLister == nil {
+		return projected, nil
+	}
+	pod, err := s.getSandboxPod(ctx, record.ID)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return projected, nil
+		}
+		return nil, fmt.Errorf("get cached sandbox pod: %w", err)
+	}
+	projected = s.podToSandbox(pod, record.ID)
+	if sandboxLifecycleTxnHidesCommittedRuntime(activeTxn) {
+		// Lifecycle barriers fence runtime access even while the cached Pod still
+		// supplies the externally visible observed status.
+		projected.InternalAddr = ""
+	}
+	return projected, nil
+}
+
 // UpdateSandbox updates mutable sandbox configuration fields.
 func (s *SandboxService) UpdateSandbox(ctx context.Context, sandboxID string, cfg *SandboxUpdateConfig) (*Sandbox, error) {
 	if cfg == nil {
@@ -848,10 +861,10 @@ func (s *SandboxService) UpdateSandbox(ctx context.Context, sandboxID string, cf
 			return nil, fmt.Errorf("get sandbox record: %w", getErr)
 		}
 		if record != nil {
-			if record.Status == SandboxStatusDeleted {
+			if record.DesiredState == SandboxDesiredStateDeleted {
 				return nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)
 			}
-			if record.Status == SandboxStatusPaused {
+			if record.DesiredState == SandboxDesiredStatePaused {
 				return s.updatePausedSandboxRecord(ctx, record, cfg)
 			}
 		}
@@ -860,7 +873,7 @@ func (s *SandboxService) UpdateSandbox(ctx context.Context, sandboxID string, cf
 	pod, err := s.getSandboxPod(ctx, sandboxID)
 	if err != nil {
 		if k8serrors.IsNotFound(err) && s.sandboxStore != nil {
-			if record != nil && record.Status != SandboxStatusDeleted {
+			if record != nil && record.DesiredState != SandboxDesiredStateDeleted {
 				return s.updatePausedSandboxRecord(ctx, record, cfg)
 			}
 		}
@@ -1157,7 +1170,7 @@ func (s *SandboxService) persistUpdatedSandboxPod(ctx context.Context, pod *core
 		TemplateName:         template.Name,
 		TemplateNamespace:    template.Namespace,
 		ClusterID:            naming.ClusterIDOrDefault(template.Spec.ClusterId),
-		Status:               s.podToSandboxStatus(pod),
+		DesiredState:         SandboxDesiredStateActive,
 		Config:               parseSandboxConfig(pod.Annotations[controller.AnnotationConfig]),
 		Mounts:               parseClaimMounts(pod.Annotations[controller.AnnotationMounts]),
 		TemplateSpec:         template.Spec,
@@ -1172,7 +1185,7 @@ func (s *SandboxService) persistUpdatedSandboxPod(ctx context.Context, pod *core
 		CreatedAt:            pod.CreationTimestamp.Time,
 	}
 	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, locked *SandboxRecord) error {
-		if locked.Status == SandboxStatusPaused || locked.Status == SandboxStatusTerminating || locked.Status == SandboxStatusDeleted || !locked.DeletedAt.IsZero() {
+		if locked.DesiredState == SandboxDesiredStatePaused || locked.DesiredState == SandboxDesiredStateTerminating || locked.DesiredState == SandboxDesiredStateDeleted || !locked.DeletedAt.IsZero() {
 			return nil
 		}
 		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sandboxID)
@@ -1314,8 +1327,8 @@ func (s *SandboxService) recordToSandbox(record *SandboxRecord) *Sandbox {
 		TemplateID:        record.TemplateID,
 		TeamID:            record.TeamID,
 		UserID:            record.UserID,
-		Status:            record.Status,
-		Paused:            record.Status == SandboxStatusPaused,
+		Status:            sandboxStatusFromDesiredState(record.DesiredState),
+		Paused:            record.DesiredState == SandboxDesiredStatePaused,
 		AutoResume:        autoResume,
 		Resources:         cloneSandboxResourceConfig(record.Config.Resources),
 		Services:          record.Config.Services,
@@ -1327,6 +1340,19 @@ func (s *SandboxService) recordToSandbox(record *SandboxRecord) *Sandbox {
 		ClaimedAt:         record.ClaimedAt,
 		CreatedAt:         record.CreatedAt,
 		UpdatedAt:         record.UpdatedAt,
+	}
+}
+
+func sandboxStatusFromDesiredState(desiredState string) string {
+	switch desiredState {
+	case SandboxDesiredStatePaused:
+		return SandboxStatusPaused
+	case SandboxDesiredStateTerminating, SandboxDesiredStateDeleted:
+		return SandboxStatusTerminating
+	default:
+		// An active durable intent without a cached runtime is starting or being
+		// reconstructed. Running and failed are projected from the Pod cache.
+		return SandboxStatusStarting
 	}
 }
 

--- a/manager/pkg/service/sandbox_service_list.go
+++ b/manager/pkg/service/sandbox_service_list.go
@@ -159,18 +159,25 @@ func (s *SandboxService) listSandboxesFromStore(ctx context.Context, req *ListSa
 	}
 	summaries := make([]*SandboxSummary, 0, len(records))
 	for _, record := range records {
+		if record == nil {
+			continue
+		}
 		sandbox := s.recordToSandbox(record)
 		var activeTxn *SandboxLifecycleTxn
-		if record != nil && record.Status != SandboxStatusPaused {
+		if record.DesiredState == SandboxDesiredStateActive {
 			activeTxn, err = s.sandboxStore.GetActiveLifecycleTxn(ctx, record.ID)
 			if err != nil {
 				return nil, err
 			}
 		}
-		if record.CurrentPodName != "" && record.Status != SandboxStatusPaused && !sandboxLifecycleTxnHidesCommittedRuntime(activeTxn) {
-			if pod, err := s.getSandboxPod(ctx, record.ID); err == nil {
-				sandbox = s.podToSandbox(pod, record.ID)
+		if record.DesiredState == SandboxDesiredStateActive {
+			sandbox, err = s.projectSandboxRecordFromCache(ctx, record, activeTxn)
+			if err != nil {
+				return nil, err
 			}
+		}
+		if req.Status != "" && sandbox.Status != req.Status {
+			continue
 		}
 		if req.Paused != nil && sandbox.Paused != *req.Paused {
 			continue

--- a/manager/pkg/service/sandbox_service_list.go
+++ b/manager/pkg/service/sandbox_service_list.go
@@ -163,15 +163,11 @@ func (s *SandboxService) listSandboxesFromStore(ctx context.Context, req *ListSa
 			continue
 		}
 		sandbox := s.recordToSandbox(record)
-		var activeTxn *SandboxLifecycleTxn
 		if record.DesiredState == SandboxDesiredStateActive {
-			activeTxn, err = s.sandboxStore.GetActiveLifecycleTxn(ctx, record.ID)
-			if err != nil {
-				return nil, err
-			}
-		}
-		if record.DesiredState == SandboxDesiredStateActive {
-			sandbox, err = s.projectSandboxRecordFromCache(ctx, record, activeTxn)
+			// SandboxSummary does not expose runtime connectivity, so lifecycle
+			// transactions are irrelevant to list projection. Avoid one database
+			// lookup per active sandbox.
+			sandbox, err = s.projectSandboxRecordFromCache(ctx, record, nil)
 			if err != nil {
 				return nil, err
 			}

--- a/manager/pkg/service/sandbox_service_list_test.go
+++ b/manager/pkg/service/sandbox_service_list_test.go
@@ -391,6 +391,7 @@ func TestListSandboxesFromStoreProjectsAndFiltersCachedPodStatus(t *testing.T) {
 	require.Len(t, starting.Sandboxes, 1)
 	assert.Equal(t, "sandbox-missing", starting.Sandboxes[0].ID)
 	assert.Empty(t, client.Actions(), "status projection must not call the Kubernetes API")
+	assert.Zero(t, store.activeTxnGets, "list projection must not query lifecycle transactions per sandbox")
 }
 
 func TestListSandboxes_TerminatingPodStatus(t *testing.T) {

--- a/manager/pkg/service/sandbox_service_list_test.go
+++ b/manager/pkg/service/sandbox_service_list_test.go
@@ -294,17 +294,17 @@ func TestListSandboxesFromStoreFiltersPausedState(t *testing.T) {
 	now := time.Now()
 	store := &memorySandboxStore{records: map[string]*SandboxRecord{
 		"sandbox-running": {
-			ID:         "sandbox-running",
-			TeamID:     "team-a",
-			TemplateID: "template-1",
-			Status:     SandboxStatusRunning,
-			CreatedAt:  now.Add(-time.Minute),
+			ID:           "sandbox-running",
+			TeamID:       "team-a",
+			TemplateID:   "template-1",
+			DesiredState: SandboxDesiredStateActive,
+			CreatedAt:    now.Add(-time.Minute),
 		},
 		"sandbox-paused": {
 			ID:                "sandbox-paused",
 			TeamID:            "team-a",
 			TemplateID:        "template-1",
-			Status:            SandboxStatusPaused,
+			DesiredState:      SandboxDesiredStatePaused,
 			RuntimeGeneration: 3,
 			CreatedAt:         now,
 		},
@@ -326,6 +326,71 @@ func TestListSandboxesFromStoreFiltersPausedState(t *testing.T) {
 	assert.Equal(t, "sandbox-paused", resp.Sandboxes[0].ID)
 	assert.True(t, resp.Sandboxes[0].Paused)
 	assert.Equal(t, int64(3), resp.Sandboxes[0].RuntimeGeneration)
+}
+
+func TestListSandboxesFromStoreProjectsAndFiltersCachedPodStatus(t *testing.T) {
+	now := time.Now()
+	runningPod := createTestPod("sandbox-running", "team-a", "template-1", controller.PoolTypeActive, now, now.Add(time.Hour), false)
+	failedPod := createTestPodWithPhase("sandbox-failed", "team-a", "template-1", controller.PoolTypeActive, now, now.Add(time.Hour), false, corev1.PodFailed)
+	store := &memorySandboxStore{records: map[string]*SandboxRecord{
+		"sandbox-running": {
+			ID:           "sandbox-running",
+			TeamID:       "team-a",
+			TemplateID:   "template-1",
+			DesiredState: SandboxDesiredStateActive,
+			CreatedAt:    now,
+		},
+		"sandbox-failed": {
+			ID:           "sandbox-failed",
+			TeamID:       "team-a",
+			TemplateID:   "template-1",
+			DesiredState: SandboxDesiredStateActive,
+			CreatedAt:    now.Add(-time.Minute),
+		},
+		"sandbox-missing": {
+			ID:           "sandbox-missing",
+			TeamID:       "team-a",
+			TemplateID:   "template-1",
+			DesiredState: SandboxDesiredStateActive,
+			CreatedAt:    now.Add(-2 * time.Minute),
+		},
+	}}
+	client := fake.NewSimpleClientset()
+	svc := &SandboxService{
+		k8sClient:    client,
+		sandboxStore: store,
+		podLister:    newTestPodLister(t, runningPod, failedPod),
+		clock:        systemTime{},
+		logger:       zap.NewNop(),
+	}
+
+	running, err := svc.ListSandboxes(context.Background(), &ListSandboxesRequest{
+		TeamID: "team-a",
+		Status: SandboxStatusRunning,
+		Limit:  50,
+	})
+	require.NoError(t, err)
+	require.Len(t, running.Sandboxes, 1)
+	assert.Equal(t, "sandbox-running", running.Sandboxes[0].ID)
+
+	failed, err := svc.ListSandboxes(context.Background(), &ListSandboxesRequest{
+		TeamID: "team-a",
+		Status: SandboxStatusFailed,
+		Limit:  50,
+	})
+	require.NoError(t, err)
+	require.Len(t, failed.Sandboxes, 1)
+	assert.Equal(t, "sandbox-failed", failed.Sandboxes[0].ID)
+
+	starting, err := svc.ListSandboxes(context.Background(), &ListSandboxesRequest{
+		TeamID: "team-a",
+		Status: SandboxStatusStarting,
+		Limit:  50,
+	})
+	require.NoError(t, err)
+	require.Len(t, starting.Sandboxes, 1)
+	assert.Equal(t, "sandbox-missing", starting.Sandboxes[0].ID)
+	assert.Empty(t, client.Actions(), "status projection must not call the Kubernetes API")
 }
 
 func TestListSandboxes_TerminatingPodStatus(t *testing.T) {

--- a/manager/pkg/service/sandbox_service_quota.go
+++ b/manager/pkg/service/sandbox_service_quota.go
@@ -119,8 +119,8 @@ func sandboxRecordCountsForActiveQuota(record *SandboxRecord) bool {
 	if record == nil || !record.DeletedAt.IsZero() {
 		return false
 	}
-	switch record.Status {
-	case SandboxStatusStarting, SandboxStatusRunning:
+	switch record.DesiredState {
+	case SandboxDesiredStateActive:
 		return true
 	default:
 		return false

--- a/manager/pkg/service/sandbox_service_quota_test.go
+++ b/manager/pkg/service/sandbox_service_quota_test.go
@@ -103,19 +103,19 @@ func TestEnforceActiveSandboxQuotaUsesSandboxStoreWhenUsageStoreDisabled(t *test
 		sandboxStore: &memorySandboxStore{
 			records: map[string]*SandboxRecord{
 				"sandbox-1": {
-					ID:     "sandbox-1",
-					TeamID: "team-1",
-					Status: SandboxStatusRunning,
+					ID:           "sandbox-1",
+					TeamID:       "team-1",
+					DesiredState: SandboxDesiredStateActive,
 				},
 				"paused": {
-					ID:     "paused",
-					TeamID: "team-1",
-					Status: SandboxStatusPaused,
+					ID:           "paused",
+					TeamID:       "team-1",
+					DesiredState: SandboxDesiredStatePaused,
 				},
 				"other-team": {
-					ID:     "other-team",
-					TeamID: "team-2",
-					Status: SandboxStatusRunning,
+					ID:           "other-team",
+					TeamID:       "team-2",
+					DesiredState: SandboxDesiredStateActive,
 				},
 			},
 		},
@@ -136,9 +136,9 @@ func TestEnforceActiveSandboxQuotaPrefersOperationalStoreOverUsageProjection(t *
 		sandboxStore: &memorySandboxStore{
 			records: map[string]*SandboxRecord{
 				"sandbox-1": {
-					ID:     "sandbox-1",
-					TeamID: "team-1",
-					Status: SandboxStatusRunning,
+					ID:           "sandbox-1",
+					TeamID:       "team-1",
+					DesiredState: SandboxDesiredStateActive,
 				},
 			},
 		},

--- a/manager/pkg/service/sandbox_service_resources_test.go
+++ b/manager/pkg/service/sandbox_service_resources_test.go
@@ -472,7 +472,7 @@ func TestUpdatePausedSandboxValidatesAndPersistsMemory(t *testing.T) {
 		ID:           "sandbox-1",
 		TeamID:       "team-a",
 		TemplateID:   "default",
-		Status:       SandboxStatusPaused,
+		DesiredState: SandboxDesiredStatePaused,
 		Config:       SandboxConfig{},
 		ClaimedAt:    now,
 		CreatedAt:    now,

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -53,10 +53,10 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 		restoreNeeded = false
 		var waitErr error
 		err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, locked *SandboxRecord) error {
-			if locked.Status == SandboxStatusDeleted || !locked.DeletedAt.IsZero() {
+			if locked.DesiredState == SandboxDesiredStateDeleted || !locked.DeletedAt.IsZero() {
 				return k8serrors.NewNotFound(corev1.Resource("sandbox"), sandboxID)
 			}
-			if locked.Status == SandboxStatusTerminating {
+			if locked.DesiredState == SandboxDesiredStateTerminating {
 				return k8serrors.NewConflict(corev1.Resource("sandbox"), sandboxID, fmt.Errorf("sandbox termination is in progress"))
 			}
 			if sandboxHardExpired(locked.HardExpiresAt, s.now()) {
@@ -90,7 +90,7 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 					}
 					return errSandboxRuntimeDeleting
 				}
-				if locked.Status == SandboxStatusPaused {
+				if locked.DesiredState == SandboxDesiredStatePaused {
 					deletingPodRef = &sandboxRuntimePodRef{
 						namespace: existing.Namespace,
 						name:      existing.Name,
@@ -122,12 +122,12 @@ func (s *SandboxService) ResumePausedSandboxRuntime(ctx context.Context, sandbox
 				}
 				pod = existing
 				record = nil
-				return tx.SaveRuntime(lockCtx, sandboxID, existing.Namespace, existing.Name, s.podToSandboxStatus(existing), runtimeGenerationFromPod(existing), parseRFC3339AnnotationTime(existing.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(existing.Annotations, controller.AnnotationHardExpiresAt), sandboxRuntimeMetadataFromPod(existing))
+				return tx.SaveRuntime(lockCtx, sandboxID, existing.Namespace, existing.Name, runtimeGenerationFromPod(existing), parseRFC3339AnnotationTime(existing.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(existing.Annotations, controller.AnnotationHardExpiresAt), sandboxRuntimeMetadataFromPod(existing))
 			}
 			if getErr != nil && !k8serrors.IsNotFound(getErr) {
 				return fmt.Errorf("get current runtime pod: %w", getErr)
 			}
-			if locked.Status != SandboxStatusPaused {
+			if locked.DesiredState != SandboxDesiredStatePaused {
 				waitErr = errSandboxRuntimeReconcileRequested
 				return nil
 			}
@@ -310,8 +310,8 @@ func (s *SandboxService) recordResumeLifecycleRuntime(ctx context.Context, sandb
 		if activeTxn == nil || activeTxn.ID != txn.ID || activeTxn.Kind != SandboxLifecycleKindResume {
 			return fmt.Errorf("resume lifecycle transaction is no longer active")
 		}
-		if locked.Status != SandboxStatusPaused {
-			return fmt.Errorf("resume lifecycle runtime update expected paused sandbox, got %s", locked.Status)
+		if locked.DesiredState != SandboxDesiredStatePaused {
+			return fmt.Errorf("resume lifecycle runtime update expected paused sandbox, got %s", locked.DesiredState)
 		}
 		podGeneration := runtimeGenerationFromPod(pod)
 		if podGeneration != txn.ToGeneration {
@@ -333,14 +333,14 @@ func (s *SandboxService) commitResumedSandboxRuntime(ctx context.Context, pod *c
 		if activeTxn == nil || activeTxn.ID != txn.ID || activeTxn.Kind != SandboxLifecycleKindResume {
 			return fmt.Errorf("resume lifecycle transaction is no longer active")
 		}
-		if locked.Status != SandboxStatusPaused {
-			return fmt.Errorf("resume lifecycle commit expected paused sandbox, got %s", locked.Status)
+		if locked.DesiredState != SandboxDesiredStatePaused {
+			return fmt.Errorf("resume lifecycle commit expected paused sandbox, got %s", locked.DesiredState)
 		}
 		podGeneration := runtimeGenerationFromPod(pod)
 		if podGeneration != txn.ToGeneration {
 			return fmt.Errorf("resume lifecycle generation changed: txn=%d pod=%d", txn.ToGeneration, podGeneration)
 		}
-		if err := tx.SaveRuntime(lockCtx, record.ID, pod.Namespace, pod.Name, s.podToSandboxStatus(pod), txn.ToGeneration, parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt), sandboxRuntimeMetadataFromPod(pod)); err != nil {
+		if err := tx.SaveRuntime(lockCtx, record.ID, pod.Namespace, pod.Name, txn.ToGeneration, parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt), sandboxRuntimeMetadataFromPod(pod)); err != nil {
 			return err
 		}
 		return tx.CommitLifecycleTxn(lockCtx, txn.ID, "")
@@ -483,7 +483,7 @@ func (s *SandboxService) finishRestoredSandboxRuntime(ctx context.Context, pod *
 	}
 	assignedPodUID := pod.UID
 	phaseStarted := time.Now()
-	pod, err = s.applySandboxRootFSCheckpointWithFallback(ctx, pod, record, template, req, rootFSState, "")
+	pod, err = s.applySandboxRootFSCheckpointWithFallback(ctx, pod, record, template, req, rootFSState, false)
 	s.observeClaimPhase(record.TemplateID, claimType, "apply_rootfs_checkpoint", phaseStarted, err)
 	if err != nil {
 		return pod, err

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -316,7 +316,7 @@ func rootFSExcludedPathsForPod(pod *corev1.Pod) []string {
 	return out
 }
 
-func (s *SandboxService) applySandboxRootFSCheckpointWithFallback(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, template *v1alpha1.SandboxTemplate, req *ClaimRequest, state *SandboxRootFSState, fallbackStatus string) (*corev1.Pod, error) {
+func (s *SandboxService) applySandboxRootFSCheckpointWithFallback(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, template *v1alpha1.SandboxTemplate, req *ClaimRequest, state *SandboxRootFSState, persistRuntime bool) (*corev1.Pod, error) {
 	if state == nil {
 		return pod, nil
 	}
@@ -357,8 +357,8 @@ func (s *SandboxService) applySandboxRootFSCheckpointWithFallback(ctx context.Co
 		s.requestSandboxDeletionAfterClaimFailure(readyPod, "checkpoint base image rootfs apply failed")
 		return readyPod, fmt.Errorf("%w; checkpoint base image retry failed: %v", err, fallbackErr)
 	}
-	if strings.TrimSpace(fallbackStatus) != "" {
-		if fallbackErr := s.saveRestoredRuntimePod(ctx, readyPod, record, fallbackStatus); fallbackErr != nil {
+	if persistRuntime {
+		if fallbackErr := s.saveRestoredRuntimePod(ctx, readyPod, record); fallbackErr != nil {
 			s.requestSandboxDeletionAfterClaimFailure(readyPod, "checkpoint base image runtime persistence failed")
 			return readyPod, fallbackErr
 		}
@@ -366,7 +366,7 @@ func (s *SandboxService) applySandboxRootFSCheckpointWithFallback(ctx context.Co
 	return readyPod, nil
 }
 
-func (s *SandboxService) saveRestoredRuntimePod(ctx context.Context, pod *corev1.Pod, record *SandboxRecord, status string) error {
+func (s *SandboxService) saveRestoredRuntimePod(ctx context.Context, pod *corev1.Pod, record *SandboxRecord) error {
 	if s == nil || s.sandboxStore == nil || pod == nil || record == nil {
 		return nil
 	}
@@ -378,13 +378,13 @@ func (s *SandboxService) saveRestoredRuntimePod(ctx context.Context, pod *corev1
 		return fmt.Errorf("sandbox_id is required")
 	}
 	return s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx SandboxStoreTx, locked *SandboxRecord) error {
-		if locked == nil || locked.Status == SandboxStatusTerminating || locked.Status == SandboxStatusDeleted || !locked.DeletedAt.IsZero() {
+		if locked == nil || locked.DesiredState == SandboxDesiredStateTerminating || locked.DesiredState == SandboxDesiredStateDeleted || !locked.DeletedAt.IsZero() {
 			return nil
 		}
 		if runtimeGenerationFromPod(pod) < locked.RuntimeGeneration {
 			return nil
 		}
-		return tx.SaveRuntime(lockCtx, sandboxID, pod.Namespace, pod.Name, status, runtimeGenerationFromPod(pod), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt), sandboxRuntimeMetadataFromPod(pod))
+		return tx.SaveRuntime(lockCtx, sandboxID, pod.Namespace, pod.Name, runtimeGenerationFromPod(pod), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt), sandboxRuntimeMetadataFromPod(pod))
 	})
 }
 

--- a/manager/pkg/service/sandbox_service_rootfs_product.go
+++ b/manager/pkg/service/sandbox_service_rootfs_product.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/pkg/template"
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
@@ -365,7 +366,7 @@ func (s *SandboxService) ForkSandbox(ctx context.Context, sourceSandboxID, teamI
 		TemplateName:      source.TemplateName,
 		TemplateNamespace: source.TemplateNamespace,
 		ClusterID:         source.ClusterID,
-		Status:            SandboxStatusPaused,
+		DesiredState:      SandboxDesiredStatePaused,
 		Config:            targetConfig,
 		TemplateSpec:      *source.TemplateSpec.DeepCopy(),
 		ClaimedAt:         now,
@@ -459,21 +460,15 @@ func (s *SandboxService) prepareRootFSSourceCheckpoint(ctx context.Context, sour
 			return nil
 		}
 		source = cloneSandboxRecordForRootFSProduct(record)
-		if record.Status == SandboxStatusPaused {
+		if record.DesiredState == SandboxDesiredStatePaused {
 			return nil
 		}
 		if !s.config.CtldEnabled || s.ctldClient == nil {
 			return ErrSandboxCheckpointRequiresCtld
 		}
-		pod, err := s.getSandboxPod(lockCtx, sourceSandboxID)
+		pod, err := s.resolveRootFSSourceRuntimePod(lockCtx, record)
 		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return apierrors.NewConflict(schema.GroupResource{Resource: "sandbox"}, sourceSandboxID, fmt.Errorf("running sandbox has no runtime pod"))
-			}
-			return fmt.Errorf("get runtime pod: %w", err)
-		}
-		if pod.DeletionTimestamp != nil {
-			return apierrors.NewConflict(schema.GroupResource{Resource: "sandbox"}, sourceSandboxID, fmt.Errorf("runtime pod deletion is in progress"))
+			return err
 		}
 		txn = &SandboxLifecycleTxn{
 			ID:               uuid.NewString(),
@@ -583,7 +578,7 @@ func (s *SandboxService) commitRootFSSnapshot(ctx context.Context, store Sandbox
 			if activeTxn != nil {
 				return errSandboxLifecycleRootFSCheckpointing
 			}
-			if record.Status != SandboxStatusPaused {
+			if record.DesiredState != SandboxDesiredStatePaused {
 				return errSandboxLifecycleRootFSCheckpointing
 			}
 		}
@@ -648,7 +643,7 @@ func (s *SandboxService) commitForkSandbox(ctx context.Context, store SandboxRoo
 			if activeTxn != nil {
 				return errSandboxLifecycleRootFSCheckpointing
 			}
-			if record.Status != SandboxStatusPaused {
+			if record.DesiredState != SandboxDesiredStatePaused {
 				return errSandboxLifecycleRootFSCheckpointing
 			}
 		}
@@ -746,14 +741,14 @@ func (s *SandboxService) requireRootFSSandboxOwnership(ctx context.Context, sand
 }
 
 func validateRootFSSandboxRecord(record *SandboxRecord, sandboxID, teamID string, requirePaused bool) error {
-	if record == nil || record.Status == SandboxStatusDeleted {
+	if record == nil || record.DesiredState == SandboxDesiredStateDeleted {
 		return apierrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)
 	}
 	if record.TeamID != teamID {
 		return apierrors.NewForbidden(schema.GroupResource{Resource: "sandbox"}, sandboxID, fmt.Errorf("sandbox belongs to a different team"))
 	}
-	if requirePaused && record.Status != SandboxStatusPaused {
-		return fmt.Errorf("%w: current status is %s", ErrSandboxRootFSRequiresPausedSandbox, record.Status)
+	if requirePaused && record.DesiredState != SandboxDesiredStatePaused {
+		return fmt.Errorf("%w: current desired state is %s", ErrSandboxRootFSRequiresPausedSandbox, record.DesiredState)
 	}
 	return nil
 }
@@ -762,13 +757,42 @@ func validateRootFSSourceSandboxRecord(record *SandboxRecord, sandboxID, teamID 
 	if err := validateRootFSSandboxRecord(record, sandboxID, teamID, false); err != nil {
 		return err
 	}
-	if record.Status != SandboxStatusPaused && record.Status != SandboxStatusRunning {
-		return fmt.Errorf("%w: current status is %s", ErrSandboxRootFSSourceRequiresRunningOrPaused, record.Status)
+	if record.DesiredState != SandboxDesiredStatePaused && record.DesiredState != SandboxDesiredStateActive {
+		return fmt.Errorf("%w: current desired state is %s", ErrSandboxRootFSSourceRequiresRunningOrPaused, record.DesiredState)
 	}
 	if sandboxHardExpired(record.HardExpiresAt, now) {
 		return apierrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, sandboxID)
 	}
 	return nil
+}
+
+// resolveRootFSSourceRuntimePod projects active source readiness exclusively
+// from the shared informer cache. Paused sources have no runtime pod by design.
+func (s *SandboxService) resolveRootFSSourceRuntimePod(ctx context.Context, record *SandboxRecord) (*corev1.Pod, error) {
+	if record == nil {
+		return nil, fmt.Errorf("%w: current status is %s", ErrSandboxRootFSSourceRequiresRunningOrPaused, SandboxStatusStarting)
+	}
+	if record.DesiredState == SandboxDesiredStatePaused {
+		return nil, nil
+	}
+	if record.DesiredState != SandboxDesiredStateActive {
+		return nil, fmt.Errorf("%w: current desired state is %s", ErrSandboxRootFSSourceRequiresRunningOrPaused, record.DesiredState)
+	}
+	if s == nil || s.podLister == nil {
+		return nil, fmt.Errorf("%w: current status is %s", ErrSandboxRootFSSourceRequiresRunningOrPaused, SandboxStatusStarting)
+	}
+	pod, err := s.getSandboxPod(ctx, record.ID)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("%w: current status is %s", ErrSandboxRootFSSourceRequiresRunningOrPaused, SandboxStatusStarting)
+		}
+		return nil, fmt.Errorf("get cached runtime pod: %w", err)
+	}
+	status := s.podToSandboxStatus(pod)
+	if status != SandboxStatusRunning {
+		return nil, fmt.Errorf("%w: current status is %s", ErrSandboxRootFSSourceRequiresRunningOrPaused, status)
+	}
+	return pod, nil
 }
 
 func sandboxRootFSSnapshotFromStore(snapshot *RootFSSnapshot) *SandboxRootFSSnapshot {

--- a/manager/pkg/service/sandbox_service_rootfs_product_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_product_test.go
@@ -21,7 +21,7 @@ func TestSandboxRootFSProductRequiresPausedSandboxForRestore(t *testing.T) {
 	now := time.Now().UTC()
 	store := &memorySandboxStore{
 		records: map[string]*SandboxRecord{
-			"sandbox-1": rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusRunning, now),
+			"sandbox-1": rootFSProductTestRecord("sandbox-1", "team-1", SandboxDesiredStateActive, now),
 		},
 		rootFSStates: map[string]*SandboxRootFSState{
 			"sandbox-1": rootFSProductTestState("sandbox-1", "team-1", "layer-1"),
@@ -54,7 +54,7 @@ func TestSandboxRootFSProductHidesInternalTemplateBuildSnapshots(t *testing.T) {
 	internalSnapshotID := "template-build-123456"
 	store := &memorySandboxStore{
 		records: map[string]*SandboxRecord{
-			"sandbox-1": rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusPaused, now),
+			"sandbox-1": rootFSProductTestRecord("sandbox-1", "team-1", SandboxDesiredStatePaused, now),
 		},
 		rootFSStates: map[string]*SandboxRootFSState{
 			"sandbox-1": rootFSProductTestState("sandbox-1", "team-1", "layer-1"),
@@ -109,7 +109,7 @@ func TestSandboxRootFSProductSnapshotsRestoresAndForksPausedSandbox(t *testing.T
 	autoResume := true
 	store := &memorySandboxStore{
 		records: map[string]*SandboxRecord{
-			"sandbox-1": rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusPaused, now),
+			"sandbox-1": rootFSProductTestRecord("sandbox-1", "team-1", SandboxDesiredStatePaused, now),
 		},
 		rootFSStates: map[string]*SandboxRootFSState{
 			"sandbox-1": rootFSProductTestState("sandbox-1", "team-1", "layer-v1"),
@@ -226,7 +226,8 @@ func TestSandboxRootFSProductSnapshotRunningSandboxCheckpointsWithoutPausingSour
 
 	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
 	pod.Status.HostIP = ctldURL.Hostname()
-	source := rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusRunning, now)
+	markRuntimeIdentityPodReady(t, pod)
+	source := rootFSProductTestRecord("sandbox-1", "team-1", SandboxDesiredStateActive, now)
 	source.CurrentPodNamespace = pod.Namespace
 	source.CurrentPodName = pod.Name
 	source.RuntimeGeneration = runtimeGenerationFromPod(pod)
@@ -265,7 +266,7 @@ func TestSandboxRootFSProductSnapshotRunningSandboxCheckpointsWithoutPausingSour
 
 	sourceRecord := store.records["sandbox-1"]
 	require.NotNil(t, sourceRecord)
-	assert.Equal(t, SandboxStatusRunning, sourceRecord.Status)
+	assert.Equal(t, SandboxDesiredStateActive, sourceRecord.DesiredState)
 	assert.Equal(t, pod.Name, sourceRecord.CurrentPodName)
 	assert.Equal(t, pod.Namespace, sourceRecord.CurrentPodNamespace)
 	assert.Equal(t, 0, store.pauses)
@@ -338,7 +339,8 @@ func TestSandboxRootFSProductForkRunningSandboxCheckpointsWithoutPausingSource(t
 
 	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
 	pod.Status.HostIP = ctldURL.Hostname()
-	source := rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusRunning, now)
+	markRuntimeIdentityPodReady(t, pod)
+	source := rootFSProductTestRecord("sandbox-1", "team-1", SandboxDesiredStateActive, now)
 	source.CurrentPodNamespace = pod.Namespace
 	source.CurrentPodName = pod.Name
 	source.RuntimeGeneration = runtimeGenerationFromPod(pod)
@@ -377,7 +379,7 @@ func TestSandboxRootFSProductForkRunningSandboxCheckpointsWithoutPausingSource(t
 
 	sourceRecord := store.records["sandbox-1"]
 	require.NotNil(t, sourceRecord)
-	assert.Equal(t, SandboxStatusRunning, sourceRecord.Status)
+	assert.Equal(t, SandboxDesiredStateActive, sourceRecord.DesiredState)
 	assert.Equal(t, pod.Name, sourceRecord.CurrentPodName)
 	assert.Equal(t, pod.Namespace, sourceRecord.CurrentPodNamespace)
 	assert.Equal(t, 0, store.pauses)
@@ -401,7 +403,7 @@ func TestSandboxRootFSProductWaitAbortsStaleForkTxn(t *testing.T) {
 	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
 	store := &memorySandboxStore{
 		records: map[string]*SandboxRecord{
-			"sandbox-1": rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusRunning, now),
+			"sandbox-1": rootFSProductTestRecord("sandbox-1", "team-1", SandboxDesiredStateActive, now),
 		},
 		lifecycleTxns: map[string]*SandboxLifecycleTxn{
 			"txn-1": {
@@ -429,7 +431,7 @@ func TestSandboxRootFSProductWaitAbortsStaleSnapshotTxn(t *testing.T) {
 	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
 	store := &memorySandboxStore{
 		records: map[string]*SandboxRecord{
-			"sandbox-1": rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusRunning, now),
+			"sandbox-1": rootFSProductTestRecord("sandbox-1", "team-1", SandboxDesiredStateActive, now),
 		},
 		lifecycleTxns: map[string]*SandboxLifecycleTxn{
 			"txn-1": {
@@ -456,7 +458,7 @@ func TestSandboxRootFSProductWaitAbortsStaleSnapshotTxn(t *testing.T) {
 func TestSandboxRootFSProductForkSetsLifecycleExpirations(t *testing.T) {
 	claimedAt := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
 	forkedAt := claimedAt.Add(5 * time.Minute)
-	source := rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusPaused, claimedAt)
+	source := rootFSProductTestRecord("sandbox-1", "team-1", SandboxDesiredStatePaused, claimedAt)
 	source.Config.TTL = int32Ptr(900)
 	source.Config.HardTTL = int32Ptr(1800)
 	source.ExpiresAt = claimedAt.Add(15 * time.Minute)
@@ -492,7 +494,7 @@ func TestSandboxRootFSProductForkSetsLifecycleExpirations(t *testing.T) {
 func TestSandboxRootFSProductForkOverridesLifecycleConfig(t *testing.T) {
 	claimedAt := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
 	forkedAt := claimedAt.Add(5 * time.Minute)
-	source := rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusPaused, claimedAt)
+	source := rootFSProductTestRecord("sandbox-1", "team-1", SandboxDesiredStatePaused, claimedAt)
 	source.Config.TTL = int32Ptr(900)
 	source.Config.HardTTL = int32Ptr(1800)
 	source.ExpiresAt = claimedAt.Add(15 * time.Minute)
@@ -541,7 +543,7 @@ func TestSandboxRootFSProductForkOverridesLifecycleConfig(t *testing.T) {
 func TestSandboxRootFSProductForkCanDisableInheritedLifecycleConfig(t *testing.T) {
 	claimedAt := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
 	forkedAt := claimedAt.Add(5 * time.Minute)
-	source := rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusPaused, claimedAt)
+	source := rootFSProductTestRecord("sandbox-1", "team-1", SandboxDesiredStatePaused, claimedAt)
 	source.Config.TTL = int32Ptr(900)
 	source.Config.HardTTL = int32Ptr(1800)
 	source.ExpiresAt = claimedAt.Add(15 * time.Minute)
@@ -582,7 +584,7 @@ func TestSandboxRootFSProductForkCanDisableInheritedLifecycleConfig(t *testing.T
 
 func TestSandboxRootFSProductForkRejectsInvalidLifecycleConfig(t *testing.T) {
 	now := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
-	source := rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusPaused, now)
+	source := rootFSProductTestRecord("sandbox-1", "team-1", SandboxDesiredStatePaused, now)
 	store := &memorySandboxStore{
 		records: map[string]*SandboxRecord{
 			"sandbox-1": source,
@@ -608,7 +610,7 @@ func TestSandboxRootFSProductForkRejectsInvalidLifecycleConfig(t *testing.T) {
 
 func TestSandboxRootFSProductForkRejectsHardExpiredSource(t *testing.T) {
 	now := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
-	source := rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusPaused, now.Add(-time.Hour))
+	source := rootFSProductTestRecord("sandbox-1", "team-1", SandboxDesiredStatePaused, now.Add(-time.Hour))
 	source.HardExpiresAt = now.Add(-time.Second)
 	store := &memorySandboxStore{
 		records: map[string]*SandboxRecord{
@@ -633,7 +635,7 @@ func TestSandboxRootFSProductRejectsExpiredSnapshotExpiration(t *testing.T) {
 	now := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
 	store := &memorySandboxStore{
 		records: map[string]*SandboxRecord{
-			"sandbox-1": rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusPaused, now),
+			"sandbox-1": rootFSProductTestRecord("sandbox-1", "team-1", SandboxDesiredStatePaused, now),
 		},
 		rootFSStates: map[string]*SandboxRootFSState{
 			"sandbox-1": rootFSProductTestState("sandbox-1", "team-1", "layer-1"),
@@ -655,7 +657,7 @@ func TestSandboxRootFSProductEnforcesTeamOwnership(t *testing.T) {
 	now := time.Now().UTC()
 	store := &memorySandboxStore{
 		records: map[string]*SandboxRecord{
-			"sandbox-1": rootFSProductTestRecord("sandbox-1", "team-1", SandboxStatusPaused, now),
+			"sandbox-1": rootFSProductTestRecord("sandbox-1", "team-1", SandboxDesiredStatePaused, now),
 		},
 		rootFSStates: map[string]*SandboxRootFSState{
 			"sandbox-1": rootFSProductTestState("sandbox-1", "team-1", "layer-1"),
@@ -804,7 +806,7 @@ func rootFSProductTestService(store *memorySandboxStore) *SandboxService {
 	}
 }
 
-func rootFSProductTestRecord(id, teamID, status string, now time.Time) *SandboxRecord {
+func rootFSProductTestRecord(id, teamID, desiredState string, now time.Time) *SandboxRecord {
 	return &SandboxRecord{
 		ID:                id,
 		TeamID:            teamID,
@@ -813,7 +815,7 @@ func rootFSProductTestRecord(id, teamID, status string, now time.Time) *SandboxR
 		TemplateName:      "template-1",
 		TemplateNamespace: "template-default",
 		ClusterID:         "default",
-		Status:            status,
+		DesiredState:      desiredState,
 		TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
 		CreatedAt:         now,
 		UpdatedAt:         now,

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -103,6 +103,7 @@ func TestPauseSandboxRuntimeQueuesRootFSSaveBeforeDeletingPod(t *testing.T) {
 	addRootFSTestVolumePortal(pod, volumeportal.WebhookStatePortalName, volumeportal.WebhookStateMountPath)
 	setRootFSTestClaimMounts(t, pod, []ClaimMount{{SandboxVolumeID: "vol-1", MountPoint: "/workspace/data"}})
 	pod.Annotations[controller.AnnotationWebhookStateVolumeID] = "webhook-state-vol-1"
+	markRuntimeIdentityPodReady(t, pod)
 	pod.Status.HostIP = ctldURL.Hostname()
 	k8sClient := fake.NewSimpleClientset(pod)
 	deleteCalled := false
@@ -121,7 +122,7 @@ func TestPauseSandboxRuntimeQueuesRootFSSaveBeforeDeletingPod(t *testing.T) {
 			ID:                "sandbox-1",
 			TeamID:            "team-1",
 			RuntimeGeneration: 3,
-			Status:            SandboxStatusRunning,
+			DesiredState:      SandboxDesiredStateActive,
 		},
 	}}
 	enqueuer := &recordingPauseEnqueuer{}
@@ -145,7 +146,7 @@ func TestPauseSandboxRuntimeQueuesRootFSSaveBeforeDeletingPod(t *testing.T) {
 	assert.Equal(t, SandboxStatusRunning, resp.Status)
 	assert.False(t, saveCalled, "pause request must not synchronously save rootfs")
 	assert.Equal(t, []string{"sandbox-1"}, enqueuer.calls)
-	assert.Equal(t, SandboxStatusRunning, store.records["sandbox-1"].Status)
+	assert.Equal(t, SandboxDesiredStateActive, store.records["sandbox-1"].DesiredState)
 	require.Len(t, store.lifecycleTxns, 1)
 
 	require.NoError(t, svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"))
@@ -164,7 +165,7 @@ func TestPauseSandboxRuntimeQueuesRootFSSaveBeforeDeletingPod(t *testing.T) {
 	assert.Equal(t, "sha256:diff", state.DiffDigest)
 	assert.Equal(t, "sandbox-rootfs/team-1/sandbox-1/3/sha256/diff.tar", state.DiffObjectKey)
 	assert.NotEmpty(t, state.LayerID)
-	assert.Equal(t, SandboxStatusPaused, store.records["sandbox-1"].Status)
+	assert.Equal(t, SandboxDesiredStatePaused, store.records["sandbox-1"].DesiredState)
 }
 
 func TestPauseSandboxRuntimeSavesChildLayerFromParentHead(t *testing.T) {
@@ -224,7 +225,7 @@ func TestPauseSandboxRuntimeSavesChildLayerFromParentHead(t *testing.T) {
 				ID:                "sandbox-1",
 				TeamID:            "team-1",
 				RuntimeGeneration: 3,
-				Status:            SandboxStatusRunning,
+				DesiredState:      SandboxDesiredStateActive,
 			},
 		},
 		rootFSStates: map[string]*SandboxRootFSState{
@@ -267,7 +268,7 @@ func TestCompletePausingSandboxRuntimeDoesNotCommitStaleCheckpoint(t *testing.T)
 				ID:                "sandbox-1",
 				TeamID:            "team-1",
 				RuntimeGeneration: 3,
-				Status:            SandboxStatusRunning,
+				DesiredState:      SandboxDesiredStateActive,
 			},
 		},
 	}
@@ -336,7 +337,7 @@ func TestCompletePausingSandboxRuntimeDoesNotCommitStaleCheckpoint(t *testing.T)
 	require.NoError(t, svc.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"))
 	assert.False(t, deleteCalled)
 	assert.Nil(t, store.rootFSStates["sandbox-1"])
-	assert.Equal(t, SandboxStatusRunning, store.records["sandbox-1"].Status)
+	assert.Equal(t, SandboxDesiredStateActive, store.records["sandbox-1"].DesiredState)
 	deleter := svc.rootFSObjectDeleter.(*recordingRootFSObjectDeleter)
 	assert.Equal(t, []string{"sandbox-rootfs/team-1/sandbox-1/3/sha256/stale.tar"}, deleter.keys)
 }
@@ -419,7 +420,7 @@ func TestPauseSandboxRuntimeSquashesRootFSWhenChainIsTooDeep(t *testing.T) {
 				ID:                "sandbox-1",
 				TeamID:            "team-1",
 				RuntimeGeneration: 3,
-				Status:            SandboxStatusRunning,
+				DesiredState:      SandboxDesiredStateActive,
 			},
 		},
 		rootFSStates: map[string]*SandboxRootFSState{
@@ -517,7 +518,7 @@ func TestPauseSandboxRuntimeFallsBackToRootLayerWhenBaselineIsMissing(t *testing
 				ID:                "sandbox-1",
 				TeamID:            "team-1",
 				RuntimeGeneration: 3,
-				Status:            SandboxStatusRunning,
+				DesiredState:      SandboxDesiredStateActive,
 			},
 		},
 		rootFSStates: map[string]*SandboxRootFSState{
@@ -558,6 +559,7 @@ func TestPauseSandboxRuntimeFallsBackToRootLayerWhenBaselineIsMissing(t *testing
 
 func TestGetSandboxHidesRuntimeAfterPauseBarrier(t *testing.T) {
 	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
+	markRuntimeIdentityPodReady(t, pod)
 	pod.Status.PodIP = "10.0.0.10"
 	store := &memorySandboxStore{
 		records: map[string]*SandboxRecord{
@@ -569,7 +571,7 @@ func TestGetSandboxHidesRuntimeAfterPauseBarrier(t *testing.T) {
 				CurrentPodName:      "pod-1",
 				CurrentPodNamespace: "default",
 				RuntimeGeneration:   3,
-				Status:              SandboxStatusRunning,
+				DesiredState:        SandboxDesiredStateActive,
 			},
 		},
 	}
@@ -658,7 +660,7 @@ func TestFinishRestoredSandboxRuntimeAppliesRootFSBeforeRuntimeActivation(t *tes
 		TemplateNamespace: "template-default",
 		TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
 		RuntimeGeneration: 3,
-		Status:            SandboxStatusPaused,
+		DesiredState:      SandboxDesiredStatePaused,
 	}
 
 	_, err := svc.finishRestoredSandboxRuntime(context.Background(), pod, record, "hot")
@@ -710,7 +712,7 @@ func TestFinishRestoredSandboxRuntimeAppliesRootFSLayerChain(t *testing.T) {
 		TemplateNamespace: "template-default",
 		TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
 		RuntimeGeneration: 3,
-		Status:            SandboxStatusPaused,
+		DesiredState:      SandboxDesiredStatePaused,
 	}
 
 	_, err := svc.finishRestoredSandboxRuntime(context.Background(), pod, record, "hot")
@@ -776,7 +778,7 @@ func TestFinishRestoredSandboxRuntimeResetsSessionStateCopiedByFork(t *testing.T
 		TemplateName:      "template-1",
 		TemplateNamespace: "template-default",
 		TemplateSpec:      v1alpha1.SandboxTemplateSpec{},
-		Status:            SandboxStatusPaused,
+		DesiredState:      SandboxDesiredStatePaused,
 	}
 
 	_, err := svc.finishRestoredSandboxRuntime(context.Background(), pod, record, "hot")
@@ -904,7 +906,7 @@ func TestFinishRestoredSandboxRuntimeRetriesWithCheckpointBaseImage(t *testing.T
 				TemplateNamespace: templateNamespace,
 				TemplateSpec:      template.Spec,
 				RuntimeGeneration: 3,
-				Status:            SandboxStatusPaused,
+				DesiredState:      SandboxDesiredStatePaused,
 			},
 		},
 		rootFSStates: map[string]*SandboxRootFSState{
@@ -963,7 +965,7 @@ func TestFinishRestoredSandboxRuntimeRetriesWithCheckpointBaseImage(t *testing.T
 	assert.NotEqual(t, "pod-current", applyTargets[1])
 	assert.Equal(t, "docker.io/library/busybox@"+checkpointDigest, fallbackImage)
 	assert.Equal(t, applyTargets[1], store.records["sandbox-1"].CurrentPodName)
-	assert.Equal(t, SandboxStatusRunning, store.records["sandbox-1"].Status)
+	assert.Equal(t, SandboxDesiredStateActive, store.records["sandbox-1"].DesiredState)
 }
 
 func TestCheckpointBaseImageRefPinsDigest(t *testing.T) {
@@ -996,7 +998,7 @@ func TestRestoreFailureCleanupCanSkipRootFSSave(t *testing.T) {
 				ID:                "sandbox-1",
 				TeamID:            "team-1",
 				RuntimeGeneration: 3,
-				Status:            SandboxStatusStarting,
+				DesiredState:      SandboxDesiredStateActive,
 			},
 		},
 		rootFSStates: map[string]*SandboxRootFSState{
@@ -1017,7 +1019,7 @@ func TestRestoreFailureCleanupCanSkipRootFSSave(t *testing.T) {
 
 	assert.False(t, saveCalled.Load())
 	assert.Equal(t, originalState.DiffObjectKey, store.rootFSStates["sandbox-1"].DiffObjectKey)
-	assert.Equal(t, SandboxStatusPaused, store.records["sandbox-1"].Status)
+	assert.Equal(t, SandboxDesiredStatePaused, store.records["sandbox-1"].DesiredState)
 }
 
 func TestRootFSExcludedPathsForPodUsesBoundClaimMountPaths(t *testing.T) {
@@ -1173,7 +1175,7 @@ func addRootFSTestPauseTxn(store *memorySandboxStore, pod *corev1.Pod, phase str
 		FromPodName:      pod.Name,
 	}
 	if record := store.records[sandboxID]; record != nil {
-		record.Status = SandboxStatusRunning
+		record.DesiredState = SandboxDesiredStateActive
 		record.CurrentPodNamespace = pod.Namespace
 		record.CurrentPodName = pod.Name
 		record.RuntimeGeneration = runtimeGenerationFromPod(pod)

--- a/manager/pkg/service/sandbox_service_ttl_test.go
+++ b/manager/pkg/service/sandbox_service_ttl_test.go
@@ -195,7 +195,7 @@ func TestUpdateSandboxPausedRecordIgnoresStaleRuntimePod(t *testing.T) {
 			TemplateID:          "default",
 			TemplateName:        "default",
 			TemplateNamespace:   "tpl-default",
-			Status:              SandboxStatusPaused,
+			DesiredState:        SandboxDesiredStatePaused,
 			Config:              SandboxConfig{TTL: int32Ptr(300)},
 			CurrentPodName:      pod.Name,
 			CurrentPodNamespace: pod.Namespace,
@@ -214,7 +214,7 @@ func TestUpdateSandboxPausedRecordIgnoresStaleRuntimePod(t *testing.T) {
 	record, err := svc.sandboxStore.GetSandbox(context.Background(), "sandbox-1")
 	require.NoError(t, err)
 	require.NotNil(t, record.Config.TTL)
-	assert.Equal(t, SandboxStatusPaused, record.Status)
+	assert.Equal(t, SandboxDesiredStatePaused, record.DesiredState)
 	assert.Equal(t, int32(0), *record.Config.TTL)
 	assert.True(t, record.ExpiresAt.IsZero())
 
@@ -229,8 +229,8 @@ func TestUpdateSandboxPausedRecordIgnoresStaleRuntimePod(t *testing.T) {
 }
 
 func TestPersistUpdatedSandboxPodDoesNotOverwriteDurableLifecycleState(t *testing.T) {
-	for _, status := range []string{SandboxStatusPaused, SandboxStatusTerminating, SandboxStatusDeleted} {
-		t.Run(status, func(t *testing.T) {
+	for _, desiredState := range []string{SandboxDesiredStatePaused, SandboxDesiredStateTerminating, SandboxDesiredStateDeleted} {
+		t.Run(desiredState, func(t *testing.T) {
 			pod := testSandboxPod()
 			pod.Annotations[controller.AnnotationConfig] = `{"ttl":0}`
 
@@ -243,7 +243,7 @@ func TestPersistUpdatedSandboxPodDoesNotOverwriteDurableLifecycleState(t *testin
 					TemplateID:          "default",
 					TemplateName:        "default",
 					TemplateNamespace:   "tpl-default",
-					Status:              status,
+					DesiredState:        desiredState,
 					Config:              SandboxConfig{TTL: int32Ptr(300)},
 					CurrentPodName:      pod.Name,
 					CurrentPodNamespace: pod.Namespace,
@@ -256,7 +256,7 @@ func TestPersistUpdatedSandboxPodDoesNotOverwriteDurableLifecycleState(t *testin
 			record, err := store.GetSandbox(context.Background(), "sandbox-1")
 			require.NoError(t, err)
 			require.NotNil(t, record.Config.TTL)
-			assert.Equal(t, status, record.Status)
+			assert.Equal(t, desiredState, record.DesiredState)
 			assert.Equal(t, int32(300), *record.Config.TTL)
 		})
 	}

--- a/manager/pkg/service/sandbox_store.go
+++ b/manager/pkg/service/sandbox_store.go
@@ -21,10 +21,14 @@ const sandboxStoreSchemaName = "manager"
 var ErrSandboxRecordNotFound = errors.New("sandbox record not found")
 
 const (
-	SandboxStatusDeleted = "deleted"
+	SandboxDesiredStateActive      = "active"
+	SandboxDesiredStatePaused      = "paused"
+	SandboxDesiredStateTerminating = "terminating"
+	SandboxDesiredStateDeleted     = "deleted"
 )
 
-// SandboxRecord is the durable sandbox identity and configuration.
+// SandboxRecord is the durable sandbox identity, desired lifecycle state, and
+// configuration. Kubernetes owns observed runtime readiness and failure state.
 type SandboxRecord struct {
 	ID                   string
 	TeamID               string
@@ -33,7 +37,7 @@ type SandboxRecord struct {
 	TemplateName         string
 	TemplateNamespace    string
 	ClusterID            string
-	Status               string
+	DesiredState         string
 	Config               SandboxConfig
 	Mounts               []ClaimMount
 	TemplateSpec         v1alpha1.SandboxTemplateSpec
@@ -43,6 +47,7 @@ type SandboxRecord struct {
 	LifecycleEpoch       int64
 	WebhookStateVolumeID string
 	OwnerKind            string
+	HotClaimCompletedAt  time.Time
 	ClaimedAt            time.Time
 	ExpiresAt            time.Time
 	HardExpiresAt        time.Time
@@ -164,7 +169,7 @@ type SandboxRuntimeMetadata struct {
 // authoritative for whether the referenced runtime currently exists.
 type SandboxRuntimeReconcileCandidate struct {
 	SandboxID         string
-	Status            string
+	DesiredState      string
 	PodNamespace      string
 	PodName           string
 	RuntimeGeneration int64
@@ -187,7 +192,7 @@ type SandboxStore interface {
 // SandboxStoreTx is a locked sandbox store transaction.
 type SandboxStoreTx interface {
 	SaveSandbox(ctx context.Context, record *SandboxRecord) error
-	SaveRuntime(ctx context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time, metadata SandboxRuntimeMetadata) error
+	SaveRuntime(ctx context.Context, sandboxID, namespace, podName string, generation int64, expiresAt, hardExpiresAt time.Time, metadata SandboxRuntimeMetadata) error
 	MarkRuntimePaused(ctx context.Context, sandboxID string, generation int64, pausedAt time.Time) error
 	MarkRuntimeTerminating(ctx context.Context, sandboxID string) error
 	SaveRootFSState(ctx context.Context, state *SandboxRootFSState) error
@@ -249,12 +254,12 @@ func upsertSandboxRecord(ctx context.Context, exec rootFSStateExecutor, record *
 	_, err = exec.Exec(ctx, `
 		INSERT INTO manager.sandboxes (
 			sandbox_id, team_id, user_id, template_id, template_name, template_namespace,
-			cluster_id, status, config, mounts, template_spec,
+			cluster_id, desired_state, config, mounts, template_spec,
 			current_pod_name, current_pod_namespace, runtime_generation, lifecycle_epoch,
-			webhook_state_volume_id, owner_kind,
+			webhook_state_volume_id, owner_kind, hot_claim_completed_at,
 			claimed_at, expires_at, hard_expires_at, deleted_at, created_at, updated_at
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, COALESCE($22, NOW()), NOW())
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, COALESCE($23, NOW()), NOW())
 		ON CONFLICT (sandbox_id) DO UPDATE SET
 			team_id = EXCLUDED.team_id,
 			user_id = EXCLUDED.user_id,
@@ -262,7 +267,7 @@ func upsertSandboxRecord(ctx context.Context, exec rootFSStateExecutor, record *
 			template_name = EXCLUDED.template_name,
 			template_namespace = EXCLUDED.template_namespace,
 			cluster_id = EXCLUDED.cluster_id,
-			status = EXCLUDED.status,
+			desired_state = EXCLUDED.desired_state,
 			config = EXCLUDED.config,
 			mounts = EXCLUDED.mounts,
 			template_spec = EXCLUDED.template_spec,
@@ -272,19 +277,20 @@ func upsertSandboxRecord(ctx context.Context, exec rootFSStateExecutor, record *
 			lifecycle_epoch = GREATEST(manager.sandboxes.lifecycle_epoch, EXCLUDED.lifecycle_epoch),
 			webhook_state_volume_id = EXCLUDED.webhook_state_volume_id,
 			owner_kind = EXCLUDED.owner_kind,
+			hot_claim_completed_at = COALESCE(EXCLUDED.hot_claim_completed_at, manager.sandboxes.hot_claim_completed_at),
 			claimed_at = EXCLUDED.claimed_at,
 			expires_at = EXCLUDED.expires_at,
 			hard_expires_at = EXCLUDED.hard_expires_at,
 			deleted_at = EXCLUDED.deleted_at,
 			updated_at = NOW()
 		WHERE manager.sandboxes.deleted_at IS NULL
-			AND manager.sandboxes.status NOT IN ($23, $24)
+			AND manager.sandboxes.desired_state NOT IN ($24, $25)
 	`, record.ID, record.TeamID, record.UserID, record.TemplateID, record.TemplateName, record.TemplateNamespace,
-		record.ClusterID, record.Status, configJSON, mountsJSON, specJSON,
+		record.ClusterID, record.DesiredState, configJSON, mountsJSON, specJSON,
 		record.CurrentPodName, record.CurrentPodNamespace, record.RuntimeGeneration, record.LifecycleEpoch,
-		strings.TrimSpace(record.WebhookStateVolumeID), strings.TrimSpace(record.OwnerKind),
+		strings.TrimSpace(record.WebhookStateVolumeID), strings.TrimSpace(record.OwnerKind), nullableTime(record.HotClaimCompletedAt),
 		nullableTime(record.ClaimedAt), nullableTime(record.ExpiresAt), nullableTime(record.HardExpiresAt), nullableTime(record.DeletedAt), nullableTime(record.CreatedAt),
-		SandboxStatusTerminating, SandboxStatusDeleted)
+		SandboxDesiredStateTerminating, SandboxDesiredStateDeleted)
 	if err != nil {
 		return fmt.Errorf("upsert sandbox: %w", err)
 	}
@@ -302,13 +308,14 @@ func (s *PGSandboxStore) ListSandboxes(ctx context.Context, req *ListSandboxesRe
 	if s == nil || s.pool == nil || req == nil {
 		return nil, nil
 	}
+	// Public status is projected from the cached Pod after this query, so only
+	// durable filters belong in SQL.
 	rows, err := s.pool.Query(ctx, sandboxRecordSelectSQL()+`
 		WHERE team_id = $1
 			AND deleted_at IS NULL
-			AND ($2 = '' OR status = $2)
-			AND ($3 = '' OR template_id = $3)
+			AND ($2 = '' OR template_id = $2)
 		ORDER BY created_at DESC
-	`, req.TeamID, req.Status, req.TemplateID)
+	`, req.TeamID, req.TemplateID)
 	if err != nil {
 		return nil, fmt.Errorf("list sandboxes: %w", err)
 	}
@@ -339,8 +346,8 @@ func (s *PGSandboxStore) CountActiveSandboxes(ctx context.Context, teamID string
 		FROM manager.sandboxes
 		WHERE team_id = $1
 			AND deleted_at IS NULL
-			AND status IN ($2, $3)
-	`, strings.TrimSpace(teamID), SandboxStatusStarting, SandboxStatusRunning).Scan(&total); err != nil {
+			AND desired_state = $2
+	`, strings.TrimSpace(teamID), SandboxDesiredStateActive).Scan(&total); err != nil {
 		return 0, fmt.Errorf("count active sandboxes: %w", err)
 	}
 	return total, nil
@@ -398,14 +405,14 @@ func (s *PGSandboxStore) ListPendingRuntimeRecoverySandboxIDs(ctx context.Contex
 			LIMIT 1
 		) latest ON TRUE
 			WHERE s.deleted_at IS NULL
-				AND s.status = $2
+				AND s.desired_state = $2
 				AND latest.kind = $3
 				AND latest.source IN ($4, $5, $6)
 			ORDER BY s.updated_at ASC
 			LIMIT $7
 		`,
 		SandboxLifecyclePhaseCommitted,
-		SandboxStatusPaused,
+		SandboxDesiredStatePaused,
 		SandboxLifecycleKindPause,
 		SandboxLifecycleSourceCrash,
 		SandboxLifecycleSourceHealth,
@@ -442,24 +449,24 @@ func (s *PGSandboxStore) ListRuntimeReconcileCandidates(ctx context.Context, clu
 		limit = 500
 	}
 	rows, err := s.pool.Query(ctx, `
-		SELECT sandbox_id, status, current_pod_namespace, current_pod_name, runtime_generation
+		SELECT sandbox_id, desired_state, current_pod_namespace, current_pod_name, runtime_generation
 		FROM manager.sandboxes
 		WHERE deleted_at IS NULL
 			AND (
-				status IN ($1, $2, $3, $4)
+				desired_state IN ($1, $2)
 				OR EXISTS (
 					SELECT 1
 					FROM manager.sandbox_lifecycle_txns txn
 					WHERE txn.sandbox_id = manager.sandboxes.sandbox_id
-						AND txn.kind = $5
+						AND txn.kind = $3
 						AND txn.phase IN ('preparing', 'barriered', 'publishing', 'committing')
 				)
 			)
-			AND cluster_id = $6
-			AND sandbox_id > $7
+			AND cluster_id = $4
+			AND sandbox_id > $5
 		ORDER BY sandbox_id ASC
-		LIMIT $8
-	`, SandboxStatusStarting, SandboxStatusRunning, SandboxStatusFailed, SandboxStatusTerminating, SandboxLifecycleKindResume, strings.TrimSpace(clusterID), strings.TrimSpace(afterSandboxID), limit)
+		LIMIT $6
+	`, SandboxDesiredStateActive, SandboxDesiredStateTerminating, SandboxLifecycleKindResume, strings.TrimSpace(clusterID), strings.TrimSpace(afterSandboxID), limit)
 	if err != nil {
 		return nil, fmt.Errorf("list sandbox runtime reconcile candidates: %w", err)
 	}
@@ -469,7 +476,7 @@ func (s *PGSandboxStore) ListRuntimeReconcileCandidates(ctx context.Context, clu
 		var candidate SandboxRuntimeReconcileCandidate
 		if err := rows.Scan(
 			&candidate.SandboxID,
-			&candidate.Status,
+			&candidate.DesiredState,
 			&candidate.PodNamespace,
 			&candidate.PodName,
 			&candidate.RuntimeGeneration,
@@ -540,13 +547,13 @@ func (s *PGSandboxStore) MarkSandboxDeleted(ctx context.Context, sandboxID strin
 	defer func() { _ = tx.Rollback(ctx) }()
 	if _, err := tx.Exec(ctx, `
 		UPDATE manager.sandboxes
-		SET status = $2,
+		SET desired_state = $2,
 			current_pod_name = '',
 			current_pod_namespace = '',
 			deleted_at = $3,
 			updated_at = NOW()
 		WHERE sandbox_id = $1
-	`, sandboxID, SandboxStatusDeleted, deletedAt); err != nil {
+	`, sandboxID, SandboxDesiredStateDeleted, deletedAt); err != nil {
 		return fmt.Errorf("mark sandbox deleted: %w", err)
 	}
 	if _, err := tx.Exec(ctx, `
@@ -705,10 +712,10 @@ func (t sandboxStoreTx) SaveSandbox(ctx context.Context, record *SandboxRecord) 
 	return upsertSandboxRecord(ctx, t.tx, record)
 }
 
-func (t sandboxStoreTx) SaveRuntime(ctx context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time, metadata SandboxRuntimeMetadata) error {
+func (t sandboxStoreTx) SaveRuntime(ctx context.Context, sandboxID, namespace, podName string, generation int64, expiresAt, hardExpiresAt time.Time, metadata SandboxRuntimeMetadata) error {
 	tag, err := t.tx.Exec(ctx, `
 		UPDATE manager.sandboxes
-		SET status = $2,
+		SET desired_state = $2,
 			current_pod_namespace = $3,
 			current_pod_name = $4,
 			runtime_generation = $5,
@@ -720,8 +727,8 @@ func (t sandboxStoreTx) SaveRuntime(ctx context.Context, sandboxID, namespace, p
 			updated_at = NOW()
 		WHERE sandbox_id = $1
 			AND deleted_at IS NULL
-			AND status NOT IN ($10, $11)
-	`, sandboxID, status, namespace, podName, generation, nullableTime(expiresAt), nullableTime(hardExpiresAt), strings.TrimSpace(metadata.WebhookStateVolumeID), strings.TrimSpace(metadata.OwnerKind), SandboxStatusTerminating, SandboxStatusDeleted)
+			AND desired_state NOT IN ($10, $11)
+	`, sandboxID, SandboxDesiredStateActive, namespace, podName, generation, nullableTime(expiresAt), nullableTime(hardExpiresAt), strings.TrimSpace(metadata.WebhookStateVolumeID), strings.TrimSpace(metadata.OwnerKind), SandboxDesiredStateTerminating, SandboxDesiredStateDeleted)
 	if err != nil {
 		return fmt.Errorf("save sandbox runtime: %w", err)
 	}
@@ -734,7 +741,7 @@ func (t sandboxStoreTx) SaveRuntime(ctx context.Context, sandboxID, namespace, p
 func (t sandboxStoreTx) MarkRuntimePaused(ctx context.Context, sandboxID string, generation int64, pausedAt time.Time) error {
 	tag, err := t.tx.Exec(ctx, `
 		UPDATE manager.sandboxes
-		SET status = $2,
+		SET desired_state = $2,
 			current_pod_namespace = '',
 			current_pod_name = '',
 			runtime_generation = GREATEST(runtime_generation, $3),
@@ -742,8 +749,8 @@ func (t sandboxStoreTx) MarkRuntimePaused(ctx context.Context, sandboxID string,
 			updated_at = NOW()
 		WHERE sandbox_id = $1
 			AND deleted_at IS NULL
-			AND status NOT IN ($4, $5)
-	`, sandboxID, SandboxStatusPaused, generation, SandboxStatusTerminating, SandboxStatusDeleted)
+			AND desired_state NOT IN ($4, $5)
+	`, sandboxID, SandboxDesiredStatePaused, generation, SandboxDesiredStateTerminating, SandboxDesiredStateDeleted)
 	if err != nil {
 		return fmt.Errorf("mark sandbox runtime paused: %w", err)
 	}
@@ -756,11 +763,11 @@ func (t sandboxStoreTx) MarkRuntimePaused(ctx context.Context, sandboxID string,
 func (t sandboxStoreTx) MarkRuntimeTerminating(ctx context.Context, sandboxID string) error {
 	tag, err := t.tx.Exec(ctx, `
 		UPDATE manager.sandboxes
-		SET status = $2,
+		SET desired_state = $2,
 			updated_at = NOW()
 		WHERE sandbox_id = $1
 			AND deleted_at IS NULL
-	`, sandboxID, SandboxStatusTerminating)
+	`, sandboxID, SandboxDesiredStateTerminating)
 	if err != nil {
 		return fmt.Errorf("mark sandbox runtime terminating: %w", err)
 	}
@@ -986,9 +993,9 @@ func (t sandboxStoreTx) UpsertSandbox(ctx context.Context, record *SandboxRecord
 func sandboxRecordSelectSQL() string {
 	return `
 		SELECT sandbox_id, team_id, user_id, template_id, template_name, template_namespace,
-			cluster_id, status, config, mounts, template_spec,
+			cluster_id, desired_state, config, mounts, template_spec,
 			current_pod_name, current_pod_namespace, runtime_generation, lifecycle_epoch,
-			webhook_state_volume_id, owner_kind,
+			webhook_state_volume_id, owner_kind, hot_claim_completed_at,
 			claimed_at, expires_at, hard_expires_at, deleted_at, created_at, updated_at
 		FROM manager.sandboxes`
 }
@@ -1374,12 +1381,12 @@ func scanSandboxRecordRows(rows pgx.Rows) (*SandboxRecord, error) {
 func scanSandboxRecordInto(scanner sandboxRecordScanner) (*SandboxRecord, error) {
 	var record SandboxRecord
 	var configJSON, mountsJSON, specJSON []byte
-	var claimedAt, expiresAt, hardExpiresAt, deletedAt *time.Time
+	var hotClaimCompletedAt, claimedAt, expiresAt, hardExpiresAt, deletedAt *time.Time
 	if err := scanner.Scan(
 		&record.ID, &record.TeamID, &record.UserID, &record.TemplateID, &record.TemplateName, &record.TemplateNamespace,
-		&record.ClusterID, &record.Status, &configJSON, &mountsJSON, &specJSON,
+		&record.ClusterID, &record.DesiredState, &configJSON, &mountsJSON, &specJSON,
 		&record.CurrentPodName, &record.CurrentPodNamespace, &record.RuntimeGeneration, &record.LifecycleEpoch,
-		&record.WebhookStateVolumeID, &record.OwnerKind,
+		&record.WebhookStateVolumeID, &record.OwnerKind, &hotClaimCompletedAt,
 		&claimedAt, &expiresAt, &hardExpiresAt, &deletedAt, &record.CreatedAt, &record.UpdatedAt,
 	); err != nil {
 		return nil, err
@@ -1394,6 +1401,7 @@ func scanSandboxRecordInto(scanner sandboxRecordScanner) (*SandboxRecord, error)
 		return nil, fmt.Errorf("unmarshal sandbox template spec: %w", err)
 	}
 	record.ClaimedAt = derefTime(claimedAt)
+	record.HotClaimCompletedAt = derefTime(hotClaimCompletedAt)
 	record.ExpiresAt = derefTime(expiresAt)
 	record.HardExpiresAt = derefTime(hardExpiresAt)
 	record.DeletedAt = derefTime(deletedAt)

--- a/manager/pkg/service/sandbox_system_volume_reconciler.go
+++ b/manager/pkg/service/sandbox_system_volume_reconciler.go
@@ -134,5 +134,5 @@ func (s *SandboxService) systemVolumeOwnerSandboxExists(ctx context.Context, san
 	if err != nil {
 		return false, err
 	}
-	return record != nil && record.Status != SandboxStatusDeleted && record.DeletedAt.IsZero(), nil
+	return record != nil && record.DesiredState != SandboxDesiredStateDeleted && record.DeletedAt.IsZero(), nil
 }

--- a/manager/pkg/service/template_build_capture_test.go
+++ b/manager/pkg/service/template_build_capture_test.go
@@ -21,9 +21,9 @@ func TestEnsureTemplateBuildCaptureReadsPinnedHeadAfterSourceAdvances(t *testing
 	base := &memorySandboxStore{
 		records: map[string]*SandboxRecord{
 			"sandbox-1": {
-				ID:     "sandbox-1",
-				TeamID: "team-1",
-				Status: SandboxStatusPaused,
+				ID:           "sandbox-1",
+				TeamID:       "team-1",
+				DesiredState: SandboxDesiredStatePaused,
 			},
 		},
 		rootFSSnapshots: map[string]*RootFSSnapshot{
@@ -161,9 +161,9 @@ func TestEnsureTemplateBuildCaptureRejectsMixedRootFSChain(t *testing.T) {
 				memorySandboxStore: &memorySandboxStore{
 					records: map[string]*SandboxRecord{
 						"sandbox-1": {
-							ID:     "sandbox-1",
-							TeamID: "team-1",
-							Status: SandboxStatusPaused,
+							ID:           "sandbox-1",
+							TeamID:       "team-1",
+							DesiredState: SandboxDesiredStatePaused,
 						},
 					},
 					rootFSSnapshots: map[string]*RootFSSnapshot{

--- a/manager/pkg/service/template_source.go
+++ b/manager/pkg/service/template_source.go
@@ -41,6 +41,9 @@ func (s *SandboxService) ResolveSandboxTemplateSource(ctx context.Context, sandb
 			return nil, fmt.Errorf("%w: %v", template.ErrTemplateSourceNotReady, err)
 		}
 	}
+	if _, err := s.resolveRootFSSourceRuntimePod(ctx, record); err != nil {
+		return nil, fmt.Errorf("%w: %v", template.ErrTemplateSourceNotReady, err)
+	}
 	return &template.SandboxTemplateSource{
 		SandboxID:  record.ID,
 		TeamID:     record.TeamID,

--- a/manager/pkg/service/template_source_test.go
+++ b/manager/pkg/service/template_source_test.go
@@ -4,25 +4,29 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/pkg/template"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestResolveSandboxTemplateSourceUsesDurableClaimSpec(t *testing.T) {
 	record := &SandboxRecord{
-		ID:         "sandbox-1",
-		TeamID:     "team-1",
-		UserID:     "user-1",
-		TemplateID: "base",
-		ClusterID:  "cluster-a",
-		Status:     SandboxStatusRunning,
+		ID:           "sandbox-1",
+		TeamID:       "team-1",
+		UserID:       "user-1",
+		TemplateID:   "base",
+		ClusterID:    "cluster-a",
+		DesiredState: SandboxDesiredStateActive,
 		TemplateSpec: v1alpha1.SandboxTemplateSpec{
 			MainContainer: v1alpha1.ContainerSpec{Image: "ubuntu:22.04"},
 		},
 	}
 	store := &memorySandboxStore{records: map[string]*SandboxRecord{record.ID: record}}
-	service := &SandboxService{sandboxStore: store}
+	pod := createTestPod(record.ID, record.TeamID, record.TemplateID, controller.PoolTypeActive, time.Now().Add(-time.Minute), time.Now().Add(time.Hour), false)
+	service := &SandboxService{sandboxStore: store, podLister: newTestPodLister(t, pod)}
 
 	source, err := service.ResolveSandboxTemplateSource(context.Background(), record.ID, record.TeamID)
 	if err != nil {
@@ -37,6 +41,41 @@ func TestResolveSandboxTemplateSourceUsesDurableClaimSpec(t *testing.T) {
 	source.Spec.MainContainer.Image = "changed"
 	if record.TemplateSpec.MainContainer.Image != "ubuntu:22.04" {
 		t.Fatal("resolved source spec must be a deep copy")
+	}
+}
+
+func TestResolveSandboxTemplateSourceRejectsActiveSourceWithoutRunningRuntime(t *testing.T) {
+	record := &SandboxRecord{
+		ID:           "sandbox-1",
+		TeamID:       "team-1",
+		DesiredState: SandboxDesiredStateActive,
+		TemplateSpec: v1alpha1.SandboxTemplateSpec{},
+	}
+	now := time.Now()
+	tests := []struct {
+		name string
+		pods []*corev1.Pod
+	}{
+		{name: "missing"},
+		{
+			name: "failed",
+			pods: []*corev1.Pod{
+				createTestPodWithPhase(record.ID, record.TeamID, "base", controller.PoolTypeActive, now.Add(-time.Minute), now.Add(time.Hour), false, corev1.PodFailed),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &memorySandboxStore{records: map[string]*SandboxRecord{record.ID: record}}
+			service := &SandboxService{sandboxStore: store, podLister: newTestPodLister(t, tt.pods...)}
+
+			_, err := service.ResolveSandboxTemplateSource(context.Background(), record.ID, record.TeamID)
+
+			if !errors.Is(err, template.ErrTemplateSourceNotReady) {
+				t.Fatalf("ResolveSandboxTemplateSource() error = %v, want %v", err, template.ErrTemplateSourceNotReady)
+			}
+		})
 	}
 }
 
@@ -64,9 +103,9 @@ func TestResolveSandboxTemplateSourceRejectsCrossTeamAndNonCaptureableState(t *t
 		{
 			name: "cross team",
 			record: &SandboxRecord{
-				ID:     "sandbox-1",
-				TeamID: "team-1",
-				Status: SandboxStatusRunning,
+				ID:           "sandbox-1",
+				TeamID:       "team-1",
+				DesiredState: SandboxDesiredStateActive,
 			},
 			teamID:      "team-2",
 			targetError: template.ErrTemplateSourceForbidden,
@@ -74,9 +113,9 @@ func TestResolveSandboxTemplateSourceRejectsCrossTeamAndNonCaptureableState(t *t
 		{
 			name: "deleted",
 			record: &SandboxRecord{
-				ID:     "sandbox-1",
-				TeamID: "team-1",
-				Status: SandboxStatusDeleted,
+				ID:           "sandbox-1",
+				TeamID:       "team-1",
+				DesiredState: SandboxDesiredStateDeleted,
 			},
 			teamID:      "team-1",
 			targetError: template.ErrTemplateSourceNotFound,
@@ -84,9 +123,9 @@ func TestResolveSandboxTemplateSourceRejectsCrossTeamAndNonCaptureableState(t *t
 		{
 			name: "transitional",
 			record: &SandboxRecord{
-				ID:     "sandbox-1",
-				TeamID: "team-1",
-				Status: "pausing",
+				ID:           "sandbox-1",
+				TeamID:       "team-1",
+				DesiredState: SandboxDesiredStateTerminating,
 			},
 			teamID:      "team-1",
 			targetError: template.ErrTemplateSourceNotReady,

--- a/tests/integration/internal/tests/manager/api_test.go
+++ b/tests/integration/internal/tests/manager/api_test.go
@@ -455,7 +455,7 @@ func TestPausedSandboxRuntimeResumeAppliesRootFSCheckpointBeforeRuntimeActivatio
 		TemplateName:      template.Name,
 		TemplateNamespace: template.Namespace,
 		ClusterID:         "default",
-		Status:            service.SandboxStatusPaused,
+		DesiredState:      service.SandboxDesiredStatePaused,
 		TemplateSpec:      template.Spec,
 		RuntimeGeneration: 3,
 		ClaimedAt:         now,
@@ -531,7 +531,7 @@ func TestPausedSandboxRuntimeResumeAppliesRootFSCheckpointBeforeRuntimeActivatio
 	if err != nil {
 		t.Fatalf("get restored sandbox record: %v", err)
 	}
-	if record.Status != service.SandboxStatusRunning || record.CurrentPodName != "idle-rootfs" || record.RuntimeGeneration != 4 {
+	if record.DesiredState != service.SandboxDesiredStateActive || record.CurrentPodName != "idle-rootfs" || record.RuntimeGeneration != 4 {
 		t.Fatalf("restored record = %+v", record)
 	}
 }
@@ -546,7 +546,7 @@ func TestSandboxRootFSProductAPI(t *testing.T) {
 		TemplateName:      "template-1",
 		TemplateNamespace: "template-default",
 		ClusterID:         "default",
-		Status:            service.SandboxStatusPaused,
+		DesiredState:      service.SandboxDesiredStatePaused,
 		CreatedAt:         now,
 		UpdatedAt:         now,
 	}, &service.SandboxRootFSState{
@@ -685,7 +685,7 @@ func TestSandboxRootFSProductAPI(t *testing.T) {
 	}
 
 	store.mu.Lock()
-	store.records["sandbox-1"].Status = service.SandboxStatusRunning
+	store.records["sandbox-1"].DesiredState = service.SandboxDesiredStateActive
 	store.mu.Unlock()
 	resp, body = doRequest(t, env.server.Client(), http.MethodPost, env.server.URL+"/api/v1/sandboxes/sandbox-1/snapshots", env.token, nil)
 	if resp.StatusCode != http.StatusServiceUnavailable {
@@ -970,10 +970,14 @@ func (s *memorySandboxStoreForManagerIntegration) UpsertSandbox(_ context.Contex
 		return nil
 	}
 	if existing := s.records[record.ID]; existing != nil &&
-		(existing.Status == service.SandboxStatusTerminating || existing.Status == service.SandboxStatusDeleted || !existing.DeletedAt.IsZero()) {
+		(existing.DesiredState == service.SandboxDesiredStateTerminating || existing.DesiredState == service.SandboxDesiredStateDeleted || !existing.DeletedAt.IsZero()) {
 		return nil
 	}
-	s.records[record.ID] = cloneSandboxRecordForManagerIntegration(record)
+	clone := cloneSandboxRecordForManagerIntegration(record)
+	if existing := s.records[record.ID]; existing != nil && clone.HotClaimCompletedAt.IsZero() {
+		clone.HotClaimCompletedAt = existing.HotClaimCompletedAt
+	}
+	s.records[record.ID] = clone
 	return nil
 }
 
@@ -1053,7 +1057,7 @@ func (s *memorySandboxStoreForManagerIntegration) MarkSandboxDeleted(_ context.C
 	if record == nil {
 		return service.ErrSandboxRecordNotFound
 	}
-	record.Status = service.SandboxStatusDeleted
+	record.DesiredState = service.SandboxDesiredStateDeleted
 	record.DeletedAt = deletedAt
 	for _, txn := range s.lifecycleTxns {
 		if txn != nil && txn.SandboxID == sandboxID && managerIntegrationLifecyclePhaseActive(txn.Phase) {
@@ -1240,14 +1244,14 @@ func (t memorySandboxStoreTxForManagerIntegration) SaveSandbox(ctx context.Conte
 	return t.store.UpsertSandbox(ctx, record)
 }
 
-func (t memorySandboxStoreTxForManagerIntegration) SaveRuntime(_ context.Context, sandboxID, namespace, podName, status string, generation int64, expiresAt, hardExpiresAt time.Time, metadata service.SandboxRuntimeMetadata) error {
+func (t memorySandboxStoreTxForManagerIntegration) SaveRuntime(_ context.Context, sandboxID, namespace, podName string, generation int64, expiresAt, hardExpiresAt time.Time, metadata service.SandboxRuntimeMetadata) error {
 	record := t.store.records[sandboxID]
-	if record == nil || record.Status == service.SandboxStatusTerminating || record.Status == service.SandboxStatusDeleted || !record.DeletedAt.IsZero() {
+	if record == nil || record.DesiredState == service.SandboxDesiredStateTerminating || record.DesiredState == service.SandboxDesiredStateDeleted || !record.DeletedAt.IsZero() {
 		return service.ErrSandboxRecordNotFound
 	}
 	record.CurrentPodNamespace = namespace
 	record.CurrentPodName = podName
-	record.Status = status
+	record.DesiredState = service.SandboxDesiredStateActive
 	record.RuntimeGeneration = generation
 	record.ExpiresAt = expiresAt
 	record.HardExpiresAt = hardExpiresAt
@@ -1262,12 +1266,12 @@ func (t memorySandboxStoreTxForManagerIntegration) SaveRuntime(_ context.Context
 
 func (t memorySandboxStoreTxForManagerIntegration) MarkRuntimePaused(_ context.Context, sandboxID string, generation int64, _ time.Time) error {
 	record := t.store.records[sandboxID]
-	if record == nil || record.Status == service.SandboxStatusTerminating || record.Status == service.SandboxStatusDeleted || !record.DeletedAt.IsZero() {
+	if record == nil || record.DesiredState == service.SandboxDesiredStateTerminating || record.DesiredState == service.SandboxDesiredStateDeleted || !record.DeletedAt.IsZero() {
 		return service.ErrSandboxRecordNotFound
 	}
 	record.CurrentPodNamespace = ""
 	record.CurrentPodName = ""
-	record.Status = service.SandboxStatusPaused
+	record.DesiredState = service.SandboxDesiredStatePaused
 	if record.RuntimeGeneration < generation {
 		record.RuntimeGeneration = generation
 	}
@@ -1280,7 +1284,7 @@ func (t memorySandboxStoreTxForManagerIntegration) MarkRuntimeTerminating(_ cont
 	if record == nil || !record.DeletedAt.IsZero() {
 		return service.ErrSandboxRecordNotFound
 	}
-	record.Status = service.SandboxStatusTerminating
+	record.DesiredState = service.SandboxDesiredStateTerminating
 	return nil
 }
 
@@ -1389,27 +1393,27 @@ func (t memorySandboxStoreTxForManagerIntegration) AbortLifecycleTxn(_ context.C
 func TestMemorySandboxStoreTxForManagerIntegrationFencesTerminatingRuntime(t *testing.T) {
 	const sandboxID = "sandbox-terminating"
 	store := newMemorySandboxStoreForManagerIntegration(&service.SandboxRecord{
-		ID:     sandboxID,
-		Status: service.SandboxStatusRunning,
+		ID:           sandboxID,
+		DesiredState: service.SandboxDesiredStateActive,
 	}, nil)
 	tx := memorySandboxStoreTxForManagerIntegration{store: store}
 
 	if err := tx.MarkRuntimeTerminating(t.Context(), sandboxID); err != nil {
 		t.Fatalf("mark runtime terminating: %v", err)
 	}
-	if got := store.records[sandboxID].Status; got != service.SandboxStatusTerminating {
-		t.Fatalf("expected terminating status, got %q", got)
+	if got := store.records[sandboxID].DesiredState; got != service.SandboxDesiredStateTerminating {
+		t.Fatalf("expected terminating desired state, got %q", got)
 	}
 	if err := tx.MarkRuntimePaused(t.Context(), sandboxID, 2, time.Now()); !stderrors.Is(err, service.ErrSandboxRecordNotFound) {
 		t.Fatalf("expected paused write to be fenced, got %v", err)
 	}
-	if err := tx.SaveRuntime(t.Context(), sandboxID, "default", "replacement", service.SandboxStatusRunning, 2, time.Time{}, time.Time{}, service.SandboxRuntimeMetadata{}); !stderrors.Is(err, service.ErrSandboxRecordNotFound) {
+	if err := tx.SaveRuntime(t.Context(), sandboxID, "default", "replacement", 2, time.Time{}, time.Time{}, service.SandboxRuntimeMetadata{}); !stderrors.Is(err, service.ErrSandboxRecordNotFound) {
 		t.Fatalf("expected runtime write to be fenced, got %v", err)
 	}
-	if err := tx.SaveSandbox(t.Context(), &service.SandboxRecord{ID: sandboxID, Status: service.SandboxStatusRunning}); err != nil {
+	if err := tx.SaveSandbox(t.Context(), &service.SandboxRecord{ID: sandboxID, DesiredState: service.SandboxDesiredStateActive}); err != nil {
 		t.Fatalf("save stale sandbox projection: %v", err)
 	}
-	if got := store.records[sandboxID].Status; got != service.SandboxStatusTerminating {
+	if got := store.records[sandboxID].DesiredState; got != service.SandboxDesiredStateTerminating {
 		t.Fatalf("expected stale sandbox projection to remain fenced, got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

- replace PostgreSQL's mixed observed `status` column with durable `desired_state` values: `active`, `paused`, `terminating`, and `deleted`
- project caller-visible `starting`, `running`, and `failed` from the shared Kubernetes Pod informer cache
- keep runtime identity and lifecycle reconciliation as anti-entropy, using cached Pod lookups to prefilter and strong API reads only for suspected drift
- avoid per-sandbox lifecycle transaction queries in list projection, since summaries do not expose runtime connectivity
- give hot-claim completion its own durable workflow timestamp instead of overloading observed `running`
- migrate existing rows in place, update lifecycle/rootfs/quota paths, and document the status ownership model

This is a follow-up to #815 and #820. It removes the remaining duplicated Pod readiness state that could become stale even when runtime identity reconciliation was correct.

## State ownership

| State | Owner |
| --- | --- |
| desired lifecycle intent and deletion | PostgreSQL |
| lifecycle transactions and runtime identity fence | PostgreSQL |
| runtime readiness/failure and current Pod phase | Kubernetes informer cache |
| suspected desired/runtime drift | periodic reconcile, cache-prefiltered |

Normal get/list/status and rootfs/template-source readiness checks do not call the Kubernetes API. They use `corelisters.PodLister`. The reconciler still performs a strong Kubernetes read after the cache indicates a missing or mismatched runtime, because absence must be confirmed before repair.

## Data migration

Migration 00011:

- maps legacy `starting`, `running`, and `failed` rows to desired `active`
- preserves `paused` and `terminating`
- maps deleted rows to `deleted` and repairs a missing `deleted_at` from `updated_at`
- renames `status` to `desired_state`, adds an allowed-value constraint, and replaces the team/status index
- adds `hot_claim_completed_at` without inferring completion from old observed status

There is intentionally no runtime compatibility path for the old schema or the old `record-status-v1` hot-claim protocol.

## Rollout

This is a non-rolling, per-region schema cutover. Every data-plane cluster in one region shares that region's PostgreSQL, so all old manager writers for the region must be coordinated.

1. Stop new claims and lifecycle writes for the region.
2. Across every cluster in the region, wait for or clean up all hot-claim reservations still in `initializing` with the old `record-status-v1` protocol.
3. Take a database backup and record the current desired/observed distribution across all teams, not only one account.
4. Scale every old manager deployment sharing the region database to zero.
5. Start one new manager instance (or a dedicated migration invocation) and let migration 00011 complete.
6. Verify migrated desired-state counts, invalid-state count = 0, cached Pod projections, paused sandboxes, and active runtime bindings across all teams/clusters.
7. Deploy the new manager version to the remaining clusters, restore replica counts, then reopen traffic.

Repeat independently for each region. New node capacity may continue to appear, but sandbox-producing manager writes must remain frozen during the cutover.

Rollback requires restoring the pre-cutover database backup before starting the old manager. The SQL down migration necessarily collapses all desired `active` rows to legacy `running`, so it is not a fidelity-preserving rollback by itself.

## Validation

- `make test manager`
- `go test ./tests/integration/internal/tests/manager`
- migration test against a temporary PostgreSQL 15 instance, including v10 -> v11 repair and constraint checks
- `go vet ./manager/pkg/service ./tests/integration/internal/tests/manager`
- `GOFLAGS=-buildvcs=false golangci-lint run ./...` with v2.5.0
- `make proto manifests apispec`
- `go mod tidy`
- repository-wide gofmt and diff checks
