### PR TITLE
fix: allow slow sandbox image startup

### DIFF
--- a/infra-operator/api/config/manager.go
+++ b/infra-operator/api/config/manager.go
@@ -12,6 +12,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// DefaultRuntimeReadyTimeout leaves enough time for large sandbox images to
+	// download and unpack before a cold claim is abandoned.
+	DefaultRuntimeReadyTimeout = 5 * time.Minute
+	// IdlePodRepairGraceBuffer prevents the warm-pool repair loop from racing a
+	// claim that is still inside its runtime readiness window.
+	IdlePodRepairGraceBuffer = 30 * time.Second
+)
+
 // ManagerLeaderElectionNameEnv identifies the Lease name shared by manager replicas.
 const ManagerLeaderElectionNameEnv = "MANAGER_LEADER_ELECTION_NAME"
 
@@ -178,8 +187,10 @@ type ManagerConfig struct {
 	// +optional
 	// +kubebuilder:default="15s"
 	CtldClientTimeout metav1.Duration `yaml:"ctld_client_timeout" json:"-"`
+	// RuntimeReadyTimeout bounds sandbox pod startup, including image download,
+	// unpack, runtime initialization, and readiness observation.
 	// +optional
-	// +kubebuilder:default="90s"
+	// +kubebuilder:default="5m"
 	RuntimeReadyTimeout metav1.Duration `yaml:"runtime_ready_timeout" json:"runtimeReadyTimeout"`
 	// +optional
 	// +kubebuilder:default="30s"
@@ -578,6 +589,21 @@ func LoadManagerConfig() *ManagerConfig {
 	applySandboxObservabilityProducerDefaults(cfg)
 	applyPodTeardownDefaults(cfg)
 	return cfg
+}
+
+// EffectiveRuntimeReadyTimeout normalizes unset and legacy short values to the
+// minimum startup window supported by manager controllers.
+func EffectiveRuntimeReadyTimeout(configured time.Duration) time.Duration {
+	if configured < DefaultRuntimeReadyTimeout {
+		return DefaultRuntimeReadyTimeout
+	}
+	return configured
+}
+
+// IdlePodRepairGracePeriod keeps warm-pool repair behind the runtime readiness
+// deadline so a slow image pull is not mistaken for an unhealthy idle pod.
+func IdlePodRepairGracePeriod(runtimeReadyTimeout time.Duration) time.Duration {
+	return EffectiveRuntimeReadyTimeout(runtimeReadyTimeout) + IdlePodRepairGraceBuffer
 }
 
 func applyPodTeardownDefaults(cfg *ManagerConfig) {

--- a/infra-operator/api/config/manager_test.go
+++ b/infra-operator/api/config/manager_test.go
@@ -4,7 +4,33 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
+
+func TestEffectiveRuntimeReadyTimeout(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured time.Duration
+		want       time.Duration
+	}{
+		{name: "unset", want: 5 * time.Minute},
+		{name: "legacy short value", configured: 90 * time.Second, want: 5 * time.Minute},
+		{name: "longer override", configured: 10 * time.Minute, want: 10 * time.Minute},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := EffectiveRuntimeReadyTimeout(test.configured); got != test.want {
+				t.Fatalf("EffectiveRuntimeReadyTimeout(%s) = %s, want %s", test.configured, got, test.want)
+			}
+		})
+	}
+}
+
+func TestIdlePodRepairGracePeriodFollowsRuntimeReadyTimeout(t *testing.T) {
+	if got, want := IdlePodRepairGracePeriod(10*time.Minute), 10*time.Minute+30*time.Second; got != want {
+		t.Fatalf("IdlePodRepairGracePeriod() = %s, want %s", got, want)
+	}
+}
 
 func TestLoadManagerConfigPreservesDefaultTeamQuotas(t *testing.T) {
 	dir := t.TempDir()

--- a/infra-operator/api/v1alpha1/service_api_config_types.go
+++ b/infra-operator/api/v1alpha1/service_api_config_types.go
@@ -973,8 +973,10 @@ type ManagerConfig struct {
 	// +optional
 	// +kubebuilder:default="30s"
 	ProcdClientTimeout metav1.Duration `json:"procdClientTimeout,omitempty"`
+	// RuntimeReadyTimeout bounds sandbox pod startup, including image download,
+	// unpack, runtime initialization, and readiness observation.
 	// +optional
-	// +kubebuilder:default="90s"
+	// +kubebuilder:default="5m"
 	RuntimeReadyTimeout metav1.Duration `json:"runtimeReadyTimeout,omitempty"`
 	// +optional
 	// +kubebuilder:default="30s"

--- a/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
+++ b/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
@@ -3926,7 +3926,10 @@ spec:
                             default: 30s
                             type: string
                           runtimeReadyTimeout:
-                            default: 90s
+                            default: 5m
+                            description: |-
+                              RuntimeReadyTimeout bounds sandbox pod startup, including image download,
+                              unpack, runtime initialization, and readiness observation.
                             type: string
                           sandboxMaxMemory:
                             default: 32Gi

--- a/manager/cmd/manager/kubernetes.go
+++ b/manager/cmd/manager/kubernetes.go
@@ -142,6 +142,7 @@ func buildManagerInformerRuntime(
 		podLister,
 		nodeLister,
 		cfg.PodTeardown,
+		cfg.RuntimeReadyTimeout.Duration,
 		metrics,
 		logger,
 	)

--- a/manager/pkg/controller/cleanup_controller.go
+++ b/manager/pkg/controller/cleanup_controller.go
@@ -101,7 +101,7 @@ func NewCleanupController(
 		hardExpiredLister: hardExpiredLister,
 		logger:            logger,
 		interval:          interval,
-		teardown:          NewPodTeardownCoordinator(podLister, nil, config.PodTeardownConfig{}, nil, logger),
+		teardown:          NewPodTeardownCoordinator(podLister, nil, config.PodTeardownConfig{}, 0, nil, logger),
 	}
 }
 

--- a/manager/pkg/controller/pod_teardown_coordinator.go
+++ b/manager/pkg/controller/pod_teardown_coordinator.go
@@ -40,12 +40,13 @@ type forceDeleteReservation struct {
 // controllers. Node slots are released once deletion is visible in the Pod
 // cache, while replacement slots are released only when pool readiness grows.
 type PodTeardownCoordinator struct {
-	podLister  corelisters.PodLister
-	nodeLister corelisters.NodeLister
-	limits     config.PodTeardownConfig
-	metrics    *obsmetrics.ManagerMetrics
-	logger     *zap.Logger
-	now        func() time.Time
+	podLister                corelisters.PodLister
+	nodeLister               corelisters.NodeLister
+	limits                   config.PodTeardownConfig
+	metrics                  *obsmetrics.ManagerMetrics
+	logger                   *zap.Logger
+	now                      func() time.Time
+	idlePodRepairGracePeriod time.Duration
 
 	mu                      sync.Mutex
 	nodeReservations        map[string]teardownReservation
@@ -89,6 +90,7 @@ func NewPodTeardownCoordinator(
 	podLister corelisters.PodLister,
 	nodeLister corelisters.NodeLister,
 	limits config.PodTeardownConfig,
+	runtimeReadyTimeout time.Duration,
 	metrics *obsmetrics.ManagerMetrics,
 	logger *zap.Logger,
 ) *PodTeardownCoordinator {
@@ -97,16 +99,17 @@ func NewPodTeardownCoordinator(
 		logger = zap.NewNop()
 	}
 	return &PodTeardownCoordinator{
-		podLister:               podLister,
-		nodeLister:              nodeLister,
-		limits:                  limits,
-		metrics:                 metrics,
-		logger:                  logger,
-		now:                     time.Now,
-		nodeReservations:        make(map[string]teardownReservation),
-		replacementReservations: make(map[string]teardownReservation),
-		forceDeleteReservations: make(map[string]forceDeleteReservation),
-		poolReadyUIDs:           make(map[string]map[string]struct{}),
+		podLister:                podLister,
+		nodeLister:               nodeLister,
+		limits:                   limits,
+		metrics:                  metrics,
+		logger:                   logger,
+		now:                      time.Now,
+		idlePodRepairGracePeriod: config.IdlePodRepairGracePeriod(runtimeReadyTimeout),
+		nodeReservations:         make(map[string]teardownReservation),
+		replacementReservations:  make(map[string]teardownReservation),
+		forceDeleteReservations:  make(map[string]forceDeleteReservation),
+		poolReadyUIDs:            make(map[string]map[string]struct{}),
 	}
 }
 
@@ -154,7 +157,7 @@ func (c *PodTeardownCoordinator) Acquire(candidates []*corev1.Pod, reason string
 			terminatingByNode[pod.Spec.NodeName]++
 			terminatingTotal++
 		}
-		if isYoungIdleReplacement(pod, now) {
+		if isYoungIdleReplacement(pod, now, c.idlePodRepairGracePeriod) {
 			youngReplacementPressure++
 		}
 	}
@@ -602,14 +605,14 @@ func teardownUsesNode(pod *corev1.Pod) bool {
 	return pod != nil && pod.Spec.NodeName != "" && !pod.Spec.HostNetwork
 }
 
-func isYoungIdleReplacement(pod *corev1.Pod, now time.Time) bool {
+func isYoungIdleReplacement(pod *corev1.Pod, now time.Time, gracePeriod time.Duration) bool {
 	if pod == nil || pod.DeletionTimestamp != nil || pod.Labels[LabelPoolType] != PoolTypeIdle || IsHotClaimReservedPod(pod) || IsPodReady(pod) {
 		return false
 	}
 	if pod.CreationTimestamp.IsZero() {
 		return false
 	}
-	return now.Sub(pod.CreationTimestamp.Time) < unhealthyIdlePodRepairGracePeriod
+	return now.Sub(pod.CreationTimestamp.Time) < gracePeriod
 }
 
 func readyIdlePodUIDsForPool(pods []*corev1.Pod, poolKey string) map[string]struct{} {

--- a/manager/pkg/controller/pod_teardown_coordinator_test.go
+++ b/manager/pkg/controller/pod_teardown_coordinator_test.go
@@ -326,6 +326,7 @@ func newTeardownTestCoordinator(
 		corelisters.NewPodLister(podIndexer),
 		corelisters.NewNodeLister(nodeIndexer),
 		limits,
+		0,
 		nil,
 		zap.NewNop(),
 	)
@@ -347,7 +348,7 @@ func teardownTestPod(name, nodeName string, terminating bool) *corev1.Pod {
 			Name:              name,
 			Namespace:         "default",
 			UID:               types.UID("uid-" + name),
-			CreationTimestamp: metav1.NewTime(time.Now().Add(-unhealthyIdlePodRepairGracePeriod - time.Minute)),
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-config.IdlePodRepairGracePeriod(0) - time.Minute)),
 			Labels: map[string]string{
 				LabelTemplateID: "template-a",
 				LabelPoolType:   PoolTypeIdle,

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -84,9 +84,8 @@ const (
 	HotClaimReservationStateReady        = sandboxpod.HotClaimReservationStateReady
 	HotClaimCompletionProtocolRecordV2   = sandboxpod.HotClaimCompletionProtocolRecordV2
 
-	unhealthyIdlePodRepairGracePeriod = 2 * time.Minute
-	warmPoolRolloutRequeueAfter       = 10 * time.Second
-	claimedPodAnnotationRequeueAfter  = 2 * time.Second
+	warmPoolRolloutRequeueAfter      = 10 * time.Second
+	claimedPodAnnotationRequeueAfter = 2 * time.Second
 
 	warmPoolRolloutMaxUnavailablePercent   int32 = 10
 	warmPoolRolloutMaxUnavailableLimit     int32 = 10
@@ -872,6 +871,7 @@ func (pm *PoolManager) repairUnhealthyIdlePods(ctx context.Context, template *v1
 	}
 
 	now := time.Now()
+	gracePeriod := pm.teardownCoordinator().idlePodRepairGracePeriod
 	candidates := make([]*corev1.Pod, 0)
 	nextGraceCheck := time.Duration(0)
 	for _, pod := range pods {
@@ -881,14 +881,14 @@ func (pm *PoolManager) repairUnhealthyIdlePods(ctx context.Context, template *v1
 		if pod.Annotations[AnnotationTemplateSpecHash] != desiredTemplateHash {
 			continue
 		}
-		if shouldRepairUnhealthyIdlePod(pod, now) {
+		if shouldRepairUnhealthyIdlePod(pod, now, gracePeriod) {
 			candidates = append(candidates, pod)
 			continue
 		}
 		if pod.DeletionTimestamp != nil || IsPodReady(pod) || pod.CreationTimestamp.IsZero() {
 			continue
 		}
-		remaining := unhealthyIdlePodRepairGracePeriod - now.Sub(pod.CreationTimestamp.Time)
+		remaining := gracePeriod - now.Sub(pod.CreationTimestamp.Time)
 		if remaining > 0 && (nextGraceCheck <= 0 || remaining < nextGraceCheck) {
 			nextGraceCheck = remaining
 		}
@@ -934,12 +934,12 @@ func (pm *PoolManager) teardownCoordinator() *PodTeardownCoordinator {
 		// A missing node lister fails closed for scheduled Pods. This fallback is
 		// primarily useful to keep narrow controller tests safe; manager wiring
 		// always injects the shared, node-aware coordinator.
-		pm.teardown = NewPodTeardownCoordinator(pm.podLister, nil, config.PodTeardownConfig{}, nil, pm.logger)
+		pm.teardown = NewPodTeardownCoordinator(pm.podLister, nil, config.PodTeardownConfig{}, 0, nil, pm.logger)
 	}
 	return pm.teardown
 }
 
-func shouldRepairUnhealthyIdlePod(pod *corev1.Pod, now time.Time) bool {
+func shouldRepairUnhealthyIdlePod(pod *corev1.Pod, now time.Time, gracePeriod time.Duration) bool {
 	if pod == nil || pod.DeletionTimestamp != nil || IsHotClaimReservedPod(pod) || IsPodReady(pod) {
 		return false
 	}
@@ -950,11 +950,12 @@ func shouldRepairUnhealthyIdlePod(pod *corev1.Pod, now time.Time) bool {
 	if pod.CreationTimestamp.IsZero() {
 		return false
 	}
-	return now.Sub(pod.CreationTimestamp.Time) >= unhealthyIdlePodRepairGracePeriod
+	return now.Sub(pod.CreationTimestamp.Time) >= gracePeriod
 }
 
 func (pm *PoolManager) deleteUnhealthyIdlePodWithRetry(ctx context.Context, namespace, podName, desiredTemplateHash string) (bool, error) {
 	deleted := false
+	gracePeriod := pm.teardownCoordinator().idlePodRepairGracePeriod
 	retryErr := retry.OnError(retry.DefaultRetry, func(err error) bool {
 		return apierrors.IsConflict(err) || apierrors.IsInvalid(err)
 	}, func() error {
@@ -969,7 +970,7 @@ func (pm *PoolManager) deleteUnhealthyIdlePodWithRetry(ctx context.Context, name
 		if pod.Labels[LabelPoolType] != PoolTypeIdle ||
 			IsHotClaimReservedPod(pod) ||
 			pod.Annotations[AnnotationTemplateSpecHash] != desiredTemplateHash ||
-			!shouldRepairUnhealthyIdlePod(pod, time.Now()) {
+			!shouldRepairUnhealthyIdlePod(pod, time.Now(), gracePeriod) {
 			return nil
 		}
 

--- a/manager/pkg/controller/pool_manager_test.go
+++ b/manager/pkg/controller/pool_manager_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	config "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	managernaming "github.com/sandbox0-ai/sandbox0/manager/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
@@ -696,7 +697,7 @@ func TestRepairUnhealthyIdlePodsDeletesStuckCurrentHashIdlePod(t *testing.T) {
 			Namespace:         "default",
 			UID:               types.UID("uid-stuck"),
 			ResourceVersion:   "31",
-			CreationTimestamp: metav1.NewTime(time.Now().Add(-unhealthyIdlePodRepairGracePeriod - time.Second)),
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-config.IdlePodRepairGracePeriod(0) - time.Second)),
 			Labels: map[string]string{
 				LabelTemplateID: "template-a",
 				LabelPoolType:   PoolTypeIdle,
@@ -715,7 +716,7 @@ func TestRepairUnhealthyIdlePodsDeletesStuckCurrentHashIdlePod(t *testing.T) {
 			Namespace:         "default",
 			UID:               types.UID("uid-ready"),
 			ResourceVersion:   "32",
-			CreationTimestamp: metav1.NewTime(time.Now().Add(-unhealthyIdlePodRepairGracePeriod - time.Second)),
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-config.IdlePodRepairGracePeriod(0) - time.Second)),
 			Labels: map[string]string{
 				LabelTemplateID: "template-a",
 				LabelPoolType:   PoolTypeIdle,
@@ -814,7 +815,56 @@ func TestRepairUnhealthyIdlePodsKeepsRecentlyCreatedPod(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, deleteActions)
 	assert.Greater(t, requeueAfter, time.Duration(0))
-	assert.LessOrEqual(t, requeueAfter, unhealthyIdlePodRepairGracePeriod)
+	assert.LessOrEqual(t, requeueAfter, config.IdlePodRepairGracePeriod(0))
+}
+
+func TestRepairUnhealthyIdlePodsFollowsRuntimeReadyTimeout(t *testing.T) {
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "template-a", Namespace: "default"},
+	}
+	podAge := 5 * time.Minute
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "idle-pulling",
+			Namespace:         "default",
+			UID:               types.UID("uid-pulling"),
+			ResourceVersion:   "42",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-podAge)),
+			Labels: map[string]string{
+				LabelTemplateID: "template-a",
+				LabelPoolType:   PoolTypeIdle,
+			},
+			Annotations: map[string]string{AnnotationTemplateSpecHash: "new-hash"},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodPending},
+	}
+
+	client := fake.NewSimpleClientset(pod)
+	podIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	require.NoError(t, podIndexer.Add(pod))
+	podLister := corelisters.NewPodLister(podIndexer)
+	runtimeReadyTimeout := 10 * time.Minute
+	teardown := NewPodTeardownCoordinator(
+		podLister,
+		nil,
+		config.PodTeardownConfig{},
+		runtimeReadyTimeout,
+		nil,
+		zap.NewNop(),
+	)
+	pm := &PoolManager{
+		k8sClient: client,
+		podLister: podLister,
+		recorder:  record.NewFakeRecorder(10),
+		logger:    zap.NewNop(),
+		teardown:  teardown,
+	}
+
+	requeueAfter, err := pm.repairUnhealthyIdlePods(context.Background(), template, "new-hash")
+	require.NoError(t, err)
+	assert.Empty(t, client.Actions())
+	want := config.IdlePodRepairGracePeriod(runtimeReadyTimeout) - podAge
+	assert.InDelta(t, want.Seconds(), requeueAfter.Seconds(), 1)
 }
 
 func TestReconcileReplicaSetTemplateUpdatesHash(t *testing.T) {

--- a/manager/pkg/service/sandbox_runtime_control.go
+++ b/manager/pkg/service/sandbox_runtime_control.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	managerconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	v1alpha1 "github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/appservice"
 	"github.com/sandbox0-ai/sandbox0/pkg/runtimecontrol"
@@ -145,7 +146,7 @@ func (s *SandboxService) waitForRuntimeAssignmentReady(
 ) (*corev1.Pod, error) {
 	timeout := s.config.RuntimeReadyTimeout
 	if timeout <= 0 {
-		timeout = defaultPodClaimReadyTimeout
+		timeout = managerconfig.DefaultRuntimeReadyTimeout
 	}
 	readyCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/manager/pkg/service/sandbox_service.go
+++ b/manager/pkg/service/sandbox_service.go
@@ -41,7 +41,6 @@ var ErrQuotaExceeded = errors.New("quota exceeded")
 var ErrInvalidNetworkPolicy = errors.New("invalid network policy")
 var ErrSandboxCheckpointRequiresCtld = errors.New("sandbox checkpoint requires ctld")
 
-const defaultPodClaimReadyTimeout = 90 * time.Second
 const defaultSandboxRestoreTimeout = 5 * time.Minute
 
 // claimIdlePodBackoff is the retry backoff for claiming idle pods.

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -918,6 +918,11 @@ func TestWaitForPodNetworkIdentityReturnsOnDeleteOrTerminal(t *testing.T) {
 
 func TestWaitForPodNetworkIdentityTimesOut(t *testing.T) {
 	pod := newClaimTestPod("ns-a", "cold-pod", "template-a", false)
+	pod.Spec.NodeName = "node-a"
+	pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
+		Type:   corev1.PodScheduled,
+		Status: corev1.ConditionTrue,
+	})
 	indexer := newClaimTestPodIndexer(t, pod)
 	svc := &SandboxService{
 		podLister: corelisters.NewPodLister(indexer),
@@ -930,8 +935,33 @@ func TestWaitForPodNetworkIdentityTimesOut(t *testing.T) {
 	if err == nil {
 		t.Fatal("waitForPodNetworkIdentity() error = nil, want timeout")
 	}
-	if !strings.Contains(err.Error(), "network identity not ready") {
-		t.Fatalf("waitForPodNetworkIdentity() error = %v, want network identity timeout", err)
+	if !strings.Contains(err.Error(), "runtime setup is in progress") {
+		t.Fatalf("waitForPodNetworkIdentity() error = %v, want runtime setup attribution", err)
+	}
+	if strings.Contains(err.Error(), "pod IP is not assigned") {
+		t.Fatalf("waitForPodNetworkIdentity() error = %v, must not misattribute a pending runtime setup to Pod IP", err)
+	}
+}
+
+func TestPodNetworkIdentityPendingReasonReportsImagePull(t *testing.T) {
+	pod := newClaimTestPod("ns-a", "cold-pod", "template-a", false)
+	pod.Spec.NodeName = "node-a"
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name: "procd",
+		State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+			Reason: "ImagePullBackOff",
+		}},
+	}}
+
+	ready, reason := isPodNetworkIdentityReady(pod)
+	if ready {
+		t.Fatal("isPodNetworkIdentityReady() = true, want false")
+	}
+	if got, want := reason, "container image pull is pending: ImagePullBackOff"; got != want {
+		t.Fatalf("isPodNetworkIdentityReady() reason = %q, want %q", got, want)
+	}
+	if got, want := podNetworkIdentityReasonLabel(reason), "image_pull"; got != want {
+		t.Fatalf("podNetworkIdentityReasonLabel() = %q, want %q", got, want)
 	}
 }
 

--- a/manager/pkg/service/sandbox_service_pod.go
+++ b/manager/pkg/service/sandbox_service_pod.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	managerconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	v1alpha1 "github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
@@ -81,10 +82,7 @@ func (s *SandboxService) waitForPodClaimReady(ctx context.Context, namespace, na
 }
 
 func (s *SandboxService) waitForPodClaimReadyTracked(ctx context.Context, namespace, name string, lifecycle *podLifecycleStageTracker) (*corev1.Pod, error) {
-	timeout := s.config.RuntimeReadyTimeout
-	if timeout < defaultPodClaimReadyTimeout {
-		timeout = defaultPodClaimReadyTimeout
-	}
+	timeout := managerconfig.EffectiveRuntimeReadyTimeout(s.config.RuntimeReadyTimeout)
 
 	readyCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -153,10 +151,7 @@ func (s *SandboxService) waitForPodNetworkIdentity(ctx context.Context, template
 }
 
 func (s *SandboxService) waitForPodNetworkIdentityTracked(ctx context.Context, template, namespace, name string, lifecycle *podLifecycleStageTracker) (*corev1.Pod, error) {
-	timeout := s.config.RuntimeReadyTimeout
-	if timeout < defaultPodClaimReadyTimeout {
-		timeout = defaultPodClaimReadyTimeout
-	}
+	timeout := managerconfig.EffectiveRuntimeReadyTimeout(s.config.RuntimeReadyTimeout)
 
 	readyCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -217,11 +212,14 @@ func (s *SandboxService) waitForPodNetworkIdentityTracked(ctx context.Context, t
 	for {
 		select {
 		case <-readyCtx.Done():
-			if ctxErr := ctx.Err(); ctxErr != nil && !errors.Is(ctxErr, context.DeadlineExceeded) {
-				lastReason = ctxErr.Error()
-				s.observePodNetworkIdentityCheck("context", "canceled", lastReason)
-				tracker.observeFailure("canceled", lastReason)
-				return nil, fmt.Errorf("pod %s/%s network identity wait canceled: %w", namespace, name, ctxErr)
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				status := "canceled"
+				if errors.Is(ctxErr, context.DeadlineExceeded) {
+					status = "timeout"
+				}
+				s.observePodNetworkIdentityCheck("context", status, lastReason)
+				tracker.observeFailure(status, lastReason)
+				return nil, fmt.Errorf("pod %s/%s network identity wait ended before readiness: %s: %w", namespace, name, lastReason, ctxErr)
 			}
 			s.observePodNetworkIdentityCheck("informer", "timeout", lastReason)
 			tracker.observeFailure("timeout", lastReason)
@@ -284,6 +282,12 @@ func podNetworkIdentityReasonLabel(reason string) string {
 		return "not_found"
 	case strings.Contains(reason, "node is not assigned"):
 		return "node_unassigned"
+	case strings.Contains(reason, "image pull"):
+		return "image_pull"
+	case strings.Contains(reason, "runtime setup"):
+		return "runtime_setup"
+	case strings.Contains(reason, "sandbox networking completed"):
+		return "ip_unreported"
 	case strings.Contains(reason, "ip is not assigned"):
 		return "ip_unassigned"
 	case strings.Contains(reason, "phase is terminal"):
@@ -487,9 +491,40 @@ func isPodNetworkIdentityReady(pod *corev1.Pod) (bool, string) {
 		return false, "pod node is not assigned"
 	}
 	if strings.TrimSpace(pod.Status.PodIP) == "" {
-		return false, "pod IP is not assigned"
+		return false, podNetworkIdentityPendingReason(pod)
 	}
 	return true, ""
+}
+
+func podNetworkIdentityPendingReason(pod *corev1.Pod) string {
+	if reason := imagePullWaitingReason(pod.Status.InitContainerStatuses); reason != "" {
+		return fmt.Sprintf("container image pull is pending: %s", reason)
+	}
+	if reason := imagePullWaitingReason(pod.Status.ContainerStatuses); reason != "" {
+		return fmt.Sprintf("container image pull is pending: %s", reason)
+	}
+	if podConditionIsTrue(pod, corev1.PodReadyToStartContainers) {
+		return "pod IP is not reported after pod sandbox networking completed"
+	}
+	return "pod runtime setup is in progress (image pull, pod sandbox setup, or kubelet status synchronization)"
+}
+
+func imagePullWaitingReason(statuses []corev1.ContainerStatus) string {
+	for i := range statuses {
+		waiting := statuses[i].State.Waiting
+		if waiting == nil {
+			continue
+		}
+		reason := strings.TrimSpace(waiting.Reason)
+		normalized := strings.ToLower(reason)
+		if strings.Contains(normalized, "imagepull") ||
+			strings.Contains(normalized, "pullimage") ||
+			normalized == "registryunavailable" ||
+			normalized == "invalidimagename" {
+			return reason
+		}
+	}
+	return ""
 }
 
 func (s *SandboxService) isPodClaimReady(_ context.Context, pod *corev1.Pod) (bool, string) {


### PR DESCRIPTION
## What changed

- raise the sandbox runtime readiness default and minimum startup window from 90 seconds to 5 minutes
- derive warm-pool unhealthy pod repair grace from the same readiness timeout plus a 30-second buffer
- keep teardown replacement accounting aligned with the warm-pool repair window
- report image pull or runtime setup progress instead of misattributing a stale Pod status to an unassigned Pod IP
- regenerate the Sandbox0Infra CRD with the new default and description

## Root cause

Large image pulls can keep kubelet's synchronous `PullImage` operation busy after the pod sandbox has already been created. During that interval, the Pod informer may still expose a stale status without `PodIP`. Manager therefore timed out at 90 seconds with a misleading network identity error. Warm-pool repair independently recycled the same pod after a fixed 2 minutes, even when the configured runtime readiness window should allow the pull to continue.

## Impact

Cold claims now have at least 5 minutes to download, unpack, and initialize large images. Warm-pool pods are not considered unhealthy until the effective runtime readiness timeout plus 30 seconds. Timeout messages and metrics distinguish image pull/runtime setup from an actual missing IP after sandbox networking is ready.

## Validation

- `GOWORK=off go test ./manager/... ./infra-operator/...`
- `GOWORK=off go test -race ./infra-operator/api/config ./manager/pkg/controller ./manager/pkg/service`
- `make manifests`
- `git diff --check`
