### PR TITLE
fix: make Aliyun template image pushes public and team-scoped

### DIFF
--- a/docs/integrations/github-ci/page.mdx
+++ b/docs/integrations/github-ci/page.mdx
@@ -107,15 +107,15 @@ The push step obtains temporary registry credentials from Sandbox0 automatically
 
 1. Authenticates to Sandbox0 with `SANDBOX0_TOKEN`
 2. Calls the registry credentials endpoint for a short-lived push credential
-3. Tags the local image with the team-scoped push registry prefix
+3. Tags the local image with the complete team-scoped `pushImage` reference returned by Sandbox0
 4. Pushes the image with Docker
-5. Prints the template image reference that Sandbox0 should use at runtime
+5. Prints the provider-specific `pullImage` reference that Sandbox0 should use at runtime
 
 This keeps registry credentials short-lived while leaving the build itself on the CI runner.
 
 ## Using the pushed image in a template
 
-After a successful push, use the printed `Template image reference` value in your template spec.
+After a successful push, use the printed `Template image reference` value in your template spec. Treat the printed value as authoritative: providers such as Aliyun ACR may map the logical image name to a tag in a fixed team repository, and the runtime reference may use a VPC-only hostname.
 
 ```yaml
 spec:

--- a/docs/template/images/page.mdx
+++ b/docs/template/images/page.mdx
@@ -81,7 +81,7 @@ Both methods use your local Docker daemon to build the image. Make sure Docker i
 
 ### Step 2 — Push to the Sandbox0 Registry
 
-Push the locally built image to the Sandbox0 registry. The CLI automatically retrieves short-lived credentials from the API and scopes the push to your team prefix:
+Push the locally built image to the Sandbox0 registry. The CLI automatically retrieves short-lived credentials and a team-scoped destination from the API:
 
 ```bash
 s0 template image push my-app:v1.2.3 -t my-app:v1.2.3
@@ -93,7 +93,7 @@ s0 template image push my-app:v1.2.3 -t my-app:v1.2.3
 
 The push command:
 1. Calls `POST /api/v1/registry/credentials` to obtain short-lived credentials
-2. Re-tags the local image with the registry hostname prepended
+2. Re-tags the local image with the complete provider-specific `pushImage` reference returned by Sandbox0
 3. Pushes the image using your Docker daemon
 
 <Callout variant="info">
@@ -176,7 +176,7 @@ Sandbox0 supports multiple container registry backends. The registry provider is
 | `aws` | Amazon ECR | Short-lived tokens (12h). Can optionally use `AssumeRole` + session policy for team-scoped pushes. |
 | `gcp` | Google Artifact Registry / GCR | Uses service account credentials. |
 | `azure` | Azure Container Registry | Uses ACR credentials. |
-| `aliyun` | Alibaba Cloud Container Registry | Uses Aliyun ACR credentials. |
+| `aliyun` | Alibaba Cloud Container Registry | Uses a fixed namespace, one private repository per team, and repository-scoped STS credentials. |
 | `harbor` | Harbor | Uses Harbor robot/user credentials from Kubernetes Secret. |
 
 For all providers, the `s0 template image push` command handles credential retrieval transparently — you always use the same CLI command regardless of the backend.
@@ -191,7 +191,9 @@ normally use cluster DNS.
 Aliyun ACR can expose separate internet and VPC hostnames. Configure `registry`
 with the internet hostname so external developers and CI can push images, and
 configure `pullRegistry` plus `internalRegistry` with the VPC hostname so
-sandbox nodes and Sandbox0 services stay on the private path:
+sandbox nodes and Sandbox0 services stay on the private path. The configured
+RAM role must allow Sandbox0 to mint repository-scoped STS sessions. Sandbox0
+creates `t-<team-key>` repositories on demand inside the fixed namespace:
 
 ```yaml
 spec:
@@ -201,13 +203,27 @@ spec:
             registry: registry.example.com
             pullRegistry: registry-vpc.example.com
             internalRegistry: registry-vpc.example.com
+            namespace: sandbox0aliue1
             region: us-east-1
             instanceId: cri-example
+            assumeRoleArn: acs:ram::123456789012:role/sandbox0_acr_upload
+            sessionDurationSeconds: 21600
             pullSecret:
                 name: acr-pull-secret
             credentialsSecret:
                 name: aliyun-credentials
 ```
+
+Aliyun ACR image paths have the fixed shape
+`<registry>/<namespace>/<repository>:<tag>`. Sandbox0 therefore maps a logical
+target such as `my-app:v1.2.3` to a deterministic tag in the team's repository.
+Do not reconstruct this address yourself; use the `Image pushed successfully`
+and `Template image reference` values printed by the CLI. The push reference
+uses the internet endpoint, while the template reference uses the VPC endpoint.
+
+The upload role may allow Push/Pull across the shared namespace, but every
+issued STS session is restricted again to exactly one team repository. A
+customer upload credential cannot pull or push another team's repository.
 
 ---
 
@@ -222,18 +238,20 @@ flowchart LR
     creds["Short-lived creds"]
     docker["docker push"]
     registry["Registry"]
-    secret["imagePullSecret (auto-injected into all sandbox pods)"]
+    secret["Cluster-managed imagePullSecret"]
+    kubelet["Node kubelet / container runtime"]
     stored["image stored"]
 
     cli -->|"image push"| api
     api --> creds
     creds --> docker
     docker --> registry
