### PR TITLE
fix(manager): complete resumed hot claims atomically

### DIFF
--- a/manager/pkg/service/hot_claim_reservation_controller_test.go
+++ b/manager/pkg/service/hot_claim_reservation_controller_test.go
@@ -109,6 +109,81 @@ func TestHotClaimReservationControllerFinalizesRecordCompletedClaim(t *testing.T
 	}
 }
 
+func TestCommittedHotClaimResumeSurvivesReservationRecoveryGrace(t *testing.T) {
+	now := time.Date(2026, time.July, 26, 12, 0, 0, 0, time.UTC)
+	pod := newHotClaimReservationTestPod(
+		now.Add(-hotClaimReservationRecoveryGracePeriod-time.Second),
+		controller.HotClaimReservationStateInitializing,
+	)
+	pod.Annotations[controller.AnnotationHotClaimCompletionProtocol] = controller.HotClaimCompletionProtocolRecordV2
+	pod.Annotations[controller.AnnotationRuntimeGeneration] = "2"
+	record := hotClaimReservationTestRecord(pod)
+	record.DesiredState = SandboxDesiredStatePaused
+	record.CurrentPodName = ""
+	record.CurrentPodNamespace = ""
+	record.RuntimeGeneration = 1
+	txn := &SandboxLifecycleTxn{
+		ID:             "resume-txn-sandbox-a",
+		SandboxID:      record.ID,
+		Kind:           SandboxLifecycleKindResume,
+		Phase:          SandboxLifecyclePhasePreparing,
+		FromGeneration: 1,
+		ToGeneration:   2,
+		ToPodNamespace: pod.Namespace,
+		ToPodName:      pod.Name,
+	}
+	store := &memorySandboxStore{
+		records:       map[string]*SandboxRecord{record.ID: record},
+		lifecycleTxns: map[string]*SandboxLifecycleTxn{txn.ID: txn},
+	}
+	service := &SandboxService{
+		sandboxStore: store,
+		clock:        fixedClock{now: now},
+	}
+
+	if err := service.commitResumedSandboxRuntime(context.Background(), pod, record, txn); err != nil {
+		t.Fatalf("commitResumedSandboxRuntime() error = %v", err)
+	}
+	gotRecord, err := store.GetSandbox(context.Background(), record.ID)
+	if err != nil {
+		t.Fatalf("GetSandbox() error = %v", err)
+	}
+	if gotRecord.DesiredState != SandboxDesiredStateActive ||
+		gotRecord.CurrentPodNamespace != pod.Namespace ||
+		gotRecord.CurrentPodName != pod.Name ||
+		gotRecord.RuntimeGeneration != 2 ||
+		!gotRecord.HotClaimCompletedAt.Equal(now) {
+		t.Fatalf("sandbox record = %#v, want committed hot resume with completion marker", gotRecord)
+	}
+	if gotTxn := store.lifecycleTxns[txn.ID]; gotTxn == nil || gotTxn.Phase != SandboxLifecyclePhaseCommitted {
+		t.Fatalf("lifecycle transaction = %#v, want committed", gotTxn)
+	}
+
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	reconciler := NewHotClaimReservationController(client, newClaimTestPodLister(t, pod), store, nil)
+	reconciler.clock = fixedClock{now: now}
+	reconciler.settleWindow = 0
+	reconciler.detachPacer = &recordingHotClaimDetachmentPacer{}
+
+	if _, err := reconciler.reconcile(context.Background(), pod.Namespace+"/"+pod.Name); err != nil {
+		t.Fatalf("reconcile() error = %v", err)
+	}
+	gotPod, err := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get finalized pod: %v", err)
+	}
+	if gotPod.Labels[controller.LabelPoolType] != controller.PoolTypeActive || controller.IsHotClaimReservedPod(gotPod) {
+		t.Fatalf("finalized pod = %#v, want active without a hot claim reservation", gotPod)
+	}
+	gotRecord, err = store.GetSandbox(context.Background(), record.ID)
+	if err != nil {
+		t.Fatalf("GetSandbox() after reconcile error = %v", err)
+	}
+	if gotRecord.DesiredState != SandboxDesiredStateActive || !gotRecord.DeletedAt.IsZero() {
+		t.Fatalf("sandbox record after recovery grace = %#v, want active and not deleted", gotRecord)
+	}
+}
+
 func TestHotClaimReservationControllerDoesNotCompleteUnsafeInitializingClaim(t *testing.T) {
 	now := time.Date(2026, time.July, 26, 12, 0, 0, 0, time.UTC)
 	tests := []struct {

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -323,6 +323,17 @@ func (t memorySandboxStoreTx) SaveRuntime(_ context.Context, sandboxID, namespac
 	return nil
 }
 
+func (t memorySandboxStoreTx) MarkHotClaimCompleted(_ context.Context, sandboxID string, completedAt time.Time) error {
+	t.store.mu.Lock()
+	defer t.store.mu.Unlock()
+	record := t.store.records[sandboxID]
+	if record == nil || record.DesiredState == SandboxDesiredStateTerminating || record.DesiredState == SandboxDesiredStateDeleted || !record.DeletedAt.IsZero() {
+		return ErrSandboxRecordNotFound
+	}
+	record.HotClaimCompletedAt = completedAt
+	return nil
+}
+
 func (t memorySandboxStoreTx) MarkRuntimePaused(_ context.Context, sandboxID string, generation int64, _ time.Time) error {
 	t.store.mu.Lock()
 	defer t.store.mu.Unlock()

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -343,6 +343,11 @@ func (s *SandboxService) commitResumedSandboxRuntime(ctx context.Context, pod *c
 		if err := tx.SaveRuntime(lockCtx, record.ID, pod.Namespace, pod.Name, txn.ToGeneration, parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationExpiresAt), parseRFC3339AnnotationTime(pod.Annotations, controller.AnnotationHardExpiresAt), sandboxRuntimeMetadataFromPod(pod)); err != nil {
 			return err
 		}
+		if hotClaimUsesRecordCompletion(pod) {
+			if err := tx.MarkHotClaimCompleted(lockCtx, record.ID, s.clock.Now().UTC()); err != nil {
+				return err
+			}
+		}
 		return tx.CommitLifecycleTxn(lockCtx, txn.ID, "")
 	})
 }

