### PR TITLE
Persist unbound portals across pause and resume

### DIFF
--- a/ctld/cmd/ctld/main.go
+++ b/ctld/cmd/ctld/main.go
@@ -371,7 +371,7 @@ func runPrimary(parent context.Context, options primaryRunOptions) error {
 	httpServer := newHTTPServer(httpAddr, combinedController{
 		Controller:  probeController,
 		Portal:      portalManager,
-		RootFS:      buildRootFSController(ctx, storageCfg, objectStoreRequestMeter, containerdRuntime, dbPool, ctldMetricsRegistry),
+		RootFS:      buildRootFSController(ctx, storageCfg, objectStoreRequestMeter, containerdRuntime, portalManager, dbPool, ctldMetricsRegistry),
 		ReadyCheck:  serviceReady,
 		HealthCheck: serviceHealthy,
 	})
@@ -601,6 +601,7 @@ func buildRootFSController(
 	storageCfg *apiconfig.StorageProxyConfig,
 	requestObserver objectstore.RequestObserver,
 	runtime *ctldrootfs.ContainerdRuntime,
+	portalBackings *ctldportal.Manager,
 	dbPool *pgxpool.Pool,
 	metricsRegistry prometheus.Registerer,
 ) rootFSHandler {
@@ -611,6 +612,7 @@ func buildRootFSController(
 	return ctldrootfs.NewController(ctldrootfs.Config{
 		Context:         ctx,
 		Runtime:         runtime,
+		PortalBackings:  portalBackings,
 		Store:           store,
 		WatchFenceRoot:  filepath.Join(portalRoot, "rootfs-watch-fences", strings.TrimSpace(haSlot)),
 		CaptureLeases:   rootfslease.NewRepository(dbPool),

--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -460,6 +461,134 @@ func (m *Manager) PublishPortal(ctx context.Context, req publishRequest) error {
 	return nil
 }
 
+// AttachRootFSBackings rebases every unbound portal for a Pod onto the
+// container overlay upper. Rootfs sync calls this before runtime activation;
+// bound SandboxVolumes keep their independent backing and are not changed.
+func (m *Manager) AttachRootFSBackings(ctx context.Context, podUID, upperRoot string) error {
+	if m == nil {
+		return fmt.Errorf("volume portal manager is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	podUID = strings.TrimSpace(podUID)
+	if podUID == "" {
+		return fmt.Errorf("pod_uid is required to attach rootfs portal backings")
+	}
+	upperRoot = filepath.Clean(strings.TrimSpace(upperRoot))
+	if upperRoot == "" || upperRoot == "." || !filepath.IsAbs(upperRoot) {
+		return fmt.Errorf("overlay upper root must be absolute")
+	}
+
+	m.mu.Lock()
+	keys := make([]string, 0)
+	for key, current := range m.portals {
+		if current != nil && current.podUID == podUID && current.volumeID == "" {
+			keys = append(keys, key)
+		}
+	}
+	m.mu.Unlock()
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		m.mu.Lock()
+		current := m.portals[key]
+		if current == nil || current.podUID != podUID || current.volumeID != "" {
+			m.mu.Unlock()
+			continue
+		}
+		session, ok := current.rootfsSession.(*rootFSBackedSession)
+		if !ok || session == nil {
+			m.mu.Unlock()
+			return fmt.Errorf("unbound volume portal %s has no rootfs-backed session", current.name)
+		}
+		oldRoot := filepath.Clean(current.rootfsBackingPath)
+		targetRoot, err := ensureRootFSBackingTarget(upperRoot, current.mountPath)
+		if err != nil {
+			m.mu.Unlock()
+			return fmt.Errorf("attach unbound volume portal %s: %w", current.name, err)
+		}
+		if oldRoot == targetRoot {
+			m.mu.Unlock()
+			continue
+		}
+		empty, err := rootFSBackingDirectoryEmpty(oldRoot)
+		if err != nil {
+			m.mu.Unlock()
+			return fmt.Errorf("inspect unbound volume portal %s staging root: %w", current.name, err)
+		}
+		if !empty {
+			m.mu.Unlock()
+			return fmt.Errorf("unbound volume portal %s received writes before rootfs sync attachment", current.name)
+		}
+		if err := session.RebaseRoot(targetRoot); err != nil {
+			m.mu.Unlock()
+			return fmt.Errorf("rebase unbound volume portal %s: %w", current.name, err)
+		}
+		current.rootfsBackingPath = targetRoot
+		if err := m.updateRecoveryManifest(ctx, recoveryManifest(current)); err != nil {
+			rollbackErr := session.RebaseRoot(oldRoot)
+			if rollbackErr == nil {
+				current.rootfsBackingPath = oldRoot
+			}
+			m.mu.Unlock()
+			return fmt.Errorf("persist unbound volume portal %s rootfs attachment: %w", current.name, errors.Join(err, rollbackErr))
+		}
+		m.mu.Unlock()
+		if err := os.Remove(oldRoot); err != nil && !errors.Is(err, os.ErrNotExist) && m.logger != nil {
+			m.logger.Warn("Failed to remove empty rootfs portal staging directory",
+				zap.String("podUID", podUID),
+				zap.String("portal", current.name),
+				zap.String("path", oldRoot),
+				zap.Error(err),
+			)
+		}
+	}
+	return nil
+}
+
+func ensureRootFSBackingTarget(upperRoot, mountPath string) (string, error) {
+	upperRoot = filepath.Clean(upperRoot)
+	mountPath = filepath.Clean(strings.TrimSpace(mountPath))
+	if !filepath.IsAbs(mountPath) || mountPath == string(filepath.Separator) {
+		return "", fmt.Errorf("portal mount path %q is not an absolute non-root path", mountPath)
+	}
+	relative := strings.TrimPrefix(mountPath, string(filepath.Separator))
+	target := filepath.Join(upperRoot, relative)
+	if target == upperRoot || !strings.HasPrefix(target, upperRoot+string(filepath.Separator)) {
+		return "", fmt.Errorf("portal mount path %q escapes overlay upper root", mountPath)
+	}
+	current := upperRoot
+	for _, component := range strings.Split(relative, string(filepath.Separator)) {
+		current = filepath.Join(current, component)
+		info, err := os.Lstat(current)
+		if errors.Is(err, os.ErrNotExist) {
+			if err := os.Mkdir(current, 0o755); err != nil && !errors.Is(err, os.ErrExist) {
+				return "", fmt.Errorf("create rootfs portal backing %s: %w", current, err)
+			}
+			info, err = os.Lstat(current)
+		}
+		if err != nil {
+			return "", fmt.Errorf("inspect rootfs portal backing %s: %w", current, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return "", fmt.Errorf("rootfs portal backing component %s is not a real directory", current)
+		}
+	}
+	return target, nil
+}
+
+func rootFSBackingDirectoryEmpty(root string) (bool, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return false, err
+	}
+	return len(entries) == 0, nil
+}
+
 func mountPortalFS(fs *volumefuse.FileSystem, targetPath string) (*fuseportal.Server, error) {
 	server, err := fuseportal.Mount(fs, targetPath, portalMountOptions())
 	if err != nil {
@@ -769,7 +898,7 @@ func (m *Manager) unpublishPortalContext(ctx context.Context, targetPath string,
 	if pm.rootfsSession != nil {
 		pm.rootfsSession.Close()
 	}
-	if !handoff && pm.rootfsBackingPath != "" {
+	if !handoff && m.ownsRootFSBackingPath(pm.rootfsBackingPath) {
 		if err := os.RemoveAll(pm.rootfsBackingPath); err != nil && firstErr == nil {
 			firstErr = err
 		}
@@ -2194,6 +2323,19 @@ func (m *Manager) unboundRootFSBackingPath(podUID, portalName string) string {
 		rootDir = m.rootDir
 	}
 	return filepath.Join(rootDir, "rootfs-portals", safePath(podUID), safePath(portalName))
+}
+
+func (m *Manager) ownsRootFSBackingPath(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	rootDir := defaultRootDir
+	if m != nil && strings.TrimSpace(m.rootDir) != "" {
+		rootDir = m.rootDir
+	}
+	root := filepath.Join(filepath.Clean(rootDir), "rootfs-portals")
+	relative, err := filepath.Rel(root, filepath.Clean(path))
+	return err == nil && relative != "." && relative != "" && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
 }
 
 func (m *Manager) rootFSStatePath(key string) string {

--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -614,7 +614,9 @@ func portalMountOptions() *fuse.MountOptions {
 		EnableLocks:   true,
 		AllowOther:    os.Getuid() == 0,
 		DirectMount:   true,
-		MaxWrite:      256 * 1024,
+		// Match the rootfs FUSE path and amortize local portal round trips for
+		// sequential I/O. fuseportal reuses these larger request buffers.
+		MaxWrite: 1 << 20,
 		// Linux 6.17 rejects ALLOW_IDMAP without default_permissions.
 		DisabledCapabilities: fuse.CAP_ALLOW_IDMAP,
 	}

--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -462,9 +462,10 @@ func (m *Manager) PublishPortal(ctx context.Context, req publishRequest) error {
 }
 
 // AttachRootFSBackings rebases every unbound portal for a Pod onto the
-// container overlay upper. Rootfs sync calls this before runtime activation;
-// bound SandboxVolumes keep their independent backing and are not changed.
-func (m *Manager) AttachRootFSBackings(ctx context.Context, podUID, upperRoot string) error {
+// container's merged rootfs. Overlayfs keeps restored Head content visible and
+// directs new writes into the active upper. Rootfs sync calls this before
+// runtime activation; bound SandboxVolumes keep their independent backing.
+func (m *Manager) AttachRootFSBackings(ctx context.Context, podUID, mergedRoot string) error {
 	if m == nil {
 		return fmt.Errorf("volume portal manager is required")
 	}
@@ -475,9 +476,9 @@ func (m *Manager) AttachRootFSBackings(ctx context.Context, podUID, upperRoot st
 	if podUID == "" {
 		return fmt.Errorf("pod_uid is required to attach rootfs portal backings")
 	}
-	upperRoot = filepath.Clean(strings.TrimSpace(upperRoot))
-	if upperRoot == "" || upperRoot == "." || !filepath.IsAbs(upperRoot) {
-		return fmt.Errorf("overlay upper root must be absolute")
+	mergedRoot = filepath.Clean(strings.TrimSpace(mergedRoot))
+	if mergedRoot == "" || mergedRoot == "." || !filepath.IsAbs(mergedRoot) {
+		return fmt.Errorf("overlay merged root must be absolute")
 	}
 
 	m.mu.Lock()
@@ -506,7 +507,7 @@ func (m *Manager) AttachRootFSBackings(ctx context.Context, podUID, upperRoot st
 			return fmt.Errorf("unbound volume portal %s has no rootfs-backed session", current.name)
 		}
 		oldRoot := filepath.Clean(current.rootfsBackingPath)
-		targetRoot, err := ensureRootFSBackingTarget(upperRoot, current.mountPath)
+		targetRoot, err := ensureRootFSBackingTarget(mergedRoot, current.mountPath)
 		if err != nil {
 			m.mu.Unlock()
 			return fmt.Errorf("attach unbound volume portal %s: %w", current.name, err)
@@ -557,18 +558,18 @@ func rootFSPersistedPortal(current *portalMount, podUID string) bool {
 	return current.name != volumeportal.WebhookStatePortalName && current.mountPath != volumeportal.WebhookStateMountPath
 }
 
-func ensureRootFSBackingTarget(upperRoot, mountPath string) (string, error) {
-	upperRoot = filepath.Clean(upperRoot)
+func ensureRootFSBackingTarget(mergedRoot, mountPath string) (string, error) {
+	mergedRoot = filepath.Clean(mergedRoot)
 	mountPath = filepath.Clean(strings.TrimSpace(mountPath))
 	if !filepath.IsAbs(mountPath) || mountPath == string(filepath.Separator) {
 		return "", fmt.Errorf("portal mount path %q is not an absolute non-root path", mountPath)
 	}
 	relative := strings.TrimPrefix(mountPath, string(filepath.Separator))
-	target := filepath.Join(upperRoot, relative)
-	if target == upperRoot || !strings.HasPrefix(target, upperRoot+string(filepath.Separator)) {
-		return "", fmt.Errorf("portal mount path %q escapes overlay upper root", mountPath)
+	target := filepath.Join(mergedRoot, relative)
+	if target == mergedRoot || !strings.HasPrefix(target, mergedRoot+string(filepath.Separator)) {
+		return "", fmt.Errorf("portal mount path %q escapes overlay merged root", mountPath)
 	}
-	current := upperRoot
+	current := mergedRoot
 	for _, component := range strings.Split(relative, string(filepath.Separator)) {
 		current = filepath.Join(current, component)
 		info, err := os.Lstat(current)
@@ -647,7 +648,7 @@ func (m *Manager) RestorePortal(ctx context.Context, manifest RecoveryManifest, 
 	}
 	m.mu.Unlock()
 
-	if err := os.MkdirAll(manifest.RootFSBackingPath, 0o755); err != nil {
+	if err := m.prepareRecoveryRootFSBacking(manifest.RootFSBackingPath); err != nil {
 		return fmt.Errorf("restore rootfs portal backing directory: %w", err)
 	}
 	statePath := strings.TrimSpace(manifest.RootFSStatePath)
@@ -2343,6 +2344,24 @@ func (m *Manager) ownsRootFSBackingPath(path string) bool {
 	root := filepath.Join(filepath.Clean(rootDir), "rootfs-portals")
 	relative, err := filepath.Rel(root, filepath.Clean(path))
 	return err == nil && relative != "." && relative != "" && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}
+
+func (m *Manager) prepareRecoveryRootFSBacking(path string) error {
+	path = filepath.Clean(strings.TrimSpace(path))
+	if path == "" || path == "." || !filepath.IsAbs(path) {
+		return fmt.Errorf("rootfs portal backing path must be absolute")
+	}
+	if m.ownsRootFSBackingPath(path) {
+		return os.MkdirAll(path, 0o755)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("external rootfs portal backing %s is not a real directory", path)
+	}
+	return nil
 }
 
 func (m *Manager) rootFSStatePath(key string) string {

--- a/ctld/internal/ctld/portal/manager.go
+++ b/ctld/internal/ctld/portal/manager.go
@@ -483,7 +483,7 @@ func (m *Manager) AttachRootFSBackings(ctx context.Context, podUID, upperRoot st
 	m.mu.Lock()
 	keys := make([]string, 0)
 	for key, current := range m.portals {
-		if current != nil && current.podUID == podUID && current.volumeID == "" {
+		if rootFSPersistedPortal(current, podUID) {
 			keys = append(keys, key)
 		}
 	}
@@ -496,7 +496,7 @@ func (m *Manager) AttachRootFSBackings(ctx context.Context, podUID, upperRoot st
 		}
 		m.mu.Lock()
 		current := m.portals[key]
-		if current == nil || current.podUID != podUID || current.volumeID != "" {
+		if !rootFSPersistedPortal(current, podUID) {
 			m.mu.Unlock()
 			continue
 		}
@@ -548,6 +548,13 @@ func (m *Manager) AttachRootFSBackings(ctx context.Context, podUID, upperRoot st
 		}
 	}
 	return nil
+}
+
+func rootFSPersistedPortal(current *portalMount, podUID string) bool {
+	if current == nil || current.podUID != podUID || current.volumeID != "" {
+		return false
+	}
+	return current.name != volumeportal.WebhookStatePortalName && current.mountPath != volumeportal.WebhookStateMountPath
 }
 
 func ensureRootFSBackingTarget(upperRoot, mountPath string) (string, error) {

--- a/ctld/internal/ctld/portal/manager_shared_test.go
+++ b/ctld/internal/ctld/portal/manager_shared_test.go
@@ -12,6 +12,7 @@ import (
 	apiconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/volume"
 )
@@ -378,6 +379,33 @@ func TestAttachRootFSBackingsSkipsBoundVolumes(t *testing.T) {
 	mgr.portals[portalKey(pm.podUID, pm.name)] = pm
 	if err := mgr.AttachRootFSBackings(context.Background(), "pod-1", t.TempDir()); err != nil {
 		t.Fatalf("AttachRootFSBackings() error = %v", err)
+	}
+}
+
+func TestAttachRootFSBackingsSkipsRuntimeOwnedWebhookPortal(t *testing.T) {
+	mgr := NewManager(Config{RootDir: t.TempDir()})
+	staging := mgr.unboundRootFSBackingPath("pod-1", volumeportal.WebhookStatePortalName)
+	if err := os.MkdirAll(staging, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", staging, err)
+	}
+	marker := filepath.Join(staging, "runtime-state")
+	if err := os.WriteFile(marker, []byte("runtime"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", marker, err)
+	}
+	pm := &portalMount{
+		podUID:            "pod-1",
+		name:              volumeportal.WebhookStatePortalName,
+		mountPath:         volumeportal.WebhookStateMountPath,
+		rootfsBackingPath: staging,
+	}
+	mgr.portals[portalKey(pm.podUID, pm.name)] = pm
+
+	if err := mgr.AttachRootFSBackings(context.Background(), "pod-1", t.TempDir()); err != nil {
+		t.Fatalf("AttachRootFSBackings() error = %v", err)
+	}
+	payload, err := os.ReadFile(marker)
+	if err != nil || string(payload) != "runtime" {
+		t.Fatalf("runtime marker = %q, %v, want runtime", string(payload), err)
 	}
 }
 

--- a/ctld/internal/ctld/portal/manager_shared_test.go
+++ b/ctld/internal/ctld/portal/manager_shared_test.go
@@ -2,6 +2,7 @@ package portal
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -332,7 +333,7 @@ func TestAttachRootFSBackingsFailsClosedAfterEarlyPortalWrite(t *testing.T) {
 	}
 }
 
-func TestAttachRootFSBackingsRebasesUnboundPortalOntoOverlayUpper(t *testing.T) {
+func TestAttachRootFSBackingsRebasesUnboundPortalOntoMergedRoot(t *testing.T) {
 	mgr := NewManager(Config{RootDir: t.TempDir()})
 	// This test exercises attachment behavior independently from recovery-store
 	// validation; production portals have a FUSE INIT request in their manifest.
@@ -354,14 +355,25 @@ func TestAttachRootFSBackingsRebasesUnboundPortalOntoOverlayUpper(t *testing.T) 
 		rootfsSession:     session,
 	}
 	mgr.portals[portalKey(pm.podUID, pm.name)] = pm
-	upper := t.TempDir()
+	merged := t.TempDir()
+	want := filepath.Join(merged, "workspace")
+	if err := os.MkdirAll(want, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", want, err)
+	}
+	restored := filepath.Join(want, "restored.txt")
+	if err := os.WriteFile(restored, []byte("from-head"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", restored, err)
+	}
 
-	if err := mgr.AttachRootFSBackings(context.Background(), "pod-1", upper); err != nil {
+	if err := mgr.AttachRootFSBackings(context.Background(), "pod-1", merged); err != nil {
 		t.Fatalf("AttachRootFSBackings() error = %v", err)
 	}
-	want := filepath.Join(upper, "workspace")
 	if pm.rootfsBackingPath != want || session.rootPath() != want {
 		t.Fatalf("attached roots = %q/%q, want %q", pm.rootfsBackingPath, session.rootPath(), want)
+	}
+	payload, err := os.ReadFile(session.hostPath("restored.txt"))
+	if err != nil || string(payload) != "from-head" {
+		t.Fatalf("restored portal content = %q, %v, want from-head", string(payload), err)
 	}
 	if _, err := os.Stat(staging); !os.IsNotExist(err) {
 		t.Fatalf("staging root stat error = %v, want not exist", err)
@@ -406,6 +418,27 @@ func TestAttachRootFSBackingsSkipsRuntimeOwnedWebhookPortal(t *testing.T) {
 	payload, err := os.ReadFile(marker)
 	if err != nil || string(payload) != "runtime" {
 		t.Fatalf("runtime marker = %q, %v, want runtime", string(payload), err)
+	}
+}
+
+func TestPrepareRecoveryRootFSBackingDoesNotRecreateExternalPath(t *testing.T) {
+	mgr := NewManager(Config{RootDir: t.TempDir()})
+	external := filepath.Join(t.TempDir(), "task-root", "workspace")
+
+	err := mgr.prepareRecoveryRootFSBacking(external)
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("prepareRecoveryRootFSBacking() error = %v, want not exist", err)
+	}
+	if _, err := os.Stat(filepath.Dir(external)); !os.IsNotExist(err) {
+		t.Fatalf("external parent stat error = %v, want not exist", err)
+	}
+
+	owned := mgr.unboundRootFSBackingPath("pod-1", "workspace")
+	if err := mgr.prepareRecoveryRootFSBacking(owned); err != nil {
+		t.Fatalf("prepareRecoveryRootFSBacking(owned) error = %v", err)
+	}
+	if info, err := os.Stat(owned); err != nil || !info.IsDir() {
+		t.Fatalf("owned backing stat = %#v, %v, want directory", info, err)
 	}
 }
 

--- a/ctld/internal/ctld/portal/manager_shared_test.go
+++ b/ctld/internal/ctld/portal/manager_shared_test.go
@@ -166,6 +166,7 @@ func TestShutdownDrainsPublishedAndOwnerOnlyVolumes(t *testing.T) {
 	rootDir := t.TempDir()
 	var detachedTarget string
 	mgr := &Manager{
+		rootDir: rootDir,
 		staleMountCleaner: func(path string) error {
 			detachedTarget = path
 			return os.RemoveAll(path)
@@ -183,7 +184,7 @@ func TestShutdownDrainsPublishedAndOwnerOnlyVolumes(t *testing.T) {
 		podUID:            "pod-1",
 		name:              "workspace",
 		targetPath:        filepath.Join(rootDir, "target"),
-		rootfsBackingPath: filepath.Join(rootDir, "rootfs"),
+		rootfsBackingPath: filepath.Join(rootDir, "rootfs-portals", "pod-1", "workspace"),
 		volumeID:          "vol-portal",
 	}
 	mgr.portals[portalKey(pm.podUID, pm.name)] = pm
@@ -223,6 +224,160 @@ func TestShutdownDrainsPublishedAndOwnerOnlyVolumes(t *testing.T) {
 	}
 	if _, err := os.Stat(pm.rootfsBackingPath); !os.IsNotExist(err) {
 		t.Fatalf("rootfs backing stat error = %v, want not exist", err)
+	}
+}
+
+func TestUnpublishPortalPreservesOverlayAttachedRootFSBacking(t *testing.T) {
+	managerRoot := t.TempDir()
+	overlayRoot := filepath.Join(t.TempDir(), "upper", "workspace")
+	if err := os.MkdirAll(overlayRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", overlayRoot, err)
+	}
+	marker := filepath.Join(overlayRoot, "marker.txt")
+	if err := os.WriteFile(marker, []byte("persistent"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", marker, err)
+	}
+	session, err := newRootFSBackedSessionWithState(overlayRoot, "")
+	if err != nil {
+		t.Fatalf("newRootFSBackedSessionWithState() error = %v", err)
+	}
+	mgr := NewManager(Config{RootDir: managerRoot})
+	pm := &portalMount{
+		podUID:            "pod-1",
+		name:              "workspace",
+		targetPath:        filepath.Join(managerRoot, "target"),
+		rootfsBackingPath: overlayRoot,
+		rootfsSession:     session,
+	}
+	mgr.portals[portalKey(pm.podUID, pm.name)] = pm
+	mgr.portalsByTarget[pm.targetPath] = pm
+
+	if err := mgr.UnpublishPortal(pm.targetPath); err != nil {
+		t.Fatalf("UnpublishPortal() error = %v", err)
+	}
+	payload, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", marker, err)
+	}
+	if string(payload) != "persistent" {
+		t.Fatalf("marker content = %q, want persistent", string(payload))
+	}
+}
+
+func TestEnsureRootFSBackingTargetCreatesRealDirectories(t *testing.T) {
+	upper := t.TempDir()
+	target, err := ensureRootFSBackingTarget(upper, "/workspace/project")
+	if err != nil {
+		t.Fatalf("ensureRootFSBackingTarget() error = %v", err)
+	}
+	want := filepath.Join(upper, "workspace", "project")
+	if target != want {
+		t.Fatalf("target = %q, want %q", target, want)
+	}
+	info, err := os.Stat(target)
+	if err != nil || !info.IsDir() {
+		t.Fatalf("target directory stat = %#v, %v", info, err)
+	}
+}
+
+func TestEnsureRootFSBackingTargetRejectsSymlinkAncestor(t *testing.T) {
+	upper := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(upper, "workspace")); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+	if _, err := ensureRootFSBackingTarget(upper, "/workspace/project"); err == nil {
+		t.Fatal("ensureRootFSBackingTarget() error = nil, want symlink rejection")
+	}
+	if _, err := os.Stat(filepath.Join(outside, "project")); !os.IsNotExist(err) {
+		t.Fatalf("outside project stat error = %v, want not exist", err)
+	}
+}
+
+func TestAttachRootFSBackingsFailsClosedAfterEarlyPortalWrite(t *testing.T) {
+	mgr := NewManager(Config{RootDir: t.TempDir()})
+	staging := mgr.unboundRootFSBackingPath("pod-1", "workspace")
+	if err := os.MkdirAll(staging, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", staging, err)
+	}
+	marker := filepath.Join(staging, "early.txt")
+	if err := os.WriteFile(marker, []byte("early"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", marker, err)
+	}
+	session, err := newRootFSBackedSessionWithState(staging, "")
+	if err != nil {
+		t.Fatalf("newRootFSBackedSessionWithState() error = %v", err)
+	}
+	defer session.Close()
+	pm := &portalMount{
+		podUID:            "pod-1",
+		name:              "workspace",
+		mountPath:         "/workspace",
+		rootfsBackingPath: staging,
+		rootfsSession:     session,
+	}
+	mgr.portals[portalKey(pm.podUID, pm.name)] = pm
+
+	err = mgr.AttachRootFSBackings(context.Background(), "pod-1", t.TempDir())
+	if err == nil {
+		t.Fatal("AttachRootFSBackings() error = nil, want early-write rejection")
+	}
+	payload, readErr := os.ReadFile(marker)
+	if readErr != nil || string(payload) != "early" {
+		t.Fatalf("staging marker = %q, %v, want early", string(payload), readErr)
+	}
+	if session.rootPath() != staging {
+		t.Fatalf("session root = %q, want %q", session.rootPath(), staging)
+	}
+}
+
+func TestAttachRootFSBackingsRebasesUnboundPortalOntoOverlayUpper(t *testing.T) {
+	mgr := NewManager(Config{RootDir: t.TempDir()})
+	// This test exercises attachment behavior independently from recovery-store
+	// validation; production portals have a FUSE INIT request in their manifest.
+	mgr.recoveryStore = nil
+	staging := mgr.unboundRootFSBackingPath("pod-1", "workspace")
+	if err := os.MkdirAll(staging, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", staging, err)
+	}
+	session, err := newRootFSBackedSessionWithState(staging, "")
+	if err != nil {
+		t.Fatalf("newRootFSBackedSessionWithState() error = %v", err)
+	}
+	defer session.Close()
+	pm := &portalMount{
+		podUID:            "pod-1",
+		name:              "workspace",
+		mountPath:         "/workspace",
+		rootfsBackingPath: staging,
+		rootfsSession:     session,
+	}
+	mgr.portals[portalKey(pm.podUID, pm.name)] = pm
+	upper := t.TempDir()
+
+	if err := mgr.AttachRootFSBackings(context.Background(), "pod-1", upper); err != nil {
+		t.Fatalf("AttachRootFSBackings() error = %v", err)
+	}
+	want := filepath.Join(upper, "workspace")
+	if pm.rootfsBackingPath != want || session.rootPath() != want {
+		t.Fatalf("attached roots = %q/%q, want %q", pm.rootfsBackingPath, session.rootPath(), want)
+	}
+	if _, err := os.Stat(staging); !os.IsNotExist(err) {
+		t.Fatalf("staging root stat error = %v, want not exist", err)
+	}
+}
+
+func TestAttachRootFSBackingsSkipsBoundVolumes(t *testing.T) {
+	mgr := NewManager(Config{RootDir: t.TempDir()})
+	pm := &portalMount{
+		podUID:    "pod-1",
+		name:      "workspace",
+		mountPath: "/workspace",
+		volumeID:  "volume-1",
+	}
+	mgr.portals[portalKey(pm.podUID, pm.name)] = pm
+	if err := mgr.AttachRootFSBackings(context.Background(), "pod-1", t.TempDir()); err != nil {
+		t.Fatalf("AttachRootFSBackings() error = %v", err)
 	}
 }
 

--- a/ctld/internal/ctld/portal/manager_shared_test.go
+++ b/ctld/internal/ctld/portal/manager_shared_test.go
@@ -29,6 +29,9 @@ func TestPortalMountOptionsDisableUnsupportedIDMapCapability(t *testing.T) {
 	if opts.DisabledCapabilities&fuse.CAP_ALLOW_IDMAP == 0 {
 		t.Fatal("portal mount options enable FUSE_ALLOW_IDMAP without default_permissions")
 	}
+	if opts.MaxWrite != 1<<20 {
+		t.Fatalf("portal max write = %d, want %d", opts.MaxWrite, 1<<20)
+	}
 }
 
 func TestNewS0FSVolumeContextWiresStorageObserver(t *testing.T) {

--- a/ctld/internal/ctld/portal/rootfs_session.go
+++ b/ctld/internal/ctld/portal/rootfs_session.go
@@ -185,6 +185,17 @@ func (s *rootFSBackedSession) SetAttr(_ context.Context, req *pb.SetAttrRequest)
 	hostPath := s.hostPath(rel)
 	attr := req.GetAttr()
 	valid := req.GetValid()
+	info, err := os.Lstat(hostPath)
+	if err != nil {
+		return nil, mapRootFSBackedError(err)
+	}
+	isSymlink := info.Mode()&os.ModeSymlink != 0
+	if isSymlink && valid&fuse.FATTR_MODE != 0 {
+		return nil, syscall.EOPNOTSUPP
+	}
+	if isSymlink && valid&fuse.FATTR_SIZE != 0 {
+		return nil, syscall.EINVAL
+	}
 	if valid&fuse.FATTR_MODE != 0 {
 		if err := os.Chmod(hostPath, os.FileMode(attr.GetMode()&0o7777)); err != nil {
 			return nil, mapRootFSBackedError(err)
@@ -209,20 +220,29 @@ func (s *rootFSBackedSession) SetAttr(_ context.Context, req *pb.SetAttrRequest)
 		}
 	}
 	if valid&(fuse.FATTR_ATIME|fuse.FATTR_MTIME|fuse.FATTR_ATIME_NOW|fuse.FATTR_MTIME_NOW) != 0 {
-		now := time.Now()
-		atime := now
-		mtime := now
+		times := []unix.Timespec{
+			{Nsec: unix.UTIME_OMIT},
+			{Nsec: unix.UTIME_OMIT},
+		}
 		if valid&fuse.FATTR_ATIME != 0 {
-			atime = time.Unix(attr.GetAtimeSec(), attr.GetAtimeNsec())
+			times[0] = unix.Timespec{Sec: attr.GetAtimeSec(), Nsec: attr.GetAtimeNsec()}
+		} else if valid&fuse.FATTR_ATIME_NOW != 0 {
+			times[0].Nsec = unix.UTIME_NOW
 		}
 		if valid&fuse.FATTR_MTIME != 0 {
-			mtime = time.Unix(attr.GetMtimeSec(), attr.GetMtimeNsec())
+			times[1] = unix.Timespec{Sec: attr.GetMtimeSec(), Nsec: attr.GetMtimeNsec()}
+		} else if valid&fuse.FATTR_MTIME_NOW != 0 {
+			times[1].Nsec = unix.UTIME_NOW
 		}
-		if err := os.Chtimes(hostPath, atime, mtime); err != nil {
+		flags := 0
+		if isSymlink {
+			flags = unix.AT_SYMLINK_NOFOLLOW
+		}
+		if err := unix.UtimesNanoAt(unix.AT_FDCWD, hostPath, times, flags); err != nil {
 			return nil, mapRootFSBackedError(err)
 		}
 	}
-	info, err := os.Lstat(hostPath)
+	info, err = os.Lstat(hostPath)
 	if err != nil {
 		return nil, mapRootFSBackedError(err)
 	}

--- a/ctld/internal/ctld/portal/rootfs_session.go
+++ b/ctld/internal/ctld/portal/rootfs_session.go
@@ -501,6 +501,22 @@ func (s *rootFSBackedSession) Fsync(_ context.Context, req *pb.FsyncRequest) (*p
 	return &pb.Empty{}, nil
 }
 
+func (s *rootFSBackedSession) FsyncDir(_ context.Context, inode uint64) error {
+	rel, err := s.relForInode(inode)
+	if err != nil {
+		return err
+	}
+	handle, err := os.Open(s.hostPath(rel))
+	if err != nil {
+		return mapRootFSBackedError(err)
+	}
+	defer handle.Close()
+	if err := handle.Sync(); err != nil {
+		return mapRootFSBackedError(err)
+	}
+	return nil
+}
+
 func (s *rootFSBackedSession) Fallocate(_ context.Context, req *pb.FallocateRequest) (*pb.Empty, error) {
 	handle, release, err := s.handleForWrite(req.GetInode(), req.GetHandleId())
 	if err != nil {

--- a/ctld/internal/ctld/portal/rootfs_session.go
+++ b/ctld/internal/ctld/portal/rootfs_session.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -27,7 +28,7 @@ const rootFSBackedSessionRoot = ""
 const rootFSRecoveryDir = ".sandbox0-ha"
 
 type rootFSBackedSession struct {
-	root string
+	root atomic.Value
 
 	mu           sync.Mutex
 	nextInode    uint64
@@ -57,7 +58,6 @@ type rootFSStateJournal struct {
 
 func newRootFSBackedSessionWithState(root, statePath string) (*rootFSBackedSession, error) {
 	session := &rootFSBackedSession{
-		root:         filepath.Clean(root),
 		nextInode:    s0fs.RootInode + 1,
 		inodeByPath:  map[string]uint64{rootFSBackedSessionRoot: s0fs.RootInode},
 		pathByInode:  map[uint64]string{s0fs.RootInode: rootFSBackedSessionRoot},
@@ -65,6 +65,7 @@ func newRootFSBackedSessionWithState(root, statePath string) (*rootFSBackedSessi
 		handles:      make(map[uint64]*os.File),
 		handleInodes: make(map[uint64]uint64),
 	}
+	session.root.Store(filepath.Clean(root))
 	if strings.TrimSpace(statePath) == "" {
 		return session, nil
 	}
@@ -77,6 +78,44 @@ func newRootFSBackedSessionWithState(root, statePath string) (*rootFSBackedSessi
 		session.applyStateEventLocked(event)
 	}
 	return session, nil
+}
+
+// RebaseRoot moves an idle unbound portal onto its container overlay upper.
+// Manager calls this before releasing the runtime assignment barrier, so the
+// portal cannot split writes between its staging directory and durable rootfs.
+func (s *rootFSBackedSession) RebaseRoot(root string) error {
+	if s == nil {
+		return fmt.Errorf("rootfs-backed portal is required")
+	}
+	root = filepath.Clean(strings.TrimSpace(root))
+	if root == "" || root == "." || !filepath.IsAbs(root) {
+		return fmt.Errorf("rootfs-backed portal root must be absolute")
+	}
+	info, err := os.Stat(root)
+	if err != nil {
+		return fmt.Errorf("inspect rootfs-backed portal root: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("rootfs-backed portal root %s is not a directory", root)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return fserror.New(fserror.FailedPrecondition, "rootfs-backed portal is closed")
+	}
+	if len(s.handles) != 0 {
+		return fserror.New(fserror.FailedPrecondition, "rootfs-backed portal has open file handles")
+	}
+	s.root.Store(root)
+	return nil
+}
+
+func (s *rootFSBackedSession) rootPath() string {
+	if s == nil {
+		return ""
+	}
+	value, _ := s.root.Load().(string)
+	return value
 }
 
 func (s *rootFSBackedSession) Close() {
@@ -542,7 +581,7 @@ func (s *rootFSBackedSession) ReleaseDir(context.Context, *pb.ReleaseDirRequest)
 
 func (s *rootFSBackedSession) StatFs(_ context.Context, _ *pb.StatFsRequest) (*pb.StatFsResponse, error) {
 	var stat unix.Statfs_t
-	if err := unix.Statfs(s.root, &stat); err != nil {
+	if err := unix.Statfs(s.rootPath(), &stat); err != nil {
 		return nil, mapRootFSBackedError(err)
 	}
 	return &pb.StatFsResponse{
@@ -820,9 +859,9 @@ func (s *rootFSBackedSession) handleForWrite(inode, handleID uint64) (*os.File, 
 func (s *rootFSBackedSession) hostPath(rel string) string {
 	rel = cleanRootFSBackedRel(rel)
 	if rel == rootFSBackedSessionRoot {
-		return s.root
+		return s.rootPath()
 	}
-	return filepath.Join(s.root, filepath.FromSlash(rel))
+	return filepath.Join(s.rootPath(), filepath.FromSlash(rel))
 }
 
 func (s *rootFSBackedSession) dropPathIfMissing(rel string, err error) {

--- a/ctld/internal/ctld/portal/rootfs_session.go
+++ b/ctld/internal/ctld/portal/rootfs_session.go
@@ -470,7 +470,14 @@ func (s *rootFSBackedSession) Release(_ context.Context, req *pb.ReleaseRequest)
 	return &pb.Empty{}, nil
 }
 
-func (s *rootFSBackedSession) Flush(_ context.Context, req *pb.FlushRequest) (*pb.Empty, error) {
+func (*rootFSBackedSession) Flush(context.Context, *pb.FlushRequest) (*pb.Empty, error) {
+	// FUSE flush runs for every close and is not a durability boundary. Writes
+	// already reach the host overlay through WriteAt; syncing here would turn
+	// every close into fsync and severely penalize small-file workloads.
+	return &pb.Empty{}, nil
+}
+
+func (s *rootFSBackedSession) Fsync(_ context.Context, req *pb.FsyncRequest) (*pb.Empty, error) {
 	if handle := s.lookupHandle(req.GetHandleId()); handle != nil {
 		if err := handle.Sync(); err != nil {
 			return nil, mapRootFSBackedError(err)
@@ -492,10 +499,6 @@ func (s *rootFSBackedSession) Flush(_ context.Context, req *pb.FlushRequest) (*p
 		}
 	}
 	return &pb.Empty{}, nil
-}
-
-func (s *rootFSBackedSession) Fsync(_ context.Context, req *pb.FsyncRequest) (*pb.Empty, error) {
-	return s.Flush(context.Background(), &pb.FlushRequest{HandleId: req.GetHandleId()})
 }
 
 func (s *rootFSBackedSession) Fallocate(_ context.Context, req *pb.FallocateRequest) (*pb.Empty, error) {

--- a/ctld/internal/ctld/portal/rootfs_session.go
+++ b/ctld/internal/ctld/portal/rootfs_session.go
@@ -80,7 +80,7 @@ func newRootFSBackedSessionWithState(root, statePath string) (*rootFSBackedSessi
 	return session, nil
 }
 
-// RebaseRoot moves an idle unbound portal onto its container overlay upper.
+// RebaseRoot moves an idle unbound portal onto its container's merged rootfs.
 // Manager calls this before releasing the runtime assignment barrier, so the
 // portal cannot split writes between its staging directory and durable rootfs.
 func (s *rootFSBackedSession) RebaseRoot(root string) error {

--- a/ctld/internal/ctld/portal/rootfs_session.go
+++ b/ctld/internal/ctld/portal/rootfs_session.go
@@ -30,16 +30,23 @@ const rootFSRecoveryDir = ".sandbox0-ha"
 type rootFSBackedSession struct {
 	root atomic.Value
 
-	mu           sync.Mutex
-	nextInode    uint64
-	inodeByPath  map[string]uint64
-	pathByInode  map[uint64]string
-	nextHandle   uint64
-	handles      map[uint64]*os.File
-	handleInodes map[uint64]uint64
-	state        *rootFSStateJournal
-	stateErr     error
-	closed       bool
+	mu              sync.Mutex
+	nextInode       uint64
+	inodeByPath     map[string]uint64
+	pathByInode     map[uint64]string
+	inodeByIdentity map[rootFSHostIdentity]uint64
+	identityByInode map[uint64]rootFSHostIdentity
+	nextHandle      uint64
+	handles         map[uint64]*os.File
+	handleInodes    map[uint64]uint64
+	state           *rootFSStateJournal
+	stateErr        error
+	closed          bool
+}
+
+type rootFSHostIdentity struct {
+	device uint64
+	inode  uint64
 }
 
 type rootFSStateEvent struct {
@@ -58,12 +65,14 @@ type rootFSStateJournal struct {
 
 func newRootFSBackedSessionWithState(root, statePath string) (*rootFSBackedSession, error) {
 	session := &rootFSBackedSession{
-		nextInode:    s0fs.RootInode + 1,
-		inodeByPath:  map[string]uint64{rootFSBackedSessionRoot: s0fs.RootInode},
-		pathByInode:  map[uint64]string{s0fs.RootInode: rootFSBackedSessionRoot},
-		nextHandle:   1,
-		handles:      make(map[uint64]*os.File),
-		handleInodes: make(map[uint64]uint64),
+		nextInode:       s0fs.RootInode + 1,
+		inodeByPath:     map[string]uint64{rootFSBackedSessionRoot: s0fs.RootInode},
+		pathByInode:     map[uint64]string{s0fs.RootInode: rootFSBackedSessionRoot},
+		inodeByIdentity: make(map[rootFSHostIdentity]uint64),
+		identityByInode: make(map[uint64]rootFSHostIdentity),
+		nextHandle:      1,
+		handles:         make(map[uint64]*os.File),
+		handleInodes:    make(map[uint64]uint64),
 	}
 	session.root.Store(filepath.Clean(root))
 	if strings.TrimSpace(statePath) == "" {
@@ -77,6 +86,7 @@ func newRootFSBackedSessionWithState(root, statePath string) (*rootFSBackedSessi
 	for _, event := range events {
 		session.applyStateEventLocked(event)
 	}
+	session.rebuildIdentityMappingsLocked()
 	return session, nil
 }
 
@@ -160,7 +170,7 @@ func (s *rootFSBackedSession) Lookup(_ context.Context, req *pb.LookupRequest) (
 	if err != nil {
 		return nil, mapRootFSBackedError(err)
 	}
-	inode := s.inodeForPath(rel)
+	inode := s.inodeForPath(rel, info)
 	return &pb.NodeResponse{Inode: inode, Generation: 1, Attr: attrFromFileInfo(inode, info)}, nil
 }
 
@@ -272,7 +282,7 @@ func (s *rootFSBackedSession) Mkdir(_ context.Context, req *pb.MkdirRequest) (*p
 	if err != nil {
 		return nil, mapRootFSBackedError(err)
 	}
-	inode := s.inodeForPath(rel)
+	inode := s.inodeForPath(rel, info)
 	return &pb.NodeResponse{Inode: inode, Generation: 1, Attr: attrFromFileInfo(inode, info)}, nil
 }
 
@@ -302,7 +312,7 @@ func (s *rootFSBackedSession) Create(_ context.Context, req *pb.CreateRequest) (
 		_ = handle.Close()
 		return nil, mapRootFSBackedError(err)
 	}
-	inode := s.inodeForPath(rel)
+	inode := s.inodeForPath(rel, info)
 	handleID := s.trackHandle(handle, inode)
 	return &pb.NodeResponse{Inode: inode, Generation: 1, Attr: attrFromFileInfo(inode, info), HandleId: handleID}, nil
 }
@@ -361,6 +371,15 @@ func (s *rootFSBackedSession) Rename(_ context.Context, req *pb.RenameRequest) (
 	if err != nil {
 		return nil, err
 	}
+	oldInfo, err := os.Lstat(s.hostPath(oldRel))
+	if err != nil {
+		return nil, mapRootFSBackedError(err)
+	}
+	if newInfo, statErr := os.Lstat(s.hostPath(newRel)); statErr == nil && os.SameFile(oldInfo, newInfo) {
+		return &pb.Empty{}, nil
+	} else if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+		return nil, mapRootFSBackedError(statErr)
+	}
 	if err := os.Rename(s.hostPath(oldRel), s.hostPath(newRel)); err != nil {
 		return nil, mapRootFSBackedError(err)
 	}
@@ -388,7 +407,7 @@ func (s *rootFSBackedSession) Link(_ context.Context, req *pb.LinkRequest) (*pb.
 	if err != nil {
 		return nil, mapRootFSBackedError(err)
 	}
-	inode := s.inodeForPath(newRel)
+	inode := s.mapPathToInode(newRel, req.GetInode(), info)
 	return &pb.NodeResponse{Inode: inode, Generation: 1, Attr: attrFromFileInfo(inode, info)}, nil
 }
 
@@ -408,7 +427,7 @@ func (s *rootFSBackedSession) Symlink(_ context.Context, req *pb.SymlinkRequest)
 	if err != nil {
 		return nil, mapRootFSBackedError(err)
 	}
-	inode := s.inodeForPath(rel)
+	inode := s.inodeForPath(rel, info)
 	return &pb.NodeResponse{Inode: inode, Generation: 1, Attr: attrFromFileInfo(inode, info)}, nil
 }
 
@@ -601,7 +620,7 @@ func (s *rootFSBackedSession) ReadDir(_ context.Context, req *pb.ReadDirRequest)
 		if err != nil {
 			return nil, mapRootFSBackedError(err)
 		}
-		inode := s.inodeForPath(child)
+		inode := s.inodeForPath(child, info)
 		attr := attrFromFileInfo(inode, info)
 		out = append(out, &pb.DirEntry{
 			Inode:  inode,
@@ -712,7 +731,7 @@ func (s *rootFSBackedSession) Mknod(_ context.Context, req *pb.MknodRequest) (*p
 	if err != nil {
 		return nil, mapRootFSBackedError(err)
 	}
-	inode := s.inodeForPath(rel)
+	inode := s.inodeForPath(rel, info)
 	return &pb.NodeResponse{Inode: inode, Generation: 1, Attr: attrFromFileInfo(inode, info)}, nil
 }
 
@@ -748,16 +767,26 @@ func (s *rootFSBackedSession) relForInode(inode uint64) (string, error) {
 	return rel, nil
 }
 
-func (s *rootFSBackedSession) inodeForPath(rel string) uint64 {
+func (s *rootFSBackedSession) inodeForPath(rel string, info os.FileInfo) uint64 {
 	rel = cleanRootFSBackedRel(rel)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.inodeForPathLocked(rel)
+	return s.inodeForPathLocked(rel, info)
 }
 
-func (s *rootFSBackedSession) inodeForPathLocked(rel string) uint64 {
+func (s *rootFSBackedSession) inodeForPathLocked(rel string, info os.FileInfo) uint64 {
 	if inode, ok := s.inodeByPath[rel]; ok {
 		return inode
+	}
+	if identity, ok := rootFSIdentityFromFileInfo(info); ok {
+		if inode, exists := s.inodeByIdentity[identity]; exists {
+			s.inodeByPath[rel] = inode
+			if _, hasPrimary := s.pathByInode[inode]; !hasPrimary {
+				s.pathByInode[inode] = rel
+			}
+			s.appendStateEventLocked(rootFSStateEvent{Operation: "map", Path: rel, Inode: inode, NextInode: s.nextInode})
+			return inode
+		}
 	}
 	inode := s.nextInode
 	s.nextInode++
@@ -767,8 +796,58 @@ func (s *rootFSBackedSession) inodeForPathLocked(rel string) uint64 {
 	}
 	s.inodeByPath[rel] = inode
 	s.pathByInode[inode] = rel
+	s.recordIdentityLocked(inode, info)
 	s.appendStateEventLocked(rootFSStateEvent{Operation: "map", Path: rel, Inode: inode, NextInode: s.nextInode})
 	return inode
+}
+
+func (s *rootFSBackedSession) mapPathToInode(rel string, inode uint64, info os.FileInfo) uint64 {
+	rel = cleanRootFSBackedRel(rel)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if inode == 0 {
+		return s.inodeForPathLocked(rel, info)
+	}
+	s.inodeByPath[rel] = inode
+	if _, ok := s.pathByInode[inode]; !ok {
+		s.pathByInode[inode] = rel
+	}
+	s.recordIdentityLocked(inode, info)
+	s.appendStateEventLocked(rootFSStateEvent{Operation: "map", Path: rel, Inode: inode, NextInode: s.nextInode})
+	return inode
+}
+
+func rootFSIdentityFromFileInfo(info os.FileInfo) (rootFSHostIdentity, bool) {
+	if info == nil {
+		return rootFSHostIdentity{}, false
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || stat.Ino == 0 {
+		return rootFSHostIdentity{}, false
+	}
+	return rootFSHostIdentity{device: uint64(stat.Dev), inode: stat.Ino}, true
+}
+
+func (s *rootFSBackedSession) recordIdentityLocked(inode uint64, info os.FileInfo) {
+	identity, ok := rootFSIdentityFromFileInfo(info)
+	if !ok {
+		return
+	}
+	if existing, found := s.inodeByIdentity[identity]; found && existing != inode {
+		return
+	}
+	s.inodeByIdentity[identity] = inode
+	s.identityByInode[inode] = identity
+}
+
+func (s *rootFSBackedSession) rebuildIdentityMappingsLocked() {
+	for rel, inode := range s.inodeByPath {
+		info, err := os.Lstat(s.hostPath(rel))
+		if err != nil {
+			continue
+		}
+		s.recordIdentityLocked(inode, info)
+	}
 }
 
 func (s *rootFSBackedSession) trackHandle(handle *os.File, inode uint64) uint64 {
@@ -914,9 +993,8 @@ func (s *rootFSBackedSession) dropPath(rel string) {
 	rel = cleanRootFSBackedRel(rel)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if inode, ok := s.inodeByPath[rel]; ok {
-		delete(s.inodeByPath, rel)
-		delete(s.pathByInode, inode)
+	if _, ok := s.inodeByPath[rel]; ok {
+		s.removePathMappingLocked(rel)
 		s.appendStateEventLocked(rootFSStateEvent{Operation: "drop", Path: rel})
 	}
 }
@@ -925,11 +1003,14 @@ func (s *rootFSBackedSession) dropPathTree(rel string) {
 	rel = cleanRootFSBackedRel(rel)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	for path, inode := range s.inodeByPath {
+	paths := make([]string, 0)
+	for path := range s.inodeByPath {
 		if path == rel || strings.HasPrefix(path, rel+"/") {
-			delete(s.inodeByPath, path)
-			delete(s.pathByInode, inode)
+			paths = append(paths, path)
 		}
+	}
+	for _, path := range paths {
+		s.removePathMappingLocked(path)
 	}
 	s.appendStateEventLocked(rootFSStateEvent{Operation: "drop_tree", Path: rel})
 }
@@ -939,20 +1020,32 @@ func (s *rootFSBackedSession) renamePathTree(oldRel, newRel string) {
 	newRel = cleanRootFSBackedRel(newRel)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	updates := make(map[string]uint64)
-	for path, inode := range s.inodeByPath {
-		if path != oldRel && !strings.HasPrefix(path, oldRel+"/") {
-			continue
-		}
-		nextPath := newRel + strings.TrimPrefix(path, oldRel)
-		updates[nextPath] = inode
-		delete(s.inodeByPath, path)
-	}
-	for path, inode := range updates {
-		s.inodeByPath[path] = inode
-		s.pathByInode[inode] = path
-	}
+	s.applyRenameStateLocked(oldRel, newRel)
 	s.appendStateEventLocked(rootFSStateEvent{Operation: "rename_tree", Path: oldRel, NewPath: newRel})
+}
+
+func (s *rootFSBackedSession) removePathMappingLocked(rel string) {
+	inode, ok := s.inodeByPath[rel]
+	if !ok {
+		return
+	}
+	delete(s.inodeByPath, rel)
+	if s.pathByInode[inode] != rel {
+		return
+	}
+	for candidate, candidateInode := range s.inodeByPath {
+		if candidateInode == inode {
+			s.pathByInode[inode] = candidate
+			return
+		}
+	}
+	delete(s.pathByInode, inode)
+	if identity, exists := s.identityByInode[inode]; exists {
+		delete(s.identityByInode, inode)
+		if s.inodeByIdentity[identity] == inode {
+			delete(s.inodeByIdentity, identity)
+		}
+	}
 }
 
 func openRootFSStateJournal(path string) (*rootFSStateJournal, []rootFSStateEvent, error) {
@@ -1024,23 +1117,25 @@ func (s *rootFSBackedSession) applyStateEventLocked(event rootFSStateEvent) {
 	case "map":
 		rel := cleanRootFSBackedRel(event.Path)
 		s.inodeByPath[rel] = event.Inode
-		s.pathByInode[event.Inode] = rel
+		if _, ok := s.pathByInode[event.Inode]; !ok {
+			s.pathByInode[event.Inode] = rel
+		}
 		if event.NextInode > s.nextInode {
 			s.nextInode = event.NextInode
 		}
 	case "drop":
 		rel := cleanRootFSBackedRel(event.Path)
-		if inode, ok := s.inodeByPath[rel]; ok {
-			delete(s.inodeByPath, rel)
-			delete(s.pathByInode, inode)
-		}
+		s.removePathMappingLocked(rel)
 	case "drop_tree":
 		rel := cleanRootFSBackedRel(event.Path)
-		for path, inode := range s.inodeByPath {
+		paths := make([]string, 0)
+		for path := range s.inodeByPath {
 			if path == rel || strings.HasPrefix(path, rel+"/") {
-				delete(s.inodeByPath, path)
-				delete(s.pathByInode, inode)
+				paths = append(paths, path)
 			}
+		}
+		for _, path := range paths {
+			s.removePathMappingLocked(path)
 		}
 	case "rename_tree":
 		s.applyRenameStateLocked(event.Path, event.NewPath)
@@ -1068,17 +1163,35 @@ func (s *rootFSBackedSession) applyRenameStateLocked(oldRel, newRel string) {
 	oldRel = cleanRootFSBackedRel(oldRel)
 	newRel = cleanRootFSBackedRel(newRel)
 	updates := make(map[string]uint64)
+	replaced := make([]string, 0)
+	for path, inode := range s.inodeByPath {
+		if path == oldRel || strings.HasPrefix(path, oldRel+"/") {
+			nextPath := newRel + strings.TrimPrefix(path, oldRel)
+			updates[nextPath] = inode
+			continue
+		}
+		if path == newRel || strings.HasPrefix(path, newRel+"/") {
+			replaced = append(replaced, path)
+		}
+	}
+	for _, path := range replaced {
+		s.removePathMappingLocked(path)
+	}
 	for path, inode := range s.inodeByPath {
 		if path != oldRel && !strings.HasPrefix(path, oldRel+"/") {
 			continue
 		}
 		nextPath := newRel + strings.TrimPrefix(path, oldRel)
-		updates[nextPath] = inode
 		delete(s.inodeByPath, path)
+		if s.pathByInode[inode] == path {
+			s.pathByInode[inode] = nextPath
+		}
 	}
 	for path, inode := range updates {
 		s.inodeByPath[path] = inode
-		s.pathByInode[inode] = path
+		if _, ok := s.pathByInode[inode]; !ok {
+			s.pathByInode[inode] = path
+		}
 	}
 }
 

--- a/ctld/internal/ctld/portal/rootfs_session_test.go
+++ b/ctld/internal/ctld/portal/rootfs_session_test.go
@@ -182,6 +182,53 @@ func TestRootFSBackedSessionRecognizesRestoredHardlinks(t *testing.T) {
 	assert.Equal(t, uint32(2), peer.Attr.Nlink)
 }
 
+func TestRootFSBackedSessionRestoresHardlinkInodeMapping(t *testing.T) {
+	backing := t.TempDir()
+	statePath := filepath.Join(t.TempDir(), "portal.jsonl")
+	ctx := context.Background()
+	primary, err := newRootFSBackedSessionWithState(backing, statePath)
+	require.NoError(t, err)
+	source, err := primary.Create(ctx, &pb.CreateRequest{
+		Parent: s0fs.RootInode,
+		Name:   "source.bin",
+		Mode:   0o600,
+		Flags:  uint32(os.O_RDWR),
+	})
+	require.NoError(t, err)
+	_, err = primary.Write(ctx, &pb.WriteRequest{
+		Inode:    source.Inode,
+		HandleId: source.HandleId,
+		Data:     []byte("persisted"),
+	})
+	require.NoError(t, err)
+	_, err = primary.Release(ctx, &pb.ReleaseRequest{Inode: source.Inode, HandleId: source.HandleId})
+	require.NoError(t, err)
+	peer, err := primary.Link(ctx, &pb.LinkRequest{
+		Inode:     source.Inode,
+		NewParent: s0fs.RootInode,
+		NewName:   "peer.bin",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, source.Inode, peer.Inode)
+	primary.Close()
+
+	standby, err := newRootFSBackedSessionWithState(backing, statePath)
+	require.NoError(t, err)
+	defer standby.Close()
+	restoredSource, err := standby.Lookup(ctx, &pb.LookupRequest{Parent: s0fs.RootInode, Name: "source.bin"})
+	require.NoError(t, err)
+	restoredPeer, err := standby.Lookup(ctx, &pb.LookupRequest{Parent: s0fs.RootInode, Name: "peer.bin"})
+	require.NoError(t, err)
+	assert.Equal(t, source.Inode, restoredSource.Inode)
+	assert.Equal(t, source.Inode, restoredPeer.Inode)
+
+	_, err = standby.Unlink(ctx, &pb.UnlinkRequest{Parent: s0fs.RootInode, Name: "source.bin"})
+	require.NoError(t, err)
+	read, err := standby.Read(ctx, &pb.ReadRequest{Inode: restoredPeer.Inode, Size: 64})
+	require.NoError(t, err)
+	assert.Equal(t, "persisted", string(read.Data))
+}
+
 func TestRootFSBackedSessionSetAttrPreservesSymlinkTimes(t *testing.T) {
 	backing := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(backing, "target"), []byte("target"), 0o640))

--- a/ctld/internal/ctld/portal/rootfs_session_test.go
+++ b/ctld/internal/ctld/portal/rootfs_session_test.go
@@ -8,7 +8,9 @@ import (
 	"strconv"
 	"syscall"
 	"testing"
+	"time"
 
+	"github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/fserror"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/s0fs"
 	pb "github.com/sandbox0-ai/sandbox0/storage-proxy/proto/fs"
@@ -102,6 +104,61 @@ func TestRootFSBackedSessionFsyncDir(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, session.FsyncDir(context.Background(), dir.Inode))
+}
+
+func TestRootFSBackedSessionSetAttrPreservesSymlinkTimes(t *testing.T) {
+	backing := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(backing, "target"), []byte("target"), 0o640))
+	session, err := newRootFSBackedSessionWithState(backing, "")
+	require.NoError(t, err)
+	defer session.Close()
+
+	link, err := session.Symlink(context.Background(), &pb.SymlinkRequest{
+		Parent: s0fs.RootInode,
+		Name:   "link",
+		Target: "target",
+	})
+	require.NoError(t, err)
+	targetBefore, err := os.Stat(filepath.Join(backing, "target"))
+	require.NoError(t, err)
+
+	const seconds = int64(1_700_000_000)
+	const nanoseconds = int64(123_456_789)
+	_, err = session.SetAttr(context.Background(), &pb.SetAttrRequest{
+		Inode: link.Inode,
+		Valid: fuse.FATTR_ATIME | fuse.FATTR_MTIME,
+		Attr: &pb.GetAttrResponse{
+			AtimeSec:  seconds,
+			AtimeNsec: nanoseconds,
+			MtimeSec:  seconds,
+			MtimeNsec: nanoseconds,
+		},
+	})
+	require.NoError(t, err)
+
+	linkAfter, err := os.Lstat(filepath.Join(backing, "link"))
+	require.NoError(t, err)
+	assert.Equal(t, time.Unix(seconds, nanoseconds), linkAfter.ModTime())
+	targetAfter, err := os.Stat(filepath.Join(backing, "target"))
+	require.NoError(t, err)
+	assert.Equal(t, targetBefore.ModTime(), targetAfter.ModTime())
+
+	_, err = session.SetAttr(context.Background(), &pb.SetAttrRequest{
+		Inode: link.Inode,
+		Valid: fuse.FATTR_SIZE,
+		Attr:  &pb.GetAttrResponse{},
+	})
+	require.ErrorIs(t, err, syscall.EINVAL)
+	_, err = session.SetAttr(context.Background(), &pb.SetAttrRequest{
+		Inode: link.Inode,
+		Valid: fuse.FATTR_MODE,
+		Attr:  &pb.GetAttrResponse{Mode: 0o600},
+	})
+	require.ErrorIs(t, err, syscall.EOPNOTSUPP)
+	assertFileContentForPortalTest(t, filepath.Join(backing, "target"), "target")
+	targetAfter, err = os.Stat(filepath.Join(backing, "target"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o640), targetAfter.Mode().Perm())
 }
 
 func TestRootFSBackedSessionRebaseExposesRestoredFilesAndRedirectsWrites(t *testing.T) {

--- a/ctld/internal/ctld/portal/rootfs_session_test.go
+++ b/ctld/internal/ctld/portal/rootfs_session_test.go
@@ -68,6 +68,28 @@ func TestRootFSBackedSessionWritesThroughBackingDir(t *testing.T) {
 	assert.Equal(t, "state.txt", list.Entries[0].Name)
 }
 
+func TestRootFSBackedSessionFlushDoesNotImplyFsync(t *testing.T) {
+	session, err := newRootFSBackedSessionWithState(t.TempDir(), "")
+	require.NoError(t, err)
+	defer session.Close()
+
+	created, err := session.Create(context.Background(), &pb.CreateRequest{
+		Parent: s0fs.RootInode,
+		Name:   "flush.txt",
+		Mode:   0o600,
+		Flags:  uint32(os.O_RDWR),
+	})
+	require.NoError(t, err)
+	handle := session.lookupHandle(created.HandleId)
+	require.NotNil(t, handle)
+	require.NoError(t, handle.Close())
+
+	_, err = session.Flush(context.Background(), &pb.FlushRequest{HandleId: created.HandleId})
+	require.NoError(t, err)
+	_, err = session.Fsync(context.Background(), &pb.FsyncRequest{HandleId: created.HandleId})
+	require.Error(t, err)
+}
+
 func TestRootFSBackedSessionRebaseExposesRestoredFilesAndRedirectsWrites(t *testing.T) {
 	staging := t.TempDir()
 	upper := t.TempDir()

--- a/ctld/internal/ctld/portal/rootfs_session_test.go
+++ b/ctld/internal/ctld/portal/rootfs_session_test.go
@@ -106,6 +106,82 @@ func TestRootFSBackedSessionFsyncDir(t *testing.T) {
 	require.NoError(t, session.FsyncDir(context.Background(), dir.Inode))
 }
 
+func TestRootFSBackedSessionHardlinkSharesInodeAndContent(t *testing.T) {
+	backing := t.TempDir()
+	session, err := newRootFSBackedSessionWithState(backing, "")
+	require.NoError(t, err)
+	defer session.Close()
+	ctx := context.Background()
+
+	source, err := session.Create(ctx, &pb.CreateRequest{
+		Parent: s0fs.RootInode,
+		Name:   "source.bin",
+		Mode:   0o600,
+		Flags:  uint32(os.O_RDWR),
+	})
+	require.NoError(t, err)
+	_, err = session.Write(ctx, &pb.WriteRequest{
+		Inode:    source.Inode,
+		HandleId: source.HandleId,
+		Data:     []byte("before"),
+	})
+	require.NoError(t, err)
+	_, err = session.Release(ctx, &pb.ReleaseRequest{Inode: source.Inode, HandleId: source.HandleId})
+	require.NoError(t, err)
+
+	peer, err := session.Link(ctx, &pb.LinkRequest{
+		Inode:     source.Inode,
+		NewParent: s0fs.RootInode,
+		NewName:   "peer.bin",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, source.Inode, peer.Inode)
+
+	opened, err := session.Open(ctx, &pb.OpenRequest{Inode: peer.Inode, Flags: uint32(os.O_RDWR)})
+	require.NoError(t, err)
+	_, err = session.Write(ctx, &pb.WriteRequest{
+		Inode:    peer.Inode,
+		HandleId: opened.HandleId,
+		Offset:   int64(len("before")),
+		Data:     []byte("-after"),
+	})
+	require.NoError(t, err)
+	_, err = session.Release(ctx, &pb.ReleaseRequest{Inode: peer.Inode, HandleId: opened.HandleId})
+	require.NoError(t, err)
+
+	assertFileContentForPortalTest(t, filepath.Join(backing, "source.bin"), "before-after")
+	assertFileContentForPortalTest(t, filepath.Join(backing, "peer.bin"), "before-after")
+	peerAttr, err := session.GetAttr(ctx, &pb.GetAttrRequest{Inode: peer.Inode})
+	require.NoError(t, err)
+	assert.Equal(t, uint32(2), peerAttr.Nlink)
+
+	_, err = session.Unlink(ctx, &pb.UnlinkRequest{Parent: s0fs.RootInode, Name: "source.bin"})
+	require.NoError(t, err)
+	read, err := session.Read(ctx, &pb.ReadRequest{Inode: peer.Inode, Size: 64})
+	require.NoError(t, err)
+	assert.Equal(t, "before-after", string(read.Data))
+}
+
+func TestRootFSBackedSessionRecognizesRestoredHardlinks(t *testing.T) {
+	backing := t.TempDir()
+	sourcePath := filepath.Join(backing, "source.bin")
+	require.NoError(t, os.WriteFile(sourcePath, []byte("restored"), 0o600))
+	require.NoError(t, os.Link(sourcePath, filepath.Join(backing, "peer.bin")))
+
+	session, err := newRootFSBackedSessionWithState(backing, "")
+	require.NoError(t, err)
+	defer session.Close()
+	ctx := context.Background()
+	source, err := session.Lookup(ctx, &pb.LookupRequest{Parent: s0fs.RootInode, Name: "source.bin"})
+	require.NoError(t, err)
+	peer, err := session.Lookup(ctx, &pb.LookupRequest{Parent: s0fs.RootInode, Name: "peer.bin"})
+	require.NoError(t, err)
+
+	assert.Equal(t, source.Inode, peer.Inode)
+	assert.Equal(t, uint32(2), source.Attr.Nlink)
+	assert.Equal(t, uint32(2), peer.Attr.Nlink)
+}
+
 func TestRootFSBackedSessionSetAttrPreservesSymlinkTimes(t *testing.T) {
 	backing := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(backing, "target"), []byte("target"), 0o640))

--- a/ctld/internal/ctld/portal/rootfs_session_test.go
+++ b/ctld/internal/ctld/portal/rootfs_session_test.go
@@ -90,6 +90,20 @@ func TestRootFSBackedSessionFlushDoesNotImplyFsync(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestRootFSBackedSessionFsyncDir(t *testing.T) {
+	session, err := newRootFSBackedSessionWithState(t.TempDir(), "")
+	require.NoError(t, err)
+	defer session.Close()
+
+	dir, err := session.Mkdir(context.Background(), &pb.MkdirRequest{
+		Parent: s0fs.RootInode,
+		Name:   "durable",
+		Mode:   0o755,
+	})
+	require.NoError(t, err)
+	require.NoError(t, session.FsyncDir(context.Background(), dir.Inode))
+}
+
 func TestRootFSBackedSessionRebaseExposesRestoredFilesAndRedirectsWrites(t *testing.T) {
 	staging := t.TempDir()
 	upper := t.TempDir()

--- a/ctld/internal/ctld/portal/rootfs_session_test.go
+++ b/ctld/internal/ctld/portal/rootfs_session_test.go
@@ -68,6 +68,69 @@ func TestRootFSBackedSessionWritesThroughBackingDir(t *testing.T) {
 	assert.Equal(t, "state.txt", list.Entries[0].Name)
 }
 
+func TestRootFSBackedSessionRebaseExposesRestoredFilesAndRedirectsWrites(t *testing.T) {
+	staging := t.TempDir()
+	upper := t.TempDir()
+	backing := filepath.Join(upper, "workspace")
+	require.NoError(t, os.Mkdir(backing, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(backing, "restored.txt"), []byte("restored"), 0o640))
+
+	session, err := newRootFSBackedSessionWithState(staging, "")
+	require.NoError(t, err)
+	defer session.Close()
+	require.NoError(t, session.RebaseRoot(backing))
+
+	ctx := context.Background()
+	restored, err := session.Lookup(ctx, &pb.LookupRequest{Parent: s0fs.RootInode, Name: "restored.txt"})
+	require.NoError(t, err)
+	read, err := session.Read(ctx, &pb.ReadRequest{Inode: restored.Inode, Size: 64})
+	require.NoError(t, err)
+	assert.Equal(t, "restored", string(read.Data))
+
+	created, err := session.Create(ctx, &pb.CreateRequest{
+		Parent: s0fs.RootInode,
+		Name:   "new.txt",
+		Mode:   0o600,
+		Flags:  uint32(os.O_RDWR),
+	})
+	require.NoError(t, err)
+	_, err = session.Write(ctx, &pb.WriteRequest{Inode: created.Inode, HandleId: created.HandleId, Data: []byte("new")})
+	require.NoError(t, err)
+	_, err = session.Release(ctx, &pb.ReleaseRequest{Inode: created.Inode, HandleId: created.HandleId})
+	require.NoError(t, err)
+	assertFileContentForPortalTest(t, filepath.Join(backing, "new.txt"), "new")
+	_, err = os.Stat(filepath.Join(staging, "new.txt"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestRootFSBackedSessionRebaseRejectsOpenHandles(t *testing.T) {
+	staging := t.TempDir()
+	backing := t.TempDir()
+	session, err := newRootFSBackedSessionWithState(staging, "")
+	require.NoError(t, err)
+	defer session.Close()
+
+	ctx := context.Background()
+	created, err := session.Create(ctx, &pb.CreateRequest{
+		Parent: s0fs.RootInode,
+		Name:   "active.txt",
+		Mode:   0o600,
+		Flags:  uint32(os.O_RDWR),
+	})
+	require.NoError(t, err)
+	err = session.RebaseRoot(backing)
+	require.Error(t, err)
+	assert.Equal(t, fserror.FailedPrecondition, fserror.CodeOf(err))
+
+	_, err = session.Write(ctx, &pb.WriteRequest{Inode: created.Inode, HandleId: created.HandleId, Data: []byte("staging")})
+	require.NoError(t, err)
+	_, err = session.Release(ctx, &pb.ReleaseRequest{Inode: created.Inode, HandleId: created.HandleId})
+	require.NoError(t, err)
+	assertFileContentForPortalTest(t, filepath.Join(staging, "active.txt"), "staging")
+	_, err = os.Stat(filepath.Join(backing, "active.txt"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
 func TestRootFSBackedSessionPreservesRemoveErrnos(t *testing.T) {
 	backing := t.TempDir()
 	session, err := newRootFSBackedSessionWithState(backing, "")

--- a/ctld/internal/ctld/rootfs/controller.go
+++ b/ctld/internal/ctld/rootfs/controller.go
@@ -23,10 +23,15 @@ var (
 type Config struct {
 	Context         context.Context
 	Runtime         rootFSV3Runtime
+	PortalBackings  rootFSPortalBackingAttacher
 	Store           objectstore.Store
 	WatchFenceRoot  string
 	CaptureLeases   rootFSCaptureLeaseStore
 	MetricsRegistry prometheus.Registerer
+}
+
+type rootFSPortalBackingAttacher interface {
+	AttachRootFSBackings(context.Context, string, string) error
 }
 
 type rootFSCaptureLeaseStore interface {
@@ -40,6 +45,7 @@ type rootFSCaptureLeaseStore interface {
 type Controller struct {
 	store          objectstore.Store
 	v3Runtime      rootFSV3Runtime
+	portalBackings rootFSPortalBackingAttacher
 	v3Context      context.Context
 	watchFenceRoot string
 	captureLeases  rootFSCaptureLeaseStore
@@ -62,6 +68,7 @@ func NewController(cfg Config) *Controller {
 	controller := &Controller{
 		store:          cfg.Store,
 		v3Runtime:      cfg.Runtime,
+		portalBackings: cfg.PortalBackings,
 		v3Context:      v3Context,
 		watchFenceRoot: cfg.WatchFenceRoot,
 		captureLeases:  cfg.CaptureLeases,

--- a/ctld/internal/ctld/rootfs/controller_v3.go
+++ b/ctld/internal/ctld/rootfs/controller_v3.go
@@ -98,6 +98,15 @@ func (c *Controller) BindRootFSSync(r *http.Request, req ctldapi.BindRootFSSyncR
 	if err != nil {
 		return ctldapi.BindRootFSSyncResponse{Info: info, Error: err.Error()}, statusForError(err)
 	}
+	if c.portalBackings != nil {
+		podUID := strings.TrimSpace(info.PodUID)
+		if podUID == "" {
+			podUID = strings.TrimSpace(req.Target.PodUID)
+		}
+		if err := c.portalBackings.AttachRootFSBackings(ctx, podUID, upperdir); err != nil {
+			return ctldapi.BindRootFSSyncResponse{Info: info, Error: err.Error()}, statusForError(err)
+		}
+	}
 	mergedRoot, err := c.v3Runtime.ActiveMergedRoot(ctx, info, upperdir)
 	if err != nil {
 		return ctldapi.BindRootFSSyncResponse{Info: info, Error: err.Error()}, statusForError(err)

--- a/ctld/internal/ctld/rootfs/controller_v3.go
+++ b/ctld/internal/ctld/rootfs/controller_v3.go
@@ -98,18 +98,18 @@ func (c *Controller) BindRootFSSync(r *http.Request, req ctldapi.BindRootFSSyncR
 	if err != nil {
 		return ctldapi.BindRootFSSyncResponse{Info: info, Error: err.Error()}, statusForError(err)
 	}
+	mergedRoot, err := c.v3Runtime.ActiveMergedRoot(ctx, info, upperdir)
+	if err != nil {
+		return ctldapi.BindRootFSSyncResponse{Info: info, Error: err.Error()}, statusForError(err)
+	}
 	if c.portalBackings != nil {
 		podUID := strings.TrimSpace(info.PodUID)
 		if podUID == "" {
 			podUID = strings.TrimSpace(req.Target.PodUID)
 		}
-		if err := c.portalBackings.AttachRootFSBackings(ctx, podUID, upperdir); err != nil {
+		if err := c.portalBackings.AttachRootFSBackings(ctx, podUID, mergedRoot); err != nil {
 			return ctldapi.BindRootFSSyncResponse{Info: info, Error: err.Error()}, statusForError(err)
 		}
-	}
-	mergedRoot, err := c.v3Runtime.ActiveMergedRoot(ctx, info, upperdir)
-	if err != nil {
-		return ctldapi.BindRootFSSyncResponse{Info: info, Error: err.Error()}, statusForError(err)
 	}
 	writer, err := rootfsstore.NewTeamWriter(c.store, req.TeamID)
 	if err != nil {

--- a/ctld/internal/ctld/rootfs/controller_v3_test.go
+++ b/ctld/internal/ctld/rootfs/controller_v3_test.go
@@ -213,12 +213,14 @@ func TestControllerBindRootFSSyncAttachesPortalBackingsBeforeStartingSession(t *
 	info := rootFSInfo("gvisor")
 	info.Snapshotter = rootfshead.SnapshotterName
 	upperdir := t.TempDir()
+	mergedRoot := t.TempDir()
 	attacher := &fakePortalBackingAttacher{}
 	controller := NewController(Config{
 		Context: context.Background(),
 		Runtime: &fakeV3Runtime{
 			fakeRuntime: &fakeRuntime{info: info},
 			upperdir:    upperdir,
+			mergedRoot:  mergedRoot,
 			base:        base,
 			baseConfig:  baseConfig,
 		},
@@ -237,7 +239,7 @@ func TestControllerBindRootFSSyncAttachesPortalBackingsBeforeStartingSession(t *
 
 	require.Equal(t, http.StatusOK, status, response.Error)
 	assert.Equal(t, "pod-uid", attacher.podUID)
-	assert.Equal(t, upperdir, attacher.upperRoot)
+	assert.Equal(t, mergedRoot, attacher.mergedRoot)
 }
 
 func TestControllerBindRootFSSyncFailsWhenPortalBackingAttachmentFails(t *testing.T) {
@@ -369,6 +371,7 @@ func TestControllerBindRootFSSyncRejectsCrossTeamParent(t *testing.T) {
 type fakeV3Runtime struct {
 	*fakeRuntime
 	upperdir              string
+	mergedRoot            string
 	base                  rootfshead.BaseIdentity
 	baseConfig            []byte
 	materializedReference rootfshead.HeadReference
@@ -391,14 +394,14 @@ type fakeCaptureLeases struct {
 }
 
 type fakePortalBackingAttacher struct {
-	podUID    string
-	upperRoot string
-	err       error
+	podUID     string
+	mergedRoot string
+	err        error
 }
 
-func (a *fakePortalBackingAttacher) AttachRootFSBackings(_ context.Context, podUID, upperRoot string) error {
+func (a *fakePortalBackingAttacher) AttachRootFSBackings(_ context.Context, podUID, mergedRoot string) error {
 	a.podUID = podUID
-	a.upperRoot = upperRoot
+	a.mergedRoot = mergedRoot
 	return a.err
 }
 
@@ -476,6 +479,9 @@ func (r *fakeV3Runtime) ActiveUpperdir(context.Context, ctldapi.RootFSInfo) (str
 }
 
 func (r *fakeV3Runtime) ActiveMergedRoot(context.Context, ctldapi.RootFSInfo, string) (string, error) {
+	if r.mergedRoot != "" {
+		return r.mergedRoot, nil
+	}
 	return r.upperdir, nil
 }
 

--- a/ctld/internal/ctld/rootfs/controller_v3_test.go
+++ b/ctld/internal/ctld/rootfs/controller_v3_test.go
@@ -208,6 +208,67 @@ func TestControllerBindRootFSSyncReleasesLeaseWhenSessionStartFails(t *testing.T
 	assert.Equal(t, int64(1), leases.releaseCalls.Load())
 }
 
+func TestControllerBindRootFSSyncAttachesPortalBackingsBeforeStartingSession(t *testing.T) {
+	base, baseConfig := testRootFSBase(t)
+	info := rootFSInfo("gvisor")
+	info.Snapshotter = rootfshead.SnapshotterName
+	upperdir := t.TempDir()
+	attacher := &fakePortalBackingAttacher{}
+	controller := NewController(Config{
+		Context: context.Background(),
+		Runtime: &fakeV3Runtime{
+			fakeRuntime: &fakeRuntime{info: info},
+			upperdir:    upperdir,
+			base:        base,
+			baseConfig:  baseConfig,
+		},
+		PortalBackings: attacher,
+		Store:          objectstore.NewMemoryStore(t.Name()),
+		WatchFenceRoot: t.TempDir(),
+		CaptureLeases:  &fakeCaptureLeases{},
+	})
+
+	response, status := controller.BindRootFSSync(httptest.NewRequest(http.MethodPut, "/", nil), ctldapi.BindRootFSSyncRequest{
+		Target:            rootFSTarget(),
+		SandboxID:         "sandbox-1",
+		TeamID:            "team-1",
+		RuntimeGeneration: 1,
+	})
+
+	require.Equal(t, http.StatusOK, status, response.Error)
+	assert.Equal(t, "pod-uid", attacher.podUID)
+	assert.Equal(t, upperdir, attacher.upperRoot)
+}
+
+func TestControllerBindRootFSSyncFailsWhenPortalBackingAttachmentFails(t *testing.T) {
+	base, baseConfig := testRootFSBase(t)
+	info := rootFSInfo("gvisor")
+	info.Snapshotter = rootfshead.SnapshotterName
+	controller := NewController(Config{
+		Context: context.Background(),
+		Runtime: &fakeV3Runtime{
+			fakeRuntime: &fakeRuntime{info: info},
+			upperdir:    t.TempDir(),
+			base:        base,
+			baseConfig:  baseConfig,
+		},
+		PortalBackings: &fakePortalBackingAttacher{err: errors.New("portal attachment failed")},
+		Store:          objectstore.NewMemoryStore(t.Name()),
+		WatchFenceRoot: t.TempDir(),
+		CaptureLeases:  &fakeCaptureLeases{},
+	})
+
+	response, status := controller.BindRootFSSync(httptest.NewRequest(http.MethodPut, "/", nil), ctldapi.BindRootFSSyncRequest{
+		Target:            rootFSTarget(),
+		SandboxID:         "sandbox-1",
+		TeamID:            "team-1",
+		RuntimeGeneration: 1,
+	})
+
+	assert.Equal(t, http.StatusInternalServerError, status)
+	assert.Contains(t, response.Error, "portal attachment failed")
+}
+
 func TestControllerExposesAndAbandonsHeadWhenMarkerUploadFails(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -327,6 +388,18 @@ type fakeCaptureLeases struct {
 	checkpointCalls atomic.Int64
 	resetCalls      atomic.Int64
 	releaseCalls    atomic.Int64
+}
+
+type fakePortalBackingAttacher struct {
+	podUID    string
+	upperRoot string
+	err       error
+}
+
+func (a *fakePortalBackingAttacher) AttachRootFSBackings(_ context.Context, podUID, upperRoot string) error {
+	a.podUID = podUID
+	a.upperRoot = upperRoot
+	return a.err
 }
 
 type failingRootFSStore struct {

--- a/ctld/internal/fuseportal/server_linux.go
+++ b/ctld/internal/fuseportal/server_linux.go
@@ -66,6 +66,7 @@ type Server struct {
 	fs          fuse.RawFileSystem
 	protocol    *fuse.ProtocolServer
 	opts        fuse.MountOptions
+	requestPool *sync.Pool
 	mountPoint  string
 	initRequest []byte
 	fd          int
@@ -174,6 +175,7 @@ func newServer(fs fuse.RawFileSystem, fd int, mountPoint string, opts *fuse.Moun
 		fs:          fs,
 		protocol:    fuse.NewProtocolServer(fs, opts),
 		opts:        *opts,
+		requestPool: sharedRequestBufferPool(opts.MaxWrite),
 		mountPoint:  mountPoint,
 		fd:          fd,
 		mux:         mux,
@@ -330,19 +332,25 @@ func (s *Server) handleReady(events uint32) (bool, error) {
 	if channelFD < 0 {
 		return true, nil
 	}
-	request, err := readRequest(channelFD, s.opts.MaxWrite)
+	requestBufferPtr := s.requestPool.Get().(*[]byte)
+	requestBuffer := *requestBufferPtr
+	request, err := readRequestInto(channelFD, requestBuffer)
 	if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EWOULDBLOCK) {
+		s.requestPool.Put(requestBufferPtr)
 		return false, nil
 	}
 	if errors.Is(err, unix.ENODEV) || errors.Is(err, unix.EBADF) {
+		s.requestPool.Put(requestBufferPtr)
 		return true, nil
 	}
 	if err != nil {
+		s.requestPool.Put(requestBufferPtr)
 		return true, fmt.Errorf("read FUSE request: %w", err)
 	}
 	s.requests.Add(1)
 	go func() {
 		defer s.requests.Done()
+		defer s.requestPool.Put(requestBufferPtr)
 		if err := s.handleAndReply(request); err != nil {
 			if s.opts.Logger != nil {
 				s.opts.Logger.Printf("handle FUSE request: %v", err)
@@ -499,11 +507,44 @@ func joinMountOptions(options []string) string {
 	return result
 }
 
-func readRequest(fd, maxWrite int) ([]byte, error) {
+// requestBufferPools is process-wide so idle portal mounts do not each retain
+// a maximum-sized request buffer. Bucketing by negotiated size avoids handing
+// a connection a buffer smaller than the kernel may write.
+var requestBufferPools sync.Map
+
+func sharedRequestBufferPool(maxWrite int) *sync.Pool {
+	size := requestBufferSize(maxWrite)
+	if existing, ok := requestBufferPools.Load(size); ok {
+		return existing.(*sync.Pool)
+	}
+	pool := &sync.Pool{New: func() any {
+		buffer := make([]byte, size)
+		return &buffer
+	}}
+	actual, _ := requestBufferPools.LoadOrStore(size, pool)
+	return actual.(*sync.Pool)
+}
+
+func requestBufferSize(maxWrite int) int {
 	if maxWrite < 128*1024 {
 		maxWrite = 128 * 1024
 	}
-	buffer := make([]byte, maxWrite+64*1024)
+	return maxWrite + 64*1024
+}
+
+func readRequest(fd, maxWrite int) ([]byte, error) {
+	buffer := make([]byte, requestBufferSize(maxWrite))
+	request, err := readRequestInto(fd, buffer)
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte(nil), request...), nil
+}
+
+func readRequestInto(fd int, buffer []byte) ([]byte, error) {
+	if len(buffer) < fuseHeaderSize {
+		return nil, fmt.Errorf("FUSE request buffer is too small: %d", len(buffer))
+	}
 	for {
 		n, err := unix.Read(fd, buffer)
 		if errors.Is(err, unix.EINTR) {
@@ -519,7 +560,7 @@ func readRequest(fd, maxWrite int) ([]byte, error) {
 		if length < fuseHeaderSize || length > n {
 			return nil, fmt.Errorf("invalid FUSE request length %d from read of %d", length, n)
 		}
-		return append([]byte(nil), buffer[:length]...), nil
+		return buffer[:length], nil
 	}
 }
 

--- a/ctld/internal/fuseportal/server_linux_test.go
+++ b/ctld/internal/fuseportal/server_linux_test.go
@@ -301,6 +301,48 @@ func TestHandleReadyIgnoresStaleReadiness(t *testing.T) {
 	}
 }
 
+func TestReadRequestIntoUsesCallerBuffer(t *testing.T) {
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		t.Fatalf("Socketpair() error = %v", err)
+	}
+	defer unix.Close(fds[0])
+	defer unix.Close(fds[1])
+
+	want := testGetattrRequest(42)
+	if _, err := unix.Write(fds[1], want); err != nil {
+		t.Fatalf("Write(request) error = %v", err)
+	}
+	buffer := make([]byte, requestBufferSize(1<<20))
+	got, err := readRequestInto(fds[0], buffer)
+	if err != nil {
+		t.Fatalf("readRequestInto() error = %v", err)
+	}
+	if len(got) != len(want) || string(got) != string(want) {
+		t.Fatalf("readRequestInto() = %x, want %x", got, want)
+	}
+	if &got[0] != &buffer[0] {
+		t.Fatal("readRequestInto() copied instead of reusing the caller buffer")
+	}
+}
+
+func TestSharedRequestBufferPoolUsesSizeBuckets(t *testing.T) {
+	smallA := sharedRequestBufferPool(256 * 1024)
+	smallB := sharedRequestBufferPool(256 * 1024)
+	large := sharedRequestBufferPool(1 << 20)
+	if smallA != smallB {
+		t.Fatal("equal request buffer sizes do not share a pool")
+	}
+	if smallA == large {
+		t.Fatal("different request buffer sizes unexpectedly share a pool")
+	}
+	buffer := large.Get().(*[]byte)
+	defer large.Put(buffer)
+	if got := len(*buffer); got != requestBufferSize(1<<20) {
+		t.Fatalf("large request buffer size = %d, want %d", got, requestBufferSize(1<<20))
+	}
+}
+
 func TestSharedEpollStaleReadinessDoesNotBlockAnotherPortal(t *testing.T) {
 	mux, err := newEpollMultiplexer(multiplexerConfig{
 		watchdogInterval: 10 * time.Millisecond,

--- a/ctld/internal/volumefuse/fs.go
+++ b/ctld/internal/volumefuse/fs.go
@@ -934,7 +934,21 @@ func (fs *FileSystem) CopyFileRange(cancel <-chan struct{}, input *fuse.CopyFile
 }
 
 func (fs *FileSystem) FsyncDir(cancel <-chan struct{}, input *fuse.FsyncIn) fuse.Status {
-	return fuse.ENOSYS
+	if isCanceled(cancel) {
+		return fuse.EINTR
+	}
+	session, st := fs.requireSession()
+	if st != fuse.OK {
+		return st
+	}
+	dirSession, ok := session.(FsyncDirSession)
+	if !ok {
+		return fuse.ENOSYS
+	}
+	if err := dirSession.FsyncDir(context.Background(), input.NodeId); err != nil {
+		return statusToFuse(err)
+	}
+	return fuse.OK
 }
 
 func (fs *FileSystem) Ioctl(cancel <-chan struct{}, in *fuse.IoctlIn, bufIn []byte, out *fuse.IoctlOut, bufOut []byte) fuse.Status {

--- a/ctld/internal/volumefuse/fs_test.go
+++ b/ctld/internal/volumefuse/fs_test.go
@@ -91,6 +91,38 @@ func TestOpenUsesSessionOpenFlags(t *testing.T) {
 	}
 }
 
+type fsyncDirTestSession struct {
+	Session
+	inode uint64
+	err   error
+}
+
+func (s *fsyncDirTestSession) FsyncDir(_ context.Context, inode uint64) error {
+	s.inode = inode
+	return s.err
+}
+
+func TestFsyncDirUsesOptInSession(t *testing.T) {
+	session := &fsyncDirTestSession{}
+	fs := New("vol-1", time.Second, session)
+
+	st := fs.FsyncDir(nil, &fuse.FsyncIn{InHeader: fuse.InHeader{NodeId: 42}})
+	if st != fuse.OK {
+		t.Fatalf("FsyncDir() status = %v, want OK", st)
+	}
+	if session.inode != 42 {
+		t.Fatalf("FsyncDir() inode = %d, want 42", session.inode)
+	}
+}
+
+func TestFsyncDirWithoutOptInReturnsNotImplemented(t *testing.T) {
+	fs := New("vol-1", time.Second, &readIntoSession{})
+
+	if st := fs.FsyncDir(nil, &fuse.FsyncIn{}); st != fuse.ENOSYS {
+		t.Fatalf("FsyncDir() status = %v, want ENOSYS", st)
+	}
+}
+
 func TestStatusToFusePreservesPOSIXErrno(t *testing.T) {
 	tests := []struct {
 		name string

--- a/ctld/internal/volumefuse/session.go
+++ b/ctld/internal/volumefuse/session.go
@@ -50,3 +50,10 @@ type ReadIntoSession interface {
 type OpenFlagsSession interface {
 	OpenFlags() uint32
 }
+
+// FsyncDirSession is implemented by sessions that can durably synchronize a
+// directory. Sessions that do not implement it retain the existing ENOSYS
+// behavior for FUSE directory fsync requests.
+type FsyncDirSession interface {
+	FsyncDir(context.Context, uint64) error
+}

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -155,7 +155,7 @@ func (s *SandboxService) bindSandboxRootFSSync(ctx context.Context, pod *corev1.
 	if err != nil {
 		return err
 	}
-	excludedPaths, err := rootFSExcludedPathsForPod(pod)
+	excludedPaths, err := rootFSExcludedPathsForPod(pod, record.Mounts)
 	if err != nil {
 		return fmt.Errorf("resolve sandbox rootfs exclusions: %w", err)
 	}
@@ -391,22 +391,38 @@ func (s *SandboxService) rootFSPlatformForPod(pod *corev1.Pod) ocispec.Platform 
 	return platform
 }
 
-func rootFSExcludedPathsForPod(pod *corev1.Pod) ([]string, error) {
+func rootFSExcludedPathsForPod(pod *corev1.Pod, expectedMounts []managerapi.ClaimMount) ([]string, error) {
 	if pod == nil {
 		return nil, nil
 	}
-	var mounts []managerapi.ClaimMount
+	mounts, err := normalizeClaimMounts(expectedMounts)
+	if err != nil {
+		return nil, fmt.Errorf("validate durable sandbox mounts: %w", err)
+	}
+	rawMounts := ""
 	if pod.Annotations != nil {
-		rawMounts := strings.TrimSpace(pod.Annotations[controller.AnnotationMounts])
+		rawMounts = strings.TrimSpace(pod.Annotations[controller.AnnotationMounts])
+	}
+	var annotatedMounts []managerapi.ClaimMount
+	if rawMounts != "" {
+		if err := json.Unmarshal([]byte(rawMounts), &annotatedMounts); err != nil {
+			return nil, fmt.Errorf("decode %s annotation: %w", controller.AnnotationMounts, err)
+		}
+		annotatedMounts, err = normalizeClaimMounts(annotatedMounts)
+		if err != nil {
+			return nil, fmt.Errorf("validate %s annotation: %w", controller.AnnotationMounts, err)
+		}
+	}
+	if len(mounts) == 0 {
 		if rawMounts != "" {
-			if err := json.Unmarshal([]byte(rawMounts), &mounts); err != nil {
-				return nil, fmt.Errorf("decode %s annotation: %w", controller.AnnotationMounts, err)
-			}
-			var err error
-			mounts, err = normalizeClaimMounts(mounts)
-			if err != nil {
-				return nil, fmt.Errorf("validate %s annotation: %w", controller.AnnotationMounts, err)
-			}
+			return nil, fmt.Errorf("validate %s annotation: unexpected mounts metadata for sandbox without durable mounts", controller.AnnotationMounts)
+		}
+	} else {
+		if rawMounts == "" {
+			return nil, fmt.Errorf("validate %s annotation: mounts metadata is missing", controller.AnnotationMounts)
+		}
+		if !sameClaimMounts(mounts, annotatedMounts) {
+			return nil, fmt.Errorf("validate %s annotation: mounts metadata does not match durable sandbox state", controller.AnnotationMounts)
 		}
 	}
 	seen := make(map[string]struct{}, len(mounts)+8)
@@ -463,6 +479,22 @@ func rootFSExcludedPathsForPod(pod *corev1.Pod) ([]string, error) {
 		add(webhookStateMountPoint)
 	}
 	return out, nil
+}
+
+func sameClaimMounts(left, right []managerapi.ClaimMount) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	byMountPoint := make(map[string]string, len(left))
+	for _, mount := range left {
+		byMountPoint[mount.MountPoint] = mount.SandboxVolumeID
+	}
+	for _, mount := range right {
+		if byMountPoint[mount.MountPoint] != mount.SandboxVolumeID {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *SandboxService) saveRestoredRuntimePod(ctx context.Context, pod *corev1.Pod, record *sandboxstore.SandboxRecord) error {

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -432,7 +432,7 @@ func rootFSExcludedPathsForPod(pod *corev1.Pod) []string {
 		}
 		for _, mount := range container.VolumeMounts {
 			if _, rootFSBackedPortal := rootFSBackedPortalVolumes[mount.Name]; rootFSBackedPortal {
-				// Unbound portals are rebased onto the overlay upper before
+				// Unbound portals are rebased onto the merged rootfs before
 				// rootfs sync starts. Bound SandboxVolumes are excluded below
 				// from the persisted claim mounts instead.
 				continue

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -154,12 +155,16 @@ func (s *SandboxService) bindSandboxRootFSSync(ctx context.Context, pod *corev1.
 	if err != nil {
 		return err
 	}
+	excludedPaths, err := rootFSExcludedPathsForPod(pod)
+	if err != nil {
+		return fmt.Errorf("resolve sandbox rootfs exclusions: %w", err)
+	}
 	request := ctldapi.BindRootFSSyncRequest{
 		Target:            rootFSTargetForPod(pod),
 		SandboxID:         record.ID,
 		TeamID:            record.TeamID,
 		RuntimeGeneration: runtimeGenerationFromPod(pod),
-		ExcludedPaths:     rootFSExcludedPathsForPod(pod),
+		ExcludedPaths:     excludedPaths,
 	}
 	if parent != nil {
 		request.Parent = cloneRootFSHeadReference(&parent.Reference)
@@ -386,13 +391,23 @@ func (s *SandboxService) rootFSPlatformForPod(pod *corev1.Pod) ocispec.Platform 
 	return platform
 }
 
-func rootFSExcludedPathsForPod(pod *corev1.Pod) []string {
+func rootFSExcludedPathsForPod(pod *corev1.Pod) ([]string, error) {
 	if pod == nil {
-		return nil
+		return nil, nil
 	}
 	var mounts []managerapi.ClaimMount
 	if pod.Annotations != nil {
-		mounts = parseClaimMounts(pod.Annotations[controller.AnnotationMounts])
+		rawMounts := strings.TrimSpace(pod.Annotations[controller.AnnotationMounts])
+		if rawMounts != "" {
+			if err := json.Unmarshal([]byte(rawMounts), &mounts); err != nil {
+				return nil, fmt.Errorf("decode %s annotation: %w", controller.AnnotationMounts, err)
+			}
+			var err error
+			mounts, err = normalizeClaimMounts(mounts)
+			if err != nil {
+				return nil, fmt.Errorf("validate %s annotation: %w", controller.AnnotationMounts, err)
+			}
+		}
 	}
 	seen := make(map[string]struct{}, len(mounts)+8)
 	out := make([]string, 0, len(mounts)+8)
@@ -447,7 +462,7 @@ func rootFSExcludedPathsForPod(pod *corev1.Pod) []string {
 	if pod.Annotations != nil && strings.TrimSpace(pod.Annotations[controller.AnnotationWebhookStateVolumeID]) != "" {
 		add(webhookStateMountPoint)
 	}
-	return out
+	return out, nil
 }
 
 func (s *SandboxService) saveRestoredRuntimePod(ctx context.Context, pod *corev1.Pod, record *sandboxstore.SandboxRecord) error {

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -415,10 +415,15 @@ func rootFSExcludedPathsForPod(pod *corev1.Pod) []string {
 	add("/tmp")
 	add("/procd")
 	add("/procd-image")
-	portalVolumes := make(map[string]struct{})
+	rootFSBackedPortalVolumes := make(map[string]struct{})
 	for _, volume := range pod.Spec.Volumes {
 		if volume.CSI != nil && volume.CSI.Driver == volumeportal.DriverName {
-			portalVolumes[volume.Name] = struct{}{}
+			attributes := volume.CSI.VolumeAttributes
+			if attributes[volumeportal.AttributePortalName] == volumeportal.WebhookStatePortalName ||
+				path.Clean(strings.TrimSpace(attributes[volumeportal.AttributeMountPath])) == volumeportal.WebhookStateMountPath {
+				continue
+			}
+			rootFSBackedPortalVolumes[volume.Name] = struct{}{}
 		}
 	}
 	for _, container := range pod.Spec.Containers {
@@ -426,7 +431,7 @@ func rootFSExcludedPathsForPod(pod *corev1.Pod) []string {
 			continue
 		}
 		for _, mount := range container.VolumeMounts {
-			if _, rootFSBackedPortal := portalVolumes[mount.Name]; rootFSBackedPortal {
+			if _, rootFSBackedPortal := rootFSBackedPortalVolumes[mount.Name]; rootFSBackedPortal {
 				// Unbound portals are rebased onto the overlay upper before
 				// rootfs sync starts. Bound SandboxVolumes are excluded below
 				// from the persisted claim mounts instead.

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
 	"github.com/sandbox0-ai/sandbox0/pkg/managerapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/rootfshead"
+	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -414,11 +415,23 @@ func rootFSExcludedPathsForPod(pod *corev1.Pod) []string {
 	add("/tmp")
 	add("/procd")
 	add("/procd-image")
+	portalVolumes := make(map[string]struct{})
+	for _, volume := range pod.Spec.Volumes {
+		if volume.CSI != nil && volume.CSI.Driver == volumeportal.DriverName {
+			portalVolumes[volume.Name] = struct{}{}
+		}
+	}
 	for _, container := range pod.Spec.Containers {
 		if container.Name != sandboxRootFSContainerName {
 			continue
 		}
 		for _, mount := range container.VolumeMounts {
+			if _, rootFSBackedPortal := portalVolumes[mount.Name]; rootFSBackedPortal {
+				// Unbound portals are rebased onto the overlay upper before
+				// rootfs sync starts. Bound SandboxVolumes are excluded below
+				// from the persisted claim mounts instead.
+				continue
+			}
 			add(strings.TrimSpace(mount.MountPath))
 		}
 		break

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -217,6 +217,28 @@ func TestBindSandboxRootFSSyncWaitsThroughTransientInitialError(t *testing.T) {
 	assert.GreaterOrEqual(t, statusCalls.Load(), int32(2))
 }
 
+func TestBindSandboxRootFSSyncRejectsMalformedClaimMounts(t *testing.T) {
+	var called atomic.Bool
+	ctld := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		called.Store(true)
+	}))
+	defer ctld.Close()
+	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
+	pod := rootFSTestPod("pod-malformed-mounts", "sandbox-1", "team-1")
+	pod.Status.HostIP = ctldURL.Hostname()
+	pod.Annotations[controller.AnnotationMounts] = "{"
+	record := &sandboxstore.SandboxRecord{ID: "sandbox-1", TeamID: "team-1", RuntimeGeneration: 1}
+	svc := &SandboxService{
+		ctldClient: ctldapi.NewClientWithTimeout(time.Second),
+		config:     SandboxServiceConfig{CtldEnabled: true, CtldPort: ctldPort},
+	}
+
+	err := svc.bindSandboxRootFSSync(context.Background(), pod, record)
+
+	require.ErrorContains(t, err, "resolve sandbox rootfs exclusions")
+	assert.False(t, called.Load())
+}
+
 func TestPrepareRootFSCheckpointAbandonsPartialSeal(t *testing.T) {
 	const sandboxID = "sandbox-1"
 	const teamID = "team-1"
@@ -775,7 +797,8 @@ func TestRootFSExcludedPathsForPodUsesBoundClaimMountPaths(t *testing.T) {
 		},
 	})
 
-	got := rootFSExcludedPathsForPod(pod)
+	got, err := rootFSExcludedPathsForPod(pod)
+	require.NoError(t, err)
 
 	assert.ElementsMatch(t, []string{
 		"/tmp", "/procd", "/procd-image",
@@ -791,9 +814,20 @@ func TestRootFSExcludedPathsForPodIncludesRuntimeMountsButNotUnboundPortals(t *t
 		Name: "runtime-config", MountPath: "/config",
 	})
 
-	got := rootFSExcludedPathsForPod(pod)
+	got, err := rootFSExcludedPathsForPod(pod)
+	require.NoError(t, err)
 
 	assert.ElementsMatch(t, []string{"/tmp", "/procd", "/procd-image", volumeportal.WebhookStateMountPath, "/config"}, got)
+}
+
+func TestRootFSExcludedPathsForPodRejectsMalformedClaimMounts(t *testing.T) {
+	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
+	addRootFSTestVolumePortal(pod, "workspace", "/workspace")
+	pod.Annotations[controller.AnnotationMounts] = "{"
+
+	_, err := rootFSExcludedPathsForPod(pod)
+
+	require.ErrorContains(t, err, "decode "+controller.AnnotationMounts+" annotation")
 }
 
 func rootFSTestPod(name, sandboxID, teamID string) *corev1.Pod {

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -783,7 +783,7 @@ func TestRootFSExcludedPathsForPodUsesBoundClaimMountPaths(t *testing.T) {
 	}, got)
 }
 
-func TestRootFSExcludedPathsForPodIncludesEveryRuntimeMount(t *testing.T) {
+func TestRootFSExcludedPathsForPodIncludesRuntimeMountsButNotUnboundPortals(t *testing.T) {
 	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
 	addRootFSTestVolumePortal(pod, "data", "/workspace/data")
 	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
@@ -792,7 +792,7 @@ func TestRootFSExcludedPathsForPodIncludesEveryRuntimeMount(t *testing.T) {
 
 	got := rootFSExcludedPathsForPod(pod)
 
-	assert.ElementsMatch(t, []string{"/tmp", "/procd", "/procd-image", "/workspace/data", "/config"}, got)
+	assert.ElementsMatch(t, []string{"/tmp", "/procd", "/procd-image", "/config"}, got)
 }
 
 func rootFSTestPod(name, sandboxID, teamID string) *corev1.Pod {

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -239,6 +239,52 @@ func TestBindSandboxRootFSSyncRejectsMalformedClaimMounts(t *testing.T) {
 	assert.False(t, called.Load())
 }
 
+func TestBindSandboxRootFSSyncRejectsMountMetadataMismatch(t *testing.T) {
+	tests := []struct {
+		name       string
+		annotation string
+	}{
+		{name: "missing"},
+		{name: "null", annotation: "null"},
+		{name: "empty", annotation: "[]"},
+		{name: "different volume", annotation: `[{"sandboxvolume_id":"vol-2","mount_point":"/workspace"}]`},
+		{name: "partial", annotation: `[{"sandboxvolume_id":"vol-1","mount_point":"/workspace"}]`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var called atomic.Bool
+			ctld := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				called.Store(true)
+			}))
+			defer ctld.Close()
+			ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
+			pod := rootFSTestPod("pod-mount-mismatch", "sandbox-1", "team-1")
+			pod.Status.HostIP = ctldURL.Hostname()
+			if test.annotation != "" {
+				pod.Annotations[controller.AnnotationMounts] = test.annotation
+			}
+			record := &sandboxstore.SandboxRecord{
+				ID:                "sandbox-1",
+				TeamID:            "team-1",
+				RuntimeGeneration: 1,
+				Mounts: []managerapi.ClaimMount{
+					{SandboxVolumeID: "vol-1", MountPoint: "/workspace"},
+					{SandboxVolumeID: "vol-3", MountPoint: "/data"},
+				},
+			}
+			svc := &SandboxService{
+				ctldClient: ctldapi.NewClientWithTimeout(time.Second),
+				config:     SandboxServiceConfig{CtldEnabled: true, CtldPort: ctldPort},
+			}
+
+			err := svc.bindSandboxRootFSSync(context.Background(), pod, record)
+
+			require.ErrorContains(t, err, "resolve sandbox rootfs exclusions")
+			assert.False(t, called.Load())
+		})
+	}
+}
+
 func TestPrepareRootFSCheckpointAbandonsPartialSeal(t *testing.T) {
 	const sandboxID = "sandbox-1"
 	const teamID = "team-1"
@@ -797,7 +843,11 @@ func TestRootFSExcludedPathsForPodUsesBoundClaimMountPaths(t *testing.T) {
 		},
 	})
 
-	got, err := rootFSExcludedPathsForPod(pod)
+	got, err := rootFSExcludedPathsForPod(pod, []managerapi.ClaimMount{
+		{SandboxVolumeID: "vol-1", MountPoint: "/workspace/data/"},
+		{SandboxVolumeID: "vol-2", MountPoint: "/workspace/database"},
+		{SandboxVolumeID: "vol-3", MountPoint: "/tmp/sandbox0-volume"},
+	})
 	require.NoError(t, err)
 
 	assert.ElementsMatch(t, []string{
@@ -814,7 +864,7 @@ func TestRootFSExcludedPathsForPodIncludesRuntimeMountsButNotUnboundPortals(t *t
 		Name: "runtime-config", MountPath: "/config",
 	})
 
-	got, err := rootFSExcludedPathsForPod(pod)
+	got, err := rootFSExcludedPathsForPod(pod, nil)
 	require.NoError(t, err)
 
 	assert.ElementsMatch(t, []string{"/tmp", "/procd", "/procd-image", volumeportal.WebhookStateMountPath, "/config"}, got)
@@ -825,7 +875,7 @@ func TestRootFSExcludedPathsForPodRejectsMalformedClaimMounts(t *testing.T) {
 	addRootFSTestVolumePortal(pod, "workspace", "/workspace")
 	pod.Annotations[controller.AnnotationMounts] = "{"
 
-	_, err := rootFSExcludedPathsForPod(pod)
+	_, err := rootFSExcludedPathsForPod(pod, nil)
 
 	require.ErrorContains(t, err, "decode "+controller.AnnotationMounts+" annotation")
 }

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -786,13 +786,14 @@ func TestRootFSExcludedPathsForPodUsesBoundClaimMountPaths(t *testing.T) {
 func TestRootFSExcludedPathsForPodIncludesRuntimeMountsButNotUnboundPortals(t *testing.T) {
 	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
 	addRootFSTestVolumePortal(pod, "data", "/workspace/data")
+	addRootFSTestVolumePortal(pod, volumeportal.WebhookStatePortalName, volumeportal.WebhookStateMountPath)
 	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
 		Name: "runtime-config", MountPath: "/config",
 	})
 
 	got := rootFSExcludedPathsForPod(pod)
 
-	assert.ElementsMatch(t, []string{"/tmp", "/procd", "/procd-image", "/config"}, got)
+	assert.ElementsMatch(t, []string{"/tmp", "/procd", "/procd-image", volumeportal.WebhookStateMountPath, "/config"}, got)
 }
 
 func rootFSTestPod(name, sandboxID, teamID string) *corev1.Pod {

--- a/tests/e2e/cases/api_mode_suite.go
+++ b/tests/e2e/cases/api_mode_suite.go
@@ -3086,6 +3086,24 @@ test "$(cat %s)" = %s
 		body, _, readErr := session.ReadFile(env.TestCtx.Context, GinkgoT(), sandboxID, filePath)
 		return body, readErr
 	}).WithTimeout(20 * time.Second).WithPolling(1 * time.Second).Should(Equal(content))
+
+	pauseResp, status, err := session.PauseSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(pauseResp).NotTo(BeNil())
+	waitForSandboxLifecycleStatusEventually(env, session, sandboxID, apispec.SandboxLifecycleStatusPaused)
+
+	resumeResp, status, err := session.ResumeSandbox(env.TestCtx.Context, GinkgoT(), sandboxID)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(status).To(Equal(http.StatusOK))
+	Expect(resumeResp).NotTo(BeNil())
+	Expect(resumeResp.Resumed).To(BeTrue())
+	waitForSandboxPodReadyEventually(env, session, sandboxID, templateNamespace)
+
+	Eventually(func() ([]byte, error) {
+		body, _, readErr := session.ReadFile(env.TestCtx.Context, GinkgoT(), sandboxID, filePath)
+		return body, readErr
+	}).WithTimeout(20 * time.Second).WithPolling(1 * time.Second).Should(Equal(content))
 }
 
 func assertClaimMountedVolumeWritable(env *framework.ScenarioEnv, session *e2eutils.Session) {


### PR DESCRIPTION
## What changed

- Rebase every unbound volume portal onto the active container merged overlay before rootfs synchronization starts.
- Keep portals backed by real SandboxVolumes independent and excluded from rootfs capture.
- Fail closed before rootfs bind when the persisted claim-mount annotation is malformed or invalid, instead of silently treating bound mounts as unbound.
- Include unbound portal paths in COW rootfs capture while retaining runtime and bound-volume exclusions.
- Restrict portal cleanup to ctld-owned staging directories so unpublish cannot remove overlay data.
- Make FUSE `flush` a non-durability close boundary while preserving explicit file `fsync`.
- Support directory `fsync` for rootfs-backed portals without changing s0fs behavior.
- Preserve symlink timestamps with no-follow setattr semantics and reject symlink truncate/chmod rather than touching the target.
- Preserve hardlink identity across path lookup, unlink, rename, pause/resume, and ctld HA recovery so linked paths share one FUSE inode and page cache.
- Raise the portal write size to 1 MiB and reuse size-bucketed request buffers to reduce allocation and copy overhead.
- Extend unit and API-mode E2E coverage for unbound portal persistence, exclusions, request-buffer reuse, directory sync, symlink metadata, and hardlink recovery.

## Root cause

Template-declared mounts that were omitted from a claim stayed writable through a temporary ctld rootfs-backed portal. Manager excluded every CSI portal mount from rootfs capture, and ctld removed the temporary backing when the runtime Pod disappeared. Files written under an unbound mount such as `/workspace` therefore disappeared after pause and resume.

## Impact

Unbound template mounts now retain their documented rootfs-backed behavior across pause and resume. Explicitly bound SandboxVolumes keep their existing independent persistence semantics. Runtime-owned portals remain excluded.

## Validation

Local:

- `go test -race ./ctld/internal/fuseportal ./ctld/internal/volumefuse ./ctld/internal/ctld/portal ./ctld/internal/ctld/rootfs ./ctld/cmd/ctld ./manager/pkg/service ./tests/e2e/cases`
- `go vet ./ctld/internal/ctld/portal ./ctld/internal/volumefuse`
- `GOFLAGS=-buildvcs=false golangci-lint run ./...` (`0 issues`)
- malformed mount metadata target tests under race (`20/20`) and the complete `manager/pkg/service` race suite

Persistent remote kind, latest ctld image `sha256:9dc6762e585b098b9c9c085104478027a9d34542e4c81276c3c34019eaf15879`:

- Rolled ctld B then A; all four Pods received new UIDs, the exact image ID, and became Ready.
- 10 immediate write-without-sync -> pause -> resume cycles passed (330 files, about 10 MiB).
- Explicit file and directory `fsync`, 5,002 files, 154,697,756 bytes, pause/resume, and full SHA-256 verification passed.
- 16 concurrent writers wrote 512 MiB at 83.49 MiB/s; immediate pause/resume and all 16 SHA-256 checks passed. Active ctld observed RSS peaked at about 159 MiB; standby stayed about 53 MiB.
- A paused v1-template sandbox resumed after the template moved to v2 with its v1 base and sandbox-owned conflict file; a fresh claim used v2.
- `/workspace` export -> replace-roots import -> pause/resume preserved regular files, hardlinks, symlinks, `user.*` xattrs, owner/mode/mtime, and removed target-only files. A real SandboxVolume bound at `/workspace` was classified separately and export was rejected.
- A targeted hardlink test reproduced distinct inode IDs, stale peer visibility, and link-topology loss on the previous image. On the latest image, both paths remained the same inode with `nlink=2` and identical content immediately, after source pause/resume, after export/import, and after target pause/resume; the archive shrank from about 2 MiB to about 1 MiB because the payload was no longer duplicated.
- Repeated the live ctld B then A replacement after the hardlink fix; reads and writes continued between replacements and the following pause/resume verification passed.

Latest paired three-run medians versus native overlayfs in the same sandbox node:

| Operation | Portal/native |
|---|---:|
| 64 MiB sequential write | 1.88x |
| 64 MiB sequential read | 2.12x |
| 2,000 small-file create | 3.06x |
| 2,000 small-file read | 1.24x |
| 2,000 small-file stat | 4.16x |
| 2,000 small-file delete | 5.42x |

Two post-hardlink runs moved in both directions rather than showing a consistent regression. Portal median absolute times remained in the previous range, while individual large-write samples still showed 1.0--1.8 s outliers. Metadata-heavy operations remain slower than overlayfs and are documented rather than hidden by the median.