-    secret --> registry
+    secret --> kubelet
+    kubelet --> registry
     registry --> stored
 ```
 
-The platform operator maintains a cluster-wide `imagePullSecret` that is automatically injected into every sandbox pod. As a template author, you only need to reference the correct image name — no credential configuration is required in the template spec.
+The platform operator maintains a cluster-managed `imagePullSecret` and references it from sandbox pod specs. The node kubelet/container runtime consumes that secret while pulling the image; it is not mounted into the sandbox container or exposed through the Sandbox0 API. As a template author, you only need to reference the correct image name — no credential configuration is required in the template spec.
 
 <Callout variant="info">
 For self-hosted deployments, the `builtin` registry provider automatically provisions and manages the pull secret. For external registries (ECR, GCP, ACR, Aliyun, Harbor), the platform operator pre-configures the credentials once during cluster setup.

--- a/infra-operator/api/config/manager.go
+++ b/infra-operator/api/config/manager.go
@@ -511,8 +511,12 @@ type RegistryAzureConfig struct {
 // RegistryAliyunConfig defines Aliyun registry config.
 type RegistryAliyunConfig struct {
 	Registry          string `yaml:"registry" json:"-"`
+	Namespace         string `yaml:"namespace" json:"-"`
 	Region            string `yaml:"region" json:"-"`
 	InstanceID        string `yaml:"instance_id" json:"-"`
+	AssumeRoleARN     string `yaml:"assume_role_arn" json:"-"`
+	ExternalID        string `yaml:"external_id" json:"-"`
+	SessionDuration   int64  `yaml:"session_duration_seconds" json:"-"`
 	CredentialsSecret string `yaml:"credentials_secret" json:"-"`
 	AccessKeyKey      string `yaml:"access_key_key" json:"-"`
 	SecretKeyKey      string `yaml:"secret_key_key" json:"-"`

--- a/infra-operator/api/v1alpha1/sandbox0infra_types.go
+++ b/infra-operator/api/v1alpha1/sandbox0infra_types.go
@@ -1141,11 +1141,30 @@ type AliyunRegistryConfig struct {
 	// +optional
 	InternalRegistry string `json:"internalRegistry,omitempty"`
 
+	// Namespace is the shared ACR namespace that contains one private
+	// repository per Sandbox0 team.
+	Namespace string `json:"namespace"`
+
 	// Region specifies the Aliyun region.
 	Region string `json:"region"`
 
 	// InstanceID specifies the ACR instance ID.
 	InstanceID string `json:"instanceId"`
+
+	// AssumeRoleARN is the RAM role used to mint repository-scoped upload
+	// credentials. The role session is restricted again for each team.
+	AssumeRoleARN string `json:"assumeRoleArn"`
+
+	// ExternalID is passed to STS AssumeRole when configured.
+	// +optional
+	ExternalID string `json:"externalId,omitempty"`
+
+	// SessionDurationSeconds controls the repository upload session lifetime.
+	// +kubebuilder:default=21600
+	// +kubebuilder:validation:Minimum=3600
+	// +kubebuilder:validation:Maximum=43200
+	// +optional
+	SessionDurationSeconds int64 `json:"sessionDurationSeconds,omitempty"`
 
 	// PullSecret references the dockerconfigjson secret to use for image pulls.
 	PullSecret DockerConfigSecretRef `json:"pullSecret"`

--- a/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
+++ b/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
@@ -2287,6 +2287,11 @@ spec:
                   aliyun:
                     description: Aliyun configures Aliyun registry integration.
                     properties:
+                      assumeRoleArn:
+                        description: |-
+                          AssumeRoleARN is the RAM role used to mint repository-scoped upload
+                          credentials. The role session is restricted again for each team.
+                        type: string
                       credentialsSecret:
                         description: CredentialsSecret references Aliyun credentials
                           for short-lived tokens.
@@ -2306,6 +2311,9 @@ spec:
                         required:
                         - name
                         type: object
+                      externalId:
+                        description: ExternalID is passed to STS AssumeRole when configured.
+                        type: string
                       instanceId:
                         description: InstanceID specifies the ACR instance ID.
                         type: string
@@ -2314,6 +2322,11 @@ spec:
                           InternalRegistry optionally specifies a private registry hostname used by
                           Sandbox0 services for server-side image publication. It defaults to
                           PullRegistry when configured, otherwise Registry.
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the shared ACR namespace that contains one private
+                          repository per Sandbox0 team.
                         type: string
                       pullRegistry:
                         description: |-
@@ -2341,9 +2354,19 @@ spec:
                         description: Registry specifies the public registry hostname
                           used for external image pushes.
                         type: string
+                      sessionDurationSeconds:
+                        default: 21600
+                        description: SessionDurationSeconds controls the repository
+                          upload session lifetime.
+                        format: int64
+                        maximum: 43200
+                        minimum: 3600
+                        type: integer
                     required:
+                    - assumeRoleArn
                     - credentialsSecret
                     - instanceId
+                    - namespace
                     - pullSecret
                     - region
                     - registry

--- a/infra-operator/internal/controller/services/registry/registry.go
+++ b/infra-operator/internal/controller/services/registry/registry.go
@@ -778,9 +778,9 @@ func resolveExternalRegistry(provider infrav1alpha1.RegistryProvider, cfg interf
 		if typed == nil {
 			return nil
 		}
-		resolved.Registry = typed.Registry
-		resolved.PullRegistry = typed.PullRegistry
-		resolved.InternalRegistry = typed.InternalRegistry
+		resolved.Registry = joinRegistryPath(typed.Registry, typed.Namespace)
+		resolved.PullRegistry = joinRegistryPath(typed.PullRegistry, typed.Namespace)
+		resolved.InternalRegistry = joinRegistryPath(typed.InternalRegistry, typed.Namespace)
 		resolved.PullSecret = &typed.PullSecret
 	case *infrav1alpha1.HarborRegistryConfig:
 		if typed == nil {
@@ -821,6 +821,15 @@ func resolveExternalRegistry(provider infrav1alpha1.RegistryProvider, cfg interf
 		SourceSecretKey:  secretKey,
 		TargetSecretName: targetSecretName,
 	}
+}
+
+func joinRegistryPath(registryHost, repositoryPath string) string {
+	host := normalizeRegistryHost(registryHost)
+	path := strings.Trim(repositoryPath, "/")
+	if host == "" || path == "" {
+		return host
+	}
+	return host + "/" + path
 }
 
 func normalizeRegistryHost(raw string) string {

--- a/infra-operator/internal/controller/services/registry/registry_explicit_test.go
+++ b/infra-operator/internal/controller/services/registry/registry_explicit_test.go
@@ -123,6 +123,7 @@ func TestResolveRegistryConfigUsesSplitAliyunEndpoints(t *testing.T) {
 					Registry:         "registry.example.com",
 					PullRegistry:     "registry-vpc.example.com",
 					InternalRegistry: "registry-service.example.com",
+					Namespace:        "sandbox0aliue1",
 					PullSecret: infrav1alpha1.DockerConfigSecretRef{
 						Name: "acr-pull-secret",
 					},
@@ -135,13 +136,13 @@ func TestResolveRegistryConfigUsesSplitAliyunEndpoints(t *testing.T) {
 	if cfg == nil {
 		t.Fatal("expected resolved registry config")
 	}
-	if cfg.PushRegistry != "registry.example.com" {
+	if cfg.PushRegistry != "registry.example.com/sandbox0aliue1" {
 		t.Fatalf("unexpected push registry: %q", cfg.PushRegistry)
 	}
-	if cfg.PullRegistry != "registry-vpc.example.com" {
+	if cfg.PullRegistry != "registry-vpc.example.com/sandbox0aliue1" {
 		t.Fatalf("unexpected pull registry: %q", cfg.PullRegistry)
 	}
-	if cfg.InternalRegistry != "registry-service.example.com" {
+	if cfg.InternalRegistry != "registry-service.example.com/sandbox0aliue1" {
 		t.Fatalf("unexpected internal registry: %q", cfg.InternalRegistry)
 	}
 	if cfg.SourceSecretName != "acr-pull-secret" {
@@ -157,6 +158,7 @@ func TestResolveRegistryConfigDefaultsAliyunInternalEndpointToPullEndpoint(t *te
 				Aliyun: &infrav1alpha1.AliyunRegistryConfig{
 					Registry:     "registry.example.com",
 					PullRegistry: "registry-vpc.example.com",
+					Namespace:    "sandbox0aliue1",
 				},
 			},
 		},
@@ -166,7 +168,7 @@ func TestResolveRegistryConfigDefaultsAliyunInternalEndpointToPullEndpoint(t *te
 	if cfg == nil {
 		t.Fatal("expected resolved registry config")
 	}
-	if cfg.InternalRegistry != "registry-vpc.example.com" {
+	if cfg.InternalRegistry != "registry-vpc.example.com/sandbox0aliue1" {
 		t.Fatalf("unexpected internal registry: %q", cfg.InternalRegistry)
 	}
 }

--- a/infra-operator/internal/plan/plan.go
+++ b/infra-operator/internal/plan/plan.go
@@ -523,8 +523,12 @@ func compileManagerRuntimeConfig(managerPlan *ManagerPlan, infra *infrav1alpha1.
 			if infra.Spec.Registry.Aliyun != nil {
 				cfg.Registry.Aliyun = &apiconfig.RegistryAliyunConfig{
 					Registry:          infra.Spec.Registry.Aliyun.Registry,
+					Namespace:         infra.Spec.Registry.Aliyun.Namespace,
 					Region:            infra.Spec.Registry.Aliyun.Region,
 					InstanceID:        infra.Spec.Registry.Aliyun.InstanceID,
+					AssumeRoleARN:     infra.Spec.Registry.Aliyun.AssumeRoleARN,
+					ExternalID:        infra.Spec.Registry.Aliyun.ExternalID,
+					SessionDuration:   infra.Spec.Registry.Aliyun.SessionDurationSeconds,
 					CredentialsSecret: infra.Spec.Registry.Aliyun.CredentialsSecret.Name,
 					AccessKeyKey:      infra.Spec.Registry.Aliyun.CredentialsSecret.AccessKeyKey,
 					SecretKeyKey:      infra.Spec.Registry.Aliyun.CredentialsSecret.SecretKeyKey,

--- a/infra-operator/internal/plan/runtime_access.go
+++ b/infra-operator/internal/plan/runtime_access.go
@@ -220,8 +220,12 @@ func (p *InfraPlan) ConfigureRegionalGatewayRegistry(cfg *apiconfig.RegionalGate
 		cred := p.infra.Spec.Registry.Aliyun.CredentialsSecret
 		cfg.Registry.Aliyun = &apiconfig.RegistryAliyunConfig{
 			Registry:        p.infra.Spec.Registry.Aliyun.Registry,
+			Namespace:       p.infra.Spec.Registry.Aliyun.Namespace,
 			Region:          p.infra.Spec.Registry.Aliyun.Region,
 			InstanceID:      p.infra.Spec.Registry.Aliyun.InstanceID,
+			AssumeRoleARN:   p.infra.Spec.Registry.Aliyun.AssumeRoleARN,
+			ExternalID:      p.infra.Spec.Registry.Aliyun.ExternalID,
+			SessionDuration: p.infra.Spec.Registry.Aliyun.SessionDurationSeconds,
 			AccessKeyID:     "${S0_REGISTRY_ALIYUN_ACCESS_KEY_ID}",
 			AccessKeySecret: "${S0_REGISTRY_ALIYUN_ACCESS_KEY_SECRET}",
 		}

--- a/manager/pkg/templateimage/publisher.go
+++ b/manager/pkg/templateimage/publisher.go
@@ -135,8 +135,13 @@ func (p *Publisher) Publish(ctx context.Context, req BuildRequest) (*Result, err
 	if err != nil {
 		return nil, err
 	}
-	pushTagRef := joinImageReference(pushRegistry, targetImage)
-	pullRepositoryRef := joinImageReference(pullRegistry, repository)
+	pushTagRef, pushRepositoryRef, pullRepositoryRef := publicationReferences(
+		pushRegistry,
+		pullRegistry,
+		repository,
+		targetImage,
+		credential.TargetTag,
+	)
 
 	targetResolver := p.newResolver(resolverOptions{
 		purpose:   resolverPurposeTarget,
@@ -223,11 +228,23 @@ func (p *Publisher) Publish(ctx context.Context, req BuildRequest) (*Result, err
 	}
 
 	return &Result{
-		PushReference:  joinImageReference(pushRegistry, repository) + "@" + manifestDesc.Digest.String(),
+		PushReference:  pushRepositoryRef + "@" + manifestDesc.Digest.String(),
 		PullReference:  pullRepositoryRef + "@" + manifestDesc.Digest.String(),
 		ManifestDigest: manifestDesc.Digest,
 		Platform:       platforms.Normalize(req.Platform),
 	}, nil
+}
+
+func publicationReferences(pushRegistry, pullRegistry, repository, targetImage, providerTag string) (pushTag, pushRepository, pullRepository string) {
+	pushTag = joinImageReference(pushRegistry, targetImage)
+	pushRepository = joinImageReference(pushRegistry, repository)
+	pullRepository = joinImageReference(pullRegistry, repository)
+	if targetTag := strings.TrimSpace(providerTag); targetTag != "" {
+		pushTag = pushRegistry + ":" + targetTag
+		pushRepository = pushRegistry
+		pullRepository = pullRegistry
+	}
+	return pushTag, pushRepository, pullRepository
 }
 
 func publicationEndpoints(

--- a/manager/pkg/templateimage/publisher_test.go
+++ b/manager/pkg/templateimage/publisher_test.go
@@ -655,6 +655,28 @@ func TestPublicationEndpointsExternalUsesInternalEndpointForServerSidePush(t *te
 	}
 }
 
+func TestPublicationReferencesUseProviderRepositoryTag(t *testing.T) {
+	t.Parallel()
+
+	pushTag, pushRepository, pullRepository := publicationReferences(
+		"registry-vpc.example.com/sandbox0/t-team",
+		"registry-vpc.example.com/sandbox0/t-team",
+		"template-workspace",
+		"template-workspace:build-1",
+		"template-workspace-build-1-hash",
+	)
+
+	if got, want := pushTag, "registry-vpc.example.com/sandbox0/t-team:template-workspace-build-1-hash"; got != want {
+		t.Fatalf("push tag = %q, want %q", got, want)
+	}
+	if got, want := pushRepository, "registry-vpc.example.com/sandbox0/t-team"; got != want {
+		t.Fatalf("push repository = %q, want %q", got, want)
+	}
+	if got, want := pullRepository, "registry-vpc.example.com/sandbox0/t-team"; got != want {
+		t.Fatalf("pull repository = %q, want %q", got, want)
+	}
+}
+
 func TestRegistryEndpointsWithPathsPreserveRepositoryAndCompareByAuthority(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -4260,6 +4260,12 @@ components:
           type: string
         pullRegistry:
           type: string
+        pushImage:
+          type: string
+          description: Complete provider-specific image reference to push. Clients should prefer this over composing pushRegistry and targetImage.
+        pullImage:
+          type: string
+          description: Complete image reference for templates and sandbox pulls. It may use a private regional endpoint.
         username:
           type: string
         password:

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -1987,12 +1987,18 @@ type RegisterRequest struct {
 
 // RegistryCredentials defines model for RegistryCredentials.
 type RegistryCredentials struct {
-	ExpiresAt    *time.Time `json:"expiresAt,omitempty"`
-	Password     string     `json:"password"`
-	Provider     string     `json:"provider"`
-	PullRegistry string     `json:"pullRegistry"`
-	PushRegistry string     `json:"pushRegistry"`
-	Username     string     `json:"username"`
+	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
+	Password  string     `json:"password"`
+	Provider  string     `json:"provider"`
+
+	// PullImage Complete image reference for templates and sandbox pulls. It may use a private regional endpoint.
+	PullImage    *string `json:"pullImage,omitempty"`
+	PullRegistry string  `json:"pullRegistry"`
+
+	// PushImage Complete provider-specific image reference to push. Clients should prefer this over composing pushRegistry and targetImage.
+	PushImage    *string `json:"pushImage,omitempty"`
+	PushRegistry string  `json:"pushRegistry"`
+	Username     string  `json:"username"`
 }
 
 // RegistryCredentialsRequest defines model for RegistryCredentialsRequest.

--- a/pkg/naming/image.go
+++ b/pkg/naming/image.go
@@ -69,27 +69,38 @@ func ValidateTeamScopedImageReference(imageRef, teamID string, privateRegistryHo
 	if err != nil {
 		return err
 	}
-	if !registryHostMatchesAny(registryHost, privateRegistryHosts) {
-		return nil
+	for _, allowed := range privateRegistryHosts {
+		requiredRepository, matches := teamRepositoryForRegistryRoot(registryHost, allowed, prefix)
+		if !matches {
+			continue
+		}
+		if repository == requiredRepository || strings.HasPrefix(repository, requiredRepository+"/") {
+			return nil
+		}
+		return fmt.Errorf("must use team registry repository %q for private registry %q", requiredRepository, registryHost)
 	}
-	if repository == prefix || strings.HasPrefix(repository, prefix+"/") {
-		return nil
-	}
-
-	return fmt.Errorf("must use team registry prefix %q for private registry %q", prefix, registryHost)
+	return nil
 }
 
-func registryHostMatchesAny(actual string, allowedHosts []string) bool {
+func teamRepositoryForRegistryRoot(actual, allowed, teamPrefix string) (string, bool) {
 	normalizedActual := NormalizeRegistryHost(actual)
-	if normalizedActual == "" {
-		return false
+	normalizedAllowed := NormalizeRegistryHost(allowed)
+	if normalizedActual == "" || normalizedAllowed == "" {
+		return "", false
 	}
-	for _, allowed := range allowedHosts {
-		if normalizedActual == NormalizeRegistryHost(allowed) {
-			return true
-		}
+	allowedHost := normalizedAllowed
+	allowedPath := ""
+	if slash := strings.Index(normalizedAllowed, "/"); slash >= 0 {
+		allowedHost = normalizedAllowed[:slash]
+		allowedPath = strings.Trim(normalizedAllowed[slash+1:], "/")
 	}
-	return false
+	if normalizedActual != allowedHost {
+		return "", false
+	}
+	if allowedPath == "" {
+		return teamPrefix, true
+	}
+	return allowedPath + "/" + teamPrefix, true
 }
 
 func isRegistryHost(candidate string) bool {

--- a/pkg/naming/image_test.go
+++ b/pkg/naming/image_test.go
@@ -15,7 +15,7 @@ func TestTeamScopedImageRegistry(t *testing.T) {
 func TestValidateTeamScopedImageReference(t *testing.T) {
 	t.Parallel()
 
-	privateHosts := []string{"registry.internal.svc:5000", "registry.example.com"}
+	privateHosts := []string{"registry.internal.svc:5000", "registry.example.com", "acr.example.com/sandbox0"}
 	prefix := TeamImageRepositoryPrefix("team-123")
 
 	tests := []struct {
@@ -38,6 +38,15 @@ func TestValidateTeamScopedImageReference(t *testing.T) {
 		{
 			name:     "other team private image rejected",
 			imageRef: "registry.internal.svc:5000/t-other/my-app:v1",
+			wantErr:  true,
+		},
+		{
+			name:     "team repository under provider namespace accepted",
+			imageRef: "acr.example.com/sandbox0/" + prefix + ":v1",
+		},
+		{
+			name:     "other team under provider namespace rejected",
+			imageRef: "acr.example.com/sandbox0/t-other:v1",
 			wantErr:  true,
 		},
 	}

--- a/pkg/registry/aliyun.go
+++ b/pkg/registry/aliyun.go
@@ -2,56 +2,129 @@ package registry
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"path"
 	"strings"
 	"time"
+	"unicode"
 
+	aliyunerrors "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	cr "github.com/aliyun/alibaba-cloud-sdk-go/services/cr_ee"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/sts"
+	distref "github.com/distribution/reference"
 	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 )
+
+const defaultAliyunRegistrySessionDuration = 6 * time.Hour
+
+type aliyunCRAPI interface {
+	GetRepository(*cr.GetRepositoryRequest) (*cr.GetRepositoryResponse, error)
+	CreateRepository(*cr.CreateRepositoryRequest) (*cr.CreateRepositoryResponse, error)
+	GetAuthorizationToken(*cr.GetAuthorizationTokenRequest) (*cr.GetAuthorizationTokenResponse, error)
+}
+
+type aliyunSTSAPI interface {
+	AssumeRole(*sts.AssumeRoleRequest) (*sts.AssumeRoleResponse, error)
+}
 
 type aliyunProvider struct {
 	cfg     config.RegistryAliyunConfig
 	secrets secretReader
+
+	newAccessKeyCRClient func(region, accessKey, secretKey string) (aliyunCRAPI, error)
+	newSTSClient         func(region, accessKey, secretKey string) (aliyunSTSAPI, error)
+	newSTSCRClient       func(region, accessKey, secretKey, securityToken string) (aliyunCRAPI, error)
 }
 
 func (p *aliyunProvider) GetPushCredentials(ctx context.Context, req PushCredentialsRequest) (*Credential, error) {
-	// TODO: add team-scoped ephemeral credentials similar to AWS AssumeRole + session policy.
-	registry := normalizeRegistryHost(p.cfg.Registry)
-	if registry == "" {
+	registryHost := normalizeRegistryHost(p.cfg.Registry)
+	if registryHost == "" {
 		return nil, fmt.Errorf("aliyun registry is required")
 	}
-	if p.cfg.Region == "" {
+	region := strings.TrimSpace(p.cfg.Region)
+	if region == "" {
 		return nil, fmt.Errorf("aliyun region is required")
 	}
-	if p.cfg.InstanceID == "" {
+	instanceID := strings.TrimSpace(p.cfg.InstanceID)
+	if instanceID == "" {
 		return nil, fmt.Errorf("aliyun instanceId is required")
 	}
-	accessKey := strings.TrimSpace(p.cfg.AccessKeyID)
-	secretKey := strings.TrimSpace(p.cfg.AccessKeySecret)
-	if accessKey == "" || secretKey == "" {
-		if strings.TrimSpace(p.cfg.CredentialsSecret) == "" {
-			return nil, fmt.Errorf("aliyun credentials secret is required")
-		}
-		var err error
-		accessKey, err = p.secrets.readRequired(ctx, p.cfg.CredentialsSecret, p.cfg.AccessKeyKey, "accessKeyId", "aliyun access key")
-		if err != nil {
-			return nil, err
-		}
-		secretKey, err = p.secrets.readRequired(ctx, p.cfg.CredentialsSecret, p.cfg.SecretKeyKey, "accessKeySecret", "aliyun secret key")
-		if err != nil {
-			return nil, err
-		}
+	namespace := strings.Trim(strings.TrimSpace(p.cfg.Namespace), "/")
+	if namespace == "" {
+		return nil, fmt.Errorf("aliyun registry namespace is required")
+	}
+	roleARN := strings.TrimSpace(p.cfg.AssumeRoleARN)
+	if roleARN == "" {
+		return nil, fmt.Errorf("aliyun registry assumeRoleArn is required")
 	}
 
-	client, err := cr.NewClientWithAccessKey(p.cfg.Region, accessKey, secretKey)
+	repository, targetTag, err := resolveAliyunTarget(req.TeamID, req.TargetImage)
 	if err != nil {
-		return nil, fmt.Errorf("create aliyun cr client: %w", err)
+		return nil, err
 	}
-	request := cr.CreateGetAuthorizationTokenRequest()
-	request.Scheme = "https"
-	request.InstanceId = p.cfg.InstanceID
-	response, err := client.GetAuthorizationToken(request)
+	accountID, err := parseAliyunAccountIDFromRoleARN(roleARN)
+	if err != nil {
+		return nil, err
+	}
+	accessKey, secretKey, err := p.baseCredentials(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	baseClient, err := p.accessKeyCRClient(region, accessKey, secretKey)
+	if err != nil {
+		return nil, fmt.Errorf("create aliyun cr management client: %w", err)
+	}
+	if err := ensureAliyunRepository(baseClient, instanceID, namespace, repository); err != nil {
+		return nil, err
+	}
+
+	policy, err := buildAliyunRegistrySessionPolicy(region, accountID, instanceID, namespace, repository)
+	if err != nil {
+		return nil, err
+	}
+	stsClient, err := p.stsClient(region, accessKey, secretKey)
+	if err != nil {
+		return nil, fmt.Errorf("create aliyun sts client: %w", err)
+	}
+	assumeRequest := sts.CreateAssumeRoleRequest()
+	assumeRequest.Scheme = "https"
+	assumeRequest.RoleArn = roleARN
+	assumeRequest.RoleSessionName = "sandbox0-acr-" + naming.TeamKey(req.TeamID)
+	assumeRequest.Policy = policy
+	assumeRequest.DurationSeconds = requests.NewInteger64(int64(p.sessionDuration().Seconds()))
+	if externalID := strings.TrimSpace(p.cfg.ExternalID); externalID != "" {
+		assumeRequest.ExternalId = externalID
+	}
+	assumed, err := stsClient.AssumeRole(assumeRequest)
+	if err != nil {
+		return nil, fmt.Errorf("assume aliyun registry role: %w", err)
+	}
+	if assumed == nil || strings.TrimSpace(assumed.Credentials.AccessKeyId) == "" ||
+		strings.TrimSpace(assumed.Credentials.AccessKeySecret) == "" ||
+		strings.TrimSpace(assumed.Credentials.SecurityToken) == "" {
+		return nil, fmt.Errorf("assume aliyun registry role returned no credentials")
+	}
+
+	client, err := p.stsCRClient(
+		region,
+		assumed.Credentials.AccessKeyId,
+		assumed.Credentials.AccessKeySecret,
+		assumed.Credentials.SecurityToken,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create aliyun cr session client: %w", err)
+	}
+	tokenRequest := cr.CreateGetAuthorizationTokenRequest()
+	tokenRequest.Scheme = "https"
+	tokenRequest.InstanceId = instanceID
+	response, err := client.GetAuthorizationToken(tokenRequest)
 	if err != nil {
 		return nil, fmt.Errorf("get aliyun authorization token: %w", err)
 	}
@@ -59,22 +132,248 @@ func (p *aliyunProvider) GetPushCredentials(ctx context.Context, req PushCredent
 		return nil, fmt.Errorf("aliyun authorization response is empty")
 	}
 	if !response.GetAuthorizationTokenIsSuccess {
-		code := strings.TrimSpace(response.Code)
-		if code == "" {
-			code = "unknown_error"
-		}
-		return nil, fmt.Errorf("aliyun authorization request failed: %s", code)
+		return nil, fmt.Errorf("aliyun authorization request failed: %s", aliyunResponseCode(response.Code))
 	}
+
 	expiresAt := time.Time{}
 	if response.ExpireTime > 0 {
-		expiresAt = time.UnixMilli(int64(response.ExpireTime))
+		expiresAt = time.UnixMilli(int64(response.ExpireTime)).UTC()
+	}
+	if stsExpiresAt, parseErr := time.Parse(time.RFC3339, strings.TrimSpace(assumed.Credentials.Expiration)); parseErr == nil &&
+		(expiresAt.IsZero() || stsExpiresAt.Before(expiresAt)) {
+		expiresAt = stsExpiresAt
 	}
 
 	return &Credential{
 		Provider:     "aliyun",
-		PushRegistry: registry,
+		PushRegistry: registryHost + "/" + namespace,
 		Username:     response.TempUsername,
 		Password:     response.AuthorizationToken,
 		ExpiresAt:    timePtr(expiresAt),
+		TargetTag:    targetTag,
 	}, nil
+}
+
+func (p *aliyunProvider) baseCredentials(ctx context.Context) (string, string, error) {
+	accessKey := strings.TrimSpace(p.cfg.AccessKeyID)
+	secretKey := strings.TrimSpace(p.cfg.AccessKeySecret)
+	if accessKey != "" && secretKey != "" {
+		return accessKey, secretKey, nil
+	}
+	if strings.TrimSpace(p.cfg.CredentialsSecret) == "" {
+		return "", "", fmt.Errorf("aliyun credentials secret is required")
+	}
+	accessKey, err := p.secrets.readRequired(ctx, p.cfg.CredentialsSecret, p.cfg.AccessKeyKey, "accessKeyId", "aliyun access key")
+	if err != nil {
+		return "", "", err
+	}
+	secretKey, err = p.secrets.readRequired(ctx, p.cfg.CredentialsSecret, p.cfg.SecretKeyKey, "accessKeySecret", "aliyun secret key")
+	if err != nil {
+		return "", "", err
+	}
+	return accessKey, secretKey, nil
+}
+
+func (p *aliyunProvider) accessKeyCRClient(region, accessKey, secretKey string) (aliyunCRAPI, error) {
+	if p.newAccessKeyCRClient != nil {
+		return p.newAccessKeyCRClient(region, accessKey, secretKey)
+	}
+	return cr.NewClientWithAccessKey(region, accessKey, secretKey)
+}
+
+func (p *aliyunProvider) stsClient(region, accessKey, secretKey string) (aliyunSTSAPI, error) {
+	if p.newSTSClient != nil {
+		return p.newSTSClient(region, accessKey, secretKey)
+	}
+	return sts.NewClientWithAccessKey(region, accessKey, secretKey)
+}
+
+func (p *aliyunProvider) stsCRClient(region, accessKey, secretKey, securityToken string) (aliyunCRAPI, error) {
+	if p.newSTSCRClient != nil {
+		return p.newSTSCRClient(region, accessKey, secretKey, securityToken)
+	}
+	return cr.NewClientWithStsToken(region, accessKey, secretKey, securityToken)
+}
+
+func (p *aliyunProvider) sessionDuration() time.Duration {
+	seconds := p.cfg.SessionDuration
+	if seconds == 0 {
+		return defaultAliyunRegistrySessionDuration
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func resolveAliyunTarget(teamID, targetImage string) (repository, tag string, err error) {
+	repository = naming.TeamImageRepositoryPrefix(teamID)
+	if repository == "" {
+		return "", "", fmt.Errorf("%w: aliyun target image requires team id", ErrInvalidTargetImage)
+	}
+	trimmedTarget := strings.TrimSpace(targetImage)
+	if trimmedTarget == "" {
+		return repository, "", nil
+	}
+	named, err := distref.ParseNormalizedNamed(trimmedTarget)
+	if err != nil {
+		return "", "", fmt.Errorf("%w: invalid aliyun target image: %v", ErrInvalidTargetImage, err)
+	}
+	if _, ok := named.(distref.Digested); ok {
+		return "", "", fmt.Errorf("%w: aliyun target image must use a tag, not a digest", ErrInvalidTargetImage)
+	}
+	named = distref.TagNameOnly(named)
+	canonical := named.String()
+	logicalRepository := distref.Path(named)
+	firstSegment, _, _ := strings.Cut(logicalRepository, "/")
+	if strings.HasPrefix(firstSegment, "t-") && firstSegment != repository {
+		return "", "", fmt.Errorf("%w: target image %q is outside team repository %q", ErrInvalidTargetImage, targetImage, repository)
+	}
+	logicalTag := "latest"
+	if tagged, ok := named.(distref.Tagged); ok {
+		logicalTag = tagged.Tag()
+	}
+	prefix := sanitizeAliyunTagPart(path.Base(logicalRepository) + "-" + logicalTag)
+	if len(prefix) > 96 {
+		prefix = prefix[:96]
+	}
+	digest := sha256.Sum256([]byte(canonical))
+	return repository, prefix + "-" + hex.EncodeToString(digest[:6]), nil
+}
+
+func sanitizeAliyunTagPart(value string) string {
+	var builder strings.Builder
+	lastSeparator := false
+	for _, char := range strings.ToLower(strings.TrimSpace(value)) {
+		if unicode.IsLetter(char) || unicode.IsDigit(char) || char == '.' || char == '_' {
+			builder.WriteRune(char)
+			lastSeparator = false
+			continue
+		}
+		if !lastSeparator && builder.Len() > 0 {
+			builder.WriteByte('-')
+			lastSeparator = true
+		}
+	}
+	result := strings.Trim(builder.String(), "-._")
+	if result == "" {
+		return "image"
+	}
+	return result
+}
+
+func buildAliyunRegistrySessionPolicy(region, accountID, instanceID, namespace, repository string) (string, error) {
+	for description, value := range map[string]string{
+		"aliyun region":      region,
+		"aliyun account id":  accountID,
+		"aliyun instance id": instanceID,
+		"aliyun namespace":   namespace,
+		"aliyun repository":  repository,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return "", fmt.Errorf("%s is required for registry session policy", description)
+		}
+	}
+	repositoryARN := fmt.Sprintf(
+		"acs:cr:%s:%s:repository/%s/%s/%s",
+		strings.TrimSpace(region),
+		strings.TrimSpace(accountID),
+		strings.TrimSpace(instanceID),
+		strings.Trim(strings.TrimSpace(namespace), "/"),
+		strings.Trim(strings.TrimSpace(repository), "/"),
+	)
+	policy := map[string]any{
+		"Version": "1",
+		"Statement": []map[string]any{
+			{
+				"Effect":   "Allow",
+				"Action":   []string{"cr:GetAuthorizationToken"},
+				"Resource": "*",
+			},
+			{
+				"Effect":   "Allow",
+				"Action":   []string{"cr:PushRepository", "cr:PullRepository"},
+				"Resource": repositoryARN,
+			},
+		},
+	}
+	data, err := json.Marshal(policy)
+	if err != nil {
+		return "", fmt.Errorf("marshal aliyun registry session policy: %w", err)
+	}
+	return string(data), nil
+}
+
+func parseAliyunAccountIDFromRoleARN(roleARN string) (string, error) {
+	parts := strings.Split(strings.TrimSpace(roleARN), ":")
+	if len(parts) != 5 || parts[0] != "acs" || parts[1] != "ram" || parts[2] != "" ||
+		strings.TrimSpace(parts[3]) == "" || !strings.HasPrefix(parts[4], "role/") {
+		return "", fmt.Errorf("aliyun registry assumeRoleArn is invalid")
+	}
+	return strings.TrimSpace(parts[3]), nil
+}
+
+func ensureAliyunRepository(client aliyunCRAPI, instanceID, namespace, repository string) error {
+	request := cr.CreateGetRepositoryRequest()
+	request.Scheme = "https"
+	request.InstanceId = instanceID
+	request.RepoNamespaceName = namespace
+	request.RepoName = repository
+	response, err := client.GetRepository(request)
+	if err == nil && response != nil && response.GetRepositoryIsSuccess {
+		return nil
+	}
+	if err == nil && response != nil && !aliyunCodeMeansNotFound(response.Code) {
+		return fmt.Errorf("get aliyun repository %q failed: %s", repository, aliyunResponseCode(response.Code))
+	}
+	if err != nil && !aliyunErrorMeansNotFound(err) {
+		return fmt.Errorf("get aliyun repository %q: %w", repository, err)
+	}
+
+	createRequest := cr.CreateCreateRepositoryRequest()
+	createRequest.Scheme = "https"
+	createRequest.InstanceId = instanceID
+	createRequest.RepoNamespaceName = namespace
+	createRequest.RepoName = repository
+	createRequest.RepoType = "PRIVATE"
+	createRequest.Summary = "Sandbox0 team template images"
+	createRequest.Detail = "Managed by Sandbox0."
+	created, createErr := client.CreateRepository(createRequest)
+	if createErr != nil {
+		if aliyunErrorMeansAlreadyExists(createErr) {
+			return nil
+		}
+		return fmt.Errorf("create aliyun repository %q: %w", repository, createErr)
+	}
+	if created == nil {
+		return fmt.Errorf("create aliyun repository %q returned no response", repository)
+	}
+	if !created.CreateRepositoryIsSuccess && !aliyunCodeMeansAlreadyExists(created.Code) {
+		return fmt.Errorf("create aliyun repository %q failed: %s", repository, aliyunResponseCode(created.Code))
+	}
+	return nil
+}
+
+func aliyunErrorMeansNotFound(err error) bool {
+	var serverErr *aliyunerrors.ServerError
+	return errors.As(err, &serverErr) && (serverErr.HttpStatus() == 404 || aliyunCodeMeansNotFound(serverErr.ErrorCode()))
+}
+
+func aliyunErrorMeansAlreadyExists(err error) bool {
+	var serverErr *aliyunerrors.ServerError
+	return errors.As(err, &serverErr) && aliyunCodeMeansAlreadyExists(serverErr.ErrorCode())
+}
+
+func aliyunCodeMeansNotFound(code string) bool {
+	normalized := strings.ToUpper(strings.TrimSpace(code))
+	return strings.Contains(normalized, "NOT_EXIST") || strings.Contains(normalized, "NOT_FOUND") || normalized == "404"
+}
+
+func aliyunCodeMeansAlreadyExists(code string) bool {
+	normalized := strings.ToUpper(strings.TrimSpace(code))
+	return strings.Contains(normalized, "ALREADY_EXIST") || strings.Contains(normalized, "ALREADYEXIST") || strings.Contains(normalized, "EXISTS")
+}
+
+func aliyunResponseCode(code string) string {
+	if value := strings.TrimSpace(code); value != "" {
+		return value
+	}
+	return "unknown_error"
 }

--- a/pkg/registry/aliyun_test.go
+++ b/pkg/registry/aliyun_test.go
@@ -1,0 +1,171 @@
+package registry
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	cr "github.com/aliyun/alibaba-cloud-sdk-go/services/cr_ee"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/sts"
+	"github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+)
+
+func TestAliyunProviderReturnsRepositoryScopedReferences(t *testing.T) {
+	t.Parallel()
+
+	management := &fakeAliyunCRClient{
+		getRepositoryResponse:    &cr.GetRepositoryResponse{GetRepositoryIsSuccess: false, Code: "REPO_NOT_EXIST"},
+		createRepositoryResponse: &cr.CreateRepositoryResponse{CreateRepositoryIsSuccess: true},
+	}
+	session := &fakeAliyunCRClient{
+		tokenResponse: &cr.GetAuthorizationTokenResponse{
+			GetAuthorizationTokenIsSuccess: true,
+			TempUsername:                   "cr_temp_user",
+			AuthorizationToken:             "secret-token",
+			ExpireTime:                     time.Now().Add(12 * time.Hour).UnixMilli(),
+		},
+	}
+	stsClient := &fakeAliyunSTSClient{
+		response: &sts.AssumeRoleResponse{Credentials: sts.Credentials{
+			AccessKeyId:     "sts-ak",
+			AccessKeySecret: "sts-sk",
+			SecurityToken:   "sts-token",
+			Expiration:      time.Now().Add(6 * time.Hour).UTC().Format(time.RFC3339),
+		}},
+	}
+	base := &aliyunProvider{
+		cfg: config.RegistryAliyunConfig{
+			Registry:        "registry.example.com",
+			Namespace:       "sandbox0",
+			Region:          "us-east-1",
+			InstanceID:      "cri-instance",
+			AssumeRoleARN:   "acs:ram::123456789012:role/sandbox0-acr-upload",
+			AccessKeyID:     "base-ak",
+			AccessKeySecret: "base-sk",
+		},
+		newAccessKeyCRClient: func(string, string, string) (aliyunCRAPI, error) { return management, nil },
+		newSTSClient:         func(string, string, string) (aliyunSTSAPI, error) { return stsClient, nil },
+		newSTSCRClient:       func(string, string, string, string) (aliyunCRAPI, error) { return session, nil },
+	}
+	provider := &providerWithPullRegistry{base: base, pullRegistry: "registry-vpc.example.com/sandbox0"}
+
+	credential, err := provider.GetPushCredentials(t.Context(), PushCredentialsRequest{
+		TeamID:      "team-1",
+		TargetImage: "probe:test",
+	})
+	if err != nil {
+		t.Fatalf("GetPushCredentials() error = %v", err)
+	}
+	repository := naming.TeamImageRepositoryPrefix("team-1")
+	if got, want := credential.PushRegistry, "registry.example.com/sandbox0/"+repository; got != want {
+		t.Fatalf("PushRegistry = %q, want %q", got, want)
+	}
+	if got, want := credential.PullRegistry, "registry-vpc.example.com/sandbox0/"+repository; got != want {
+		t.Fatalf("PullRegistry = %q, want %q", got, want)
+	}
+	if !strings.HasPrefix(credential.PushImage, credential.PushRegistry+":probe-test-") {
+		t.Fatalf("PushImage = %q", credential.PushImage)
+	}
+	if got, want := credential.PullImage, credential.PullRegistry+":"+credential.TargetTag; got != want {
+		t.Fatalf("PullImage = %q, want %q", got, want)
+	}
+	if management.created == nil || management.created.RepoName != repository || management.created.RepoNamespaceName != "sandbox0" {
+		t.Fatalf("created repository = %#v", management.created)
+	}
+	if stsClient.request == nil {
+		t.Fatal("AssumeRole request was not recorded")
+	}
+	if !strings.Contains(stsClient.request.Policy, "repository/cri-instance/sandbox0/"+repository) {
+		t.Fatalf("session policy does not scope repository: %s", stsClient.request.Policy)
+	}
+}
+
+func TestBuildAliyunRegistrySessionPolicy(t *testing.T) {
+	t.Parallel()
+
+	policy, err := buildAliyunRegistrySessionPolicy("us-east-1", "123456789012", "cri-1", "sandbox0", "t-team")
+	if err != nil {
+		t.Fatalf("buildAliyunRegistrySessionPolicy() error = %v", err)
+	}
+	var decoded struct {
+		Version   string `json:"Version"`
+		Statement []struct {
+			Action   []string `json:"Action"`
+			Resource string   `json:"Resource"`
+		} `json:"Statement"`
+	}
+	if err := json.Unmarshal([]byte(policy), &decoded); err != nil {
+		t.Fatalf("unmarshal policy: %v", err)
+	}
+	if decoded.Version != "1" || len(decoded.Statement) != 2 {
+		t.Fatalf("unexpected policy %#v", decoded)
+	}
+	if got, want := decoded.Statement[1].Resource, "acs:cr:us-east-1:123456789012:repository/cri-1/sandbox0/t-team"; got != want {
+		t.Fatalf("repository resource = %q, want %q", got, want)
+	}
+}
+
+func TestResolveAliyunTarget(t *testing.T) {
+	t.Parallel()
+
+	repository, tag, err := resolveAliyunTarget("team-1", "probe:test")
+	if err != nil {
+		t.Fatalf("resolveAliyunTarget() error = %v", err)
+	}
+	if repository != naming.TeamImageRepositoryPrefix("team-1") {
+		t.Fatalf("repository = %q", repository)
+	}
+	if !strings.HasPrefix(tag, "probe-test-") || len(tag) > 128 {
+		t.Fatalf("tag = %q", tag)
+	}
+	_, sameTag, err := resolveAliyunTarget("team-1", "probe:test")
+	if err != nil || sameTag != tag {
+		t.Fatalf("target mapping is not deterministic: %q, %v", sameTag, err)
+	}
+	if _, _, err := resolveAliyunTarget("team-1", "t-other/probe:test"); err == nil {
+		t.Fatal("cross-team target did not fail")
+	}
+	repositoryWithoutTarget, tagWithoutTarget, err := resolveAliyunTarget("team-1", "")
+	if err != nil {
+		t.Fatalf("resolveAliyunTarget() without target error = %v", err)
+	}
+	if repositoryWithoutTarget != repository || tagWithoutTarget != "" {
+		t.Fatalf("targetless mapping = %q, %q", repositoryWithoutTarget, tagWithoutTarget)
+	}
+}
+
+type fakeAliyunCRClient struct {
+	getRepositoryResponse    *cr.GetRepositoryResponse
+	getRepositoryError       error
+	createRepositoryResponse *cr.CreateRepositoryResponse
+	createRepositoryError    error
+	tokenResponse            *cr.GetAuthorizationTokenResponse
+	tokenError               error
+	created                  *cr.CreateRepositoryRequest
+}
+
+func (f *fakeAliyunCRClient) GetRepository(*cr.GetRepositoryRequest) (*cr.GetRepositoryResponse, error) {
+	return f.getRepositoryResponse, f.getRepositoryError
+}
+
+func (f *fakeAliyunCRClient) CreateRepository(request *cr.CreateRepositoryRequest) (*cr.CreateRepositoryResponse, error) {
+	f.created = request
+	return f.createRepositoryResponse, f.createRepositoryError
+}
+
+func (f *fakeAliyunCRClient) GetAuthorizationToken(*cr.GetAuthorizationTokenRequest) (*cr.GetAuthorizationTokenResponse, error) {
+	return f.tokenResponse, f.tokenError
+}
+
+type fakeAliyunSTSClient struct {
+	response *sts.AssumeRoleResponse
+	err      error
+	request  *sts.AssumeRoleRequest
+}
+
+func (f *fakeAliyunSTSClient) AssumeRole(request *sts.AssumeRoleRequest) (*sts.AssumeRoleResponse, error) {
+	f.request = request
+	return f.response, f.err
+}

--- a/pkg/registry/provider.go
+++ b/pkg/registry/provider.go
@@ -19,9 +19,12 @@ type Credential struct {
 	Provider     string     `json:"provider"`
 	PushRegistry string     `json:"pushRegistry"`
 	PullRegistry string     `json:"pullRegistry,omitempty"`
+	PushImage    string     `json:"pushImage,omitempty"`
+	PullImage    string     `json:"pullImage,omitempty"`
 	Username     string     `json:"username"`
 	Password     string     `json:"password"`
 	ExpiresAt    *time.Time `json:"expiresAt,omitempty"`
+	TargetTag    string     `json:"-"`
 }
 
 // PushCredentialsRequest describes the image push the caller is preparing.
@@ -124,6 +127,10 @@ func (p *providerWithPullRegistry) GetPushCredentials(ctx context.Context, req P
 	if strings.TrimSpace(req.TeamID) != "" {
 		creds.PushRegistry = naming.TeamScopedImageRegistry(creds.PushRegistry, req.TeamID)
 		creds.PullRegistry = naming.TeamScopedImageRegistry(creds.PullRegistry, req.TeamID)
+	}
+	if strings.TrimSpace(creds.TargetTag) != "" {
+		creds.PushImage = creds.PushRegistry + ":" + creds.TargetTag
+		creds.PullImage = creds.PullRegistry + ":" + creds.TargetTag
 	}
 	return creds, nil
 }

--- a/regional-gateway/pkg/http/handlers_registry_test.go
+++ b/regional-gateway/pkg/http/handlers_registry_test.go
@@ -66,6 +66,10 @@ func TestRegistryCredentialsRequireRegistryWritePermission(t *testing.T) {
 		if got := registrySpy.callCount(); got != 1 {
 			t.Fatalf("registry call count = %d, want 1", got)
 		}
+		if body := rec.Body.String(); !strings.Contains(body, `"pushImage":"registry.example.com/t-team:my-app-v1"`) ||
+			!strings.Contains(body, `"pullImage":"registry-vpc.example.com/t-team:my-app-v1"`) {
+			t.Fatalf("response does not contain complete image references: %s", body)
+		}
 	})
 
 	t.Run("allowed with developer role", func(t *testing.T) {
@@ -155,6 +159,8 @@ func (s *registryProviderSpy) GetPushCredentials(_ context.Context, req registry
 	return &registryprovider.Credential{
 		Provider:     "builtin",
 		PushRegistry: "registry.example.com",
+		PushImage:    "registry.example.com/t-team:my-app-v1",
+		PullImage:    "registry-vpc.example.com/t-team:my-app-v1",
 		Username:     "user",
 		Password:     "password",
 	}, nil


### PR DESCRIPTION
## What changed

- provision one private Aliyun ACR repository per Sandbox0 team on demand
- mint six-hour STS sessions restricted to the exact team repository
- return complete provider-specific push and pull image references
- keep customer pushes on the public endpoint and manager/node traffic on the VPC endpoint
- update CLI-facing API docs, tenant image validation, and provider tests

## Root cause

The existing Aliyun provider returned an ACR temporary password but did not include the fixed ACR namespace, provision team repositories, or scope the token to one repository. The generic image path composition also produced an invalid extra repository level for ACR.

## Impact

External customers can push private template images without VPC access. Issued credentials cannot access another team's repository, while Sandbox0 services continue to publish and pull through the VPC hostname.

## Validation

- `go test ./pkg/registry ./pkg/naming ./manager/pkg/templateimage ./manager/pkg/http ./regional-gateway/pkg/http ./infra-operator/internal/controller/services/registry ./infra-operator/internal/plan`
- full non-E2E package tests passed; the local E2E package requires the remote kind environment
- generated OpenAPI and CRD artifacts refreshed