--- a/manager/pkg/service/sandbox_store.go
+++ b/manager/pkg/service/sandbox_store.go
@@ -193,6 +193,7 @@ type SandboxStore interface {
 type SandboxStoreTx interface {
 	SaveSandbox(ctx context.Context, record *SandboxRecord) error
 	SaveRuntime(ctx context.Context, sandboxID, namespace, podName string, generation int64, expiresAt, hardExpiresAt time.Time, metadata SandboxRuntimeMetadata) error
+	MarkHotClaimCompleted(ctx context.Context, sandboxID string, completedAt time.Time) error
 	MarkRuntimePaused(ctx context.Context, sandboxID string, generation int64, pausedAt time.Time) error
 	MarkRuntimeTerminating(ctx context.Context, sandboxID string) error
 	SaveRootFSState(ctx context.Context, state *SandboxRootFSState) error
@@ -749,6 +750,26 @@ func (t sandboxStoreTx) SaveRuntime(ctx context.Context, sandboxID, namespace, p
 	`, sandboxID, SandboxDesiredStateActive, namespace, podName, generation, nullableTime(expiresAt), nullableTime(hardExpiresAt), strings.TrimSpace(metadata.WebhookStateVolumeID), strings.TrimSpace(metadata.OwnerKind), SandboxDesiredStateTerminating, SandboxDesiredStateDeleted)
 	if err != nil {
 		return fmt.Errorf("save sandbox runtime: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("%w: %s", ErrSandboxRecordNotFound, sandboxID)
+	}
+	return nil
+}
+
+// MarkHotClaimCompleted records a hot-pool handoff inside the caller's locked
+// lifecycle transaction.
+func (t sandboxStoreTx) MarkHotClaimCompleted(ctx context.Context, sandboxID string, completedAt time.Time) error {
+	tag, err := t.tx.Exec(ctx, `
+		UPDATE manager.sandboxes
+		SET hot_claim_completed_at = $2,
+			updated_at = NOW()
+		WHERE sandbox_id = $1
+			AND deleted_at IS NULL
+			AND desired_state NOT IN ($3, $4)
+	`, sandboxID, completedAt, SandboxDesiredStateTerminating, SandboxDesiredStateDeleted)
+	if err != nil {
+		return fmt.Errorf("mark hot claim completed: %w", err)
 	}
 	if tag.RowsAffected() == 0 {
 		return fmt.Errorf("%w: %s", ErrSandboxRecordNotFound, sandboxID)

--- a/tests/integration/internal/tests/manager/api_test.go
+++ b/tests/integration/internal/tests/manager/api_test.go
@@ -1264,6 +1264,15 @@ func (t memorySandboxStoreTxForManagerIntegration) SaveRuntime(_ context.Context
 	return nil
 }
 
+func (t memorySandboxStoreTxForManagerIntegration) MarkHotClaimCompleted(_ context.Context, sandboxID string, completedAt time.Time) error {
+	record := t.store.records[sandboxID]
+	if record == nil || record.DesiredState == service.SandboxDesiredStateTerminating || record.DesiredState == service.SandboxDesiredStateDeleted || !record.DeletedAt.IsZero() {
+		return service.ErrSandboxRecordNotFound
+	}
+	record.HotClaimCompletedAt = completedAt
+	return nil
+}
+
 func (t memorySandboxStoreTxForManagerIntegration) MarkRuntimePaused(_ context.Context, sandboxID string, generation int64, _ time.Time) error {
 	record := t.store.records[sandboxID]
 	if record == nil || record.DesiredState == service.SandboxDesiredStateTerminating || record.DesiredState == service.SandboxDesiredStateDeleted || !record.DeletedAt.IsZero() {


### PR DESCRIPTION
## Summary

- mark record-v2 hot claims complete when a paused sandbox resumes through the hot pool
- persist the completion marker in the same locked PostgreSQL transaction as the runtime projection and resume lifecycle commit
- add a regression test covering reconciliation after the five-minute reservation recovery grace period

## Root cause

#824 made `hot_claim_completed_at` the durable completion signal for initializing hot claims. The normal claim path wrote that marker, but the pause-to-hot-resume path committed the new runtime and only enqueued reservation reconciliation. A resumed sandbox without an existing marker was therefore classified as an abandoned partial claim after five minutes, soft-deleted in PostgreSQL, and its pod deleted.

## Validation

- `go test ./manager/pkg/service -run 'Test(CompleteHotClaimReservation|CommittedHotClaimResume|HotClaimReservationController)' -count=1`
- `go test ./manager/pkg/service -count=1`
- `go test -race ./manager/pkg/service -count=1`

The broader `go test ./manager/... -count=1` run passed all runnable manager packages; `manager/cmd/manager` could not set up locally because the ignored generated `storage-proxy/proto/fs` package was absent. The PR workflow generates that package before tests.
