### PR TITLE
Fix public push and private registry routing

### DIFF
--- a/docs/template/images/page.mdx
+++ b/docs/template/images/page.mdx
@@ -188,6 +188,27 @@ DNS name for manager's server-side publication only. Do not put a Kubernetes
 Service DNS name in a Template image reference: node container runtimes do not
 normally use cluster DNS.
 
+Aliyun ACR can expose separate internet and VPC hostnames. Configure `registry`
+with the internet hostname so external developers and CI can push images, and
+configure `pullRegistry` plus `internalRegistry` with the VPC hostname so
+sandbox nodes and Sandbox0 services stay on the private path:
+
+```yaml
+spec:
+    registry:
+        provider: aliyun
+        aliyun:
+            registry: registry.example.com
+            pullRegistry: registry-vpc.example.com
+            internalRegistry: registry-vpc.example.com
+            region: us-east-1
+            instanceId: cri-example
+            pullSecret:
+                name: acr-pull-secret
+            credentialsSecret:
+                name: aliyun-credentials
+```
+
 ---
 
 ## How Authentication Works

--- a/infra-operator/api/v1alpha1/sandbox0infra_types.go
+++ b/infra-operator/api/v1alpha1/sandbox0infra_types.go
@@ -1127,8 +1127,19 @@ type AzureRegistryCredentialsSecret struct {
 
 // AliyunRegistryConfig defines Aliyun registry configuration.
 type AliyunRegistryConfig struct {
-	// Registry specifies the registry hostname.
+	// Registry specifies the public registry hostname used for external image pushes.
 	Registry string `json:"registry"`
+
+	// PullRegistry optionally specifies a private registry hostname reachable by
+	// sandbox nodes. It defaults to Registry.
+	// +optional
+	PullRegistry string `json:"pullRegistry,omitempty"`
+
+	// InternalRegistry optionally specifies a private registry hostname used by
+	// Sandbox0 services for server-side image publication. It defaults to
+	// PullRegistry when configured, otherwise Registry.
+	// +optional
+	InternalRegistry string `json:"internalRegistry,omitempty"`
 
 	// Region specifies the Aliyun region.
 	Region string `json:"region"`

--- a/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
+++ b/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
@@ -2309,6 +2309,17 @@ spec:
                       instanceId:
                         description: InstanceID specifies the ACR instance ID.
                         type: string
+                      internalRegistry:
+                        description: |-
+                          InternalRegistry optionally specifies a private registry hostname used by
+                          Sandbox0 services for server-side image publication. It defaults to
+                          PullRegistry when configured, otherwise Registry.
+                        type: string
+                      pullRegistry:
+                        description: |-
+                          PullRegistry optionally specifies a private registry hostname reachable by
+                          sandbox nodes. It defaults to Registry.
+                        type: string
                       pullSecret:
                         description: PullSecret references the dockerconfigjson secret
                           to use for image pulls.
@@ -2327,7 +2338,8 @@ spec:
                         description: Region specifies the Aliyun region.
                         type: string
                       registry:
-                        description: Registry specifies the registry hostname.
+                        description: Registry specifies the public registry hostname
+                          used for external image pushes.
                         type: string
                     required:
                     - credentialsSecret

--- a/infra-operator/chart/samples/single-cluster/fullmode.yaml
+++ b/infra-operator/chart/samples/single-cluster/fullmode.yaml
@@ -107,6 +107,23 @@ spec:
   #       name: aws-credentials
   #       accessKeyKey: accessKeyId
   #       secretKeyKey: secretAccessKey
+  # Example Aliyun ACR endpoints split between external push traffic and
+  # private node/service traffic:
+  # registry:
+  #   provider: aliyun
+  #   aliyun:
+  #     registry: registry.example.com
+  #     pullRegistry: registry-vpc.example.com
+  #     internalRegistry: registry-vpc.example.com
+  #     region: us-east-1
+  #     instanceId: cri-example
+  #     pullSecret:
+  #       name: acr-pull-secret
+  #       key: .dockerconfigjson
+  #     credentialsSecret:
+  #       name: aliyun-credentials
+  #       accessKeyKey: accessKeyId
+  #       secretKeyKey: accessKeySecret
   builtinTemplates:
     - templateId: default
       image: sandbox0ai/otemplates:default-v0.2.0

--- a/infra-operator/internal/controller/services/registry/registry.go
+++ b/infra-operator/internal/controller/services/registry/registry.go
@@ -743,10 +743,12 @@ func builtinInternalRegistry(infra *infrav1alpha1.Sandbox0Infra, builtin infrav1
 }
 
 type registryProviderConfig struct {
-	Registry   string
-	PullSecret *infrav1alpha1.DockerConfigSecretRef
-	Region     string
-	RegistryID string
+	Registry         string
+	PullRegistry     string
+	InternalRegistry string
+	PullSecret       *infrav1alpha1.DockerConfigSecretRef
+	Region           string
+	RegistryID       string
 }
 
 func resolveExternalRegistry(provider infrav1alpha1.RegistryProvider, cfg interface{}, targetSecretName string) *ResolvedRegistryConfig {
@@ -777,6 +779,8 @@ func resolveExternalRegistry(provider infrav1alpha1.RegistryProvider, cfg interf
 			return nil
 		}
 		resolved.Registry = typed.Registry
+		resolved.PullRegistry = typed.PullRegistry
+		resolved.InternalRegistry = typed.InternalRegistry
 		resolved.PullSecret = &typed.PullSecret
 	case *infrav1alpha1.HarborRegistryConfig:
 		if typed == nil {
@@ -800,11 +804,19 @@ func resolveExternalRegistry(provider infrav1alpha1.RegistryProvider, cfg interf
 	if resolved.Registry == "" && resolved.Region != "" && resolved.RegistryID != "" {
 		resolved.Registry = fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", resolved.RegistryID, resolved.Region)
 	}
+	pullRegistry := resolved.PullRegistry
+	if pullRegistry == "" {
+		pullRegistry = resolved.Registry
+	}
+	internalRegistry := resolved.InternalRegistry
+	if internalRegistry == "" {
+		internalRegistry = pullRegistry
+	}
 	return &ResolvedRegistryConfig{
 		Provider:         provider,
 		PushRegistry:     resolved.Registry,
-		PullRegistry:     resolved.Registry,
-		InternalRegistry: resolved.Registry,
+		PullRegistry:     pullRegistry,
+		InternalRegistry: internalRegistry,
 		SourceSecretName: secretName,
 		SourceSecretKey:  secretKey,
 		TargetSecretName: targetSecretName,

--- a/infra-operator/internal/controller/services/registry/registry_explicit_test.go
+++ b/infra-operator/internal/controller/services/registry/registry_explicit_test.go
@@ -113,3 +113,60 @@ func TestResolveRegistryConfigAllowsGCPWithoutPullSecret(t *testing.T) {
 		t.Fatalf("expected no source pull secret, got %#v", cfg)
 	}
 }
+
+func TestResolveRegistryConfigUsesSplitAliyunEndpoints(t *testing.T) {
+	infra := &infrav1alpha1.Sandbox0Infra{
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			Registry: &infrav1alpha1.RegistryConfig{
+				Provider: infrav1alpha1.RegistryProviderAliyun,
+				Aliyun: &infrav1alpha1.AliyunRegistryConfig{
+					Registry:         "registry.example.com",
+					PullRegistry:     "registry-vpc.example.com",
+					InternalRegistry: "registry-service.example.com",
+					PullSecret: infrav1alpha1.DockerConfigSecretRef{
+						Name: "acr-pull-secret",
+					},
+				},
+			},
+		},
+	}
+
+	cfg := ResolveRegistryConfig(infra)
+	if cfg == nil {
+		t.Fatal("expected resolved registry config")
+	}
+	if cfg.PushRegistry != "registry.example.com" {
+		t.Fatalf("unexpected push registry: %q", cfg.PushRegistry)
+	}
+	if cfg.PullRegistry != "registry-vpc.example.com" {
+		t.Fatalf("unexpected pull registry: %q", cfg.PullRegistry)
+	}
+	if cfg.InternalRegistry != "registry-service.example.com" {
+		t.Fatalf("unexpected internal registry: %q", cfg.InternalRegistry)
+	}
+	if cfg.SourceSecretName != "acr-pull-secret" {
+		t.Fatalf("unexpected source secret: %q", cfg.SourceSecretName)
+	}
+}
+
+func TestResolveRegistryConfigDefaultsAliyunInternalEndpointToPullEndpoint(t *testing.T) {
+	infra := &infrav1alpha1.Sandbox0Infra{
+		Spec: infrav1alpha1.Sandbox0InfraSpec{
+			Registry: &infrav1alpha1.RegistryConfig{
+				Provider: infrav1alpha1.RegistryProviderAliyun,
+				Aliyun: &infrav1alpha1.AliyunRegistryConfig{
+					Registry:     "registry.example.com",
+					PullRegistry: "registry-vpc.example.com",
+				},
+			},
+		},
+	}
+
+	cfg := ResolveRegistryConfig(infra)
+	if cfg == nil {
+		t.Fatal("expected resolved registry config")
+	}
+	if cfg.InternalRegistry != "registry-vpc.example.com" {
+		t.Fatalf("unexpected internal registry: %q", cfg.InternalRegistry)
+	}
+}

--- a/manager/pkg/templateimage/publisher.go
+++ b/manager/pkg/templateimage/publisher.go
@@ -240,11 +240,13 @@ func publicationEndpoints(
 	if pull == "" {
 		pull = push
 	}
-	if strings.EqualFold(strings.TrimSpace(credential.Provider), "builtin") {
-		serverRegistry := strings.Trim(naming.NormalizeRegistryHost(internalRegistry), "/")
-		if serverRegistry != "" {
-			push = naming.TeamScopedImageRegistry(serverRegistry, teamID)
-		} else {
+	provider := strings.TrimSpace(credential.Provider)
+	serverRegistry := strings.Trim(naming.NormalizeRegistryHost(internalRegistry), "/")
+	if serverRegistry != "" {
+		push = naming.TeamScopedImageRegistry(serverRegistry, teamID)
+	}
+	if strings.EqualFold(provider, "builtin") {
+		if serverRegistry == "" {
 			// Preserve compatibility with configs where PullRegistry carried
 			// the builtin service endpoint.
 			push = pull

--- a/manager/pkg/templateimage/publisher_test.go
+++ b/manager/pkg/templateimage/publisher_test.go
@@ -632,6 +632,29 @@ func TestPublicationEndpointsExternalUsesPushAndPullEndpoints(t *testing.T) {
 	}
 }
 
+func TestPublicationEndpointsExternalUsesInternalEndpointForServerSidePush(t *testing.T) {
+	t.Parallel()
+
+	teamID := "team"
+	teamPrefix := naming.TeamImageRepositoryPrefix(teamID)
+	push, pull, plainHTTP, err := publicationEndpoints(
+		&managerregistry.Credential{
+			Provider:     "aliyun",
+			PushRegistry: "registry.example.com/" + teamPrefix,
+			PullRegistry: "registry-vpc.example.com/" + teamPrefix,
+		},
+		"registry-vpc.example.com",
+		teamID,
+	)
+	if err != nil {
+		t.Fatalf("publicationEndpoints() error = %v", err)
+	}
+	want := "registry-vpc.example.com/" + teamPrefix
+	if push != want || pull != want || plainHTTP {
+		t.Fatalf("publicationEndpoints() = %q, %q, %v", push, pull, plainHTTP)
+	}
+}
+
 func TestRegistryEndpointsWithPathsPreserveRepositoryAndCompareByAuthority(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- add distinct Aliyun public push, private pull, and private internal registry endpoints
- use the internal endpoint for manager-side template image publication
- preserve existing single-endpoint configurations through defaults
- document and test the split endpoint configuration

## Why

The ali-ue1 registry currently advertises its VPC-only ACR hostname as the push endpoint. External customers therefore receive an NXDOMAIN hostname from `s0 template image credentials`. The public ACR hostname must be advertised for customer/CI pushes while ACK nodes and Sandbox0 services continue to use the VPC hostname.

## Tests

- `go test ./infra-operator/internal/controller/services/registry ./infra-operator/internal/plan ./manager/pkg/templateimage`
- `go test ./infra-operator/...`
- `make test manager`
- `make manifests`

## Deployment validation

The companion infrastructure PR renders the public hostname as `registry` and the VPC hostname as both `pullRegistry` and `internalRegistry`. End-to-end `s0` push/template/claim validation will be recorded after the candidate runtime is deployed.
