### PR TITLE
perf(rootfs): keep warm pods on resume

### DIFF
--- a/ctld/internal/ctld/rootfs/containerd_runtime.go
+++ b/ctld/internal/ctld/rootfs/containerd_runtime.go
@@ -31,12 +31,17 @@ type criRuntimeService interface {
 	PodSandboxStats(ctx context.Context, in *runtimeapi.PodSandboxStatsRequest, opts ...grpc.CallOption) (*runtimeapi.PodSandboxStatsResponse, error)
 }
 
+type criImageService interface {
+	ImageStatus(ctx context.Context, in *runtimeapi.ImageStatusRequest, opts ...grpc.CallOption) (*runtimeapi.ImageStatusResponse, error)
+}
+
 type ContainerdRuntimeConfig struct {
 	CRIEndpoint            string
 	ContainerdEndpoint     string
 	Namespace              string
 	DialTimeout            time.Duration
 	CRIClient              criRuntimeService
+	CRIImageClient         criImageService
 	CRIDialContext         func(ctx context.Context, endpoint string) (*grpc.ClientConn, error)
 	ContainerdClient       containerdClient
 	ContainerdDataRoot     string
@@ -44,18 +49,20 @@ type ContainerdRuntimeConfig struct {
 }
 
 type ContainerdRuntime struct {
-	criEndpoint            string
-	containerdEndpoint     string
-	containerdDataRoot     string
-	containerdHostDataRoot string
-	namespace              string
-	dialTimeout            time.Duration
-	criClient              criRuntimeService
-	criDialContext         func(ctx context.Context, endpoint string) (*grpc.ClientConn, error)
-	criMu                  sync.Mutex
-	criConn                *grpc.ClientConn
-	connectedCRIClient     criRuntimeService
-	containerdClient       containerdClient
+	criEndpoint             string
+	containerdEndpoint      string
+	containerdDataRoot      string
+	containerdHostDataRoot  string
+	namespace               string
+	dialTimeout             time.Duration
+	criClient               criRuntimeService
+	criImageClient          criImageService
+	criDialContext          func(ctx context.Context, endpoint string) (*grpc.ClientConn, error)
+	criMu                   sync.Mutex
+	criConn                 *grpc.ClientConn
+	connectedCRIClient      criRuntimeService
+	connectedCRIImageClient criImageService
+	containerdClient        containerdClient
 }
 
 type containerdClient interface {
@@ -83,6 +90,10 @@ func NewContainerdRuntime(cfg ContainerdRuntimeConfig) *ContainerdRuntime {
 	if timeout <= 0 {
 		timeout = defaultDialTimeout
 	}
+	imageClient := cfg.CRIImageClient
+	if imageClient == nil {
+		imageClient, _ = cfg.CRIClient.(criImageService)
+	}
 	return &ContainerdRuntime{
 		criEndpoint:            criEndpoint,
 		containerdEndpoint:     containerdEndpoint,
@@ -91,6 +102,7 @@ func NewContainerdRuntime(cfg ContainerdRuntimeConfig) *ContainerdRuntime {
 		namespace:              namespace,
 		dialTimeout:            timeout,
 		criClient:              cfg.CRIClient,
+		criImageClient:         imageClient,
 		criDialContext:         cfg.CRIDialContext,
 		containerdClient:       cfg.ContainerdClient,
 	}
@@ -200,6 +212,7 @@ func (r *ContainerdRuntime) Close() error {
 	conn := r.criConn
 	r.criConn = nil
 	r.connectedCRIClient = nil
+	r.connectedCRIImageClient = nil
 	r.criMu.Unlock()
 	if conn == nil {
 		return nil
@@ -233,7 +246,29 @@ func (r *ContainerdRuntime) runtimeClient(ctx context.Context) (criRuntimeServic
 	}
 	r.criConn = conn
 	r.connectedCRIClient = runtimeapi.NewRuntimeServiceClient(conn)
+	r.connectedCRIImageClient = runtimeapi.NewImageServiceClient(conn)
 	return r.connectedCRIClient, nil
+}
+
+func (r *ContainerdRuntime) imageClient(ctx context.Context) (criImageService, error) {
+	if r != nil && r.criImageClient != nil {
+		return r.criImageClient, nil
+	}
+	if r == nil {
+		return nil, fmt.Errorf("containerd runtime is nil")
+	}
+	if r.criClient != nil {
+		return nil, fmt.Errorf("cri image service client is not configured")
+	}
+	if _, err := r.runtimeClient(ctx); err != nil {
+		return nil, err
+	}
+	r.criMu.Lock()
+	defer r.criMu.Unlock()
+	if r.connectedCRIImageClient == nil {
+		return nil, fmt.Errorf("cri image service client is not connected")
+	}
+	return r.connectedCRIImageClient, nil
 }
 
 func (r *ContainerdRuntime) client(ctx context.Context) (containerdClient, func(), error) {

--- a/ctld/internal/ctld/rootfs/head_v3.go
+++ b/ctld/internal/ctld/rootfs/head_v3.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/rootfsstore"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/rootfshead"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 const (
@@ -266,7 +267,39 @@ func (r *ContainerdRuntime) MaterializeRootFSHead(
 	if err := localImage.Unpack(leaseCtx, rootfshead.SnapshotterName); err != nil {
 		return fmt.Errorf("unpack local rootfs Head image: %w", err)
 	}
+	if err := r.waitForCRIImage(leaseCtx, image.Name); err != nil {
+		return err
+	}
 	return nil
+}
+
+// waitForCRIImage closes the registration race between containerd's image
+// store and the CRI image service observed by kubelet.
+func (r *ContainerdRuntime) waitForCRIImage(ctx context.Context, image string) error {
+	client, err := r.imageClient(ctx)
+	if err != nil {
+		return err
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		response, requestErr := client.ImageStatus(waitCtx, &runtimeapi.ImageStatusRequest{
+			Image: &runtimeapi.ImageSpec{Image: image},
+		})
+		if requestErr == nil && response != nil && response.Image != nil {
+			return nil
+		}
+		select {
+		case <-waitCtx.Done():
+			if requestErr != nil {
+				return fmt.Errorf("wait for local rootfs Head image in CRI: %w", requestErr)
+			}
+			return fmt.Errorf("wait for local rootfs Head image in CRI: %w", waitCtx.Err())
+		case <-ticker.C:
+		}
+	}
 }
 
 // ensureRootFSHeadSnapshot explicitly commits the marker snapshot with its

--- a/ctld/internal/ctld/rootfs/head_v3_test.go
+++ b/ctld/internal/ctld/rootfs/head_v3_test.go
@@ -21,7 +21,34 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/rootfshead"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
+
+func TestWaitForCRIImageWaitsForImageServiceVisibility(t *testing.T) {
+	imageClient := &sequencedCRIImageClient{visibleAt: 3}
+	runtime := NewContainerdRuntime(ContainerdRuntimeConfig{CRIImageClient: imageClient})
+
+	require.NoError(t, runtime.waitForCRIImage(context.Background(), "sandbox0.local/rootfs-heads@sha256:test"))
+	assert.Equal(t, 3, imageClient.calls)
+}
+
+type sequencedCRIImageClient struct {
+	calls     int
+	visibleAt int
+}
+
+func (c *sequencedCRIImageClient) ImageStatus(
+	_ context.Context,
+	request *runtimeapi.ImageStatusRequest,
+	_ ...grpc.CallOption,
+) (*runtimeapi.ImageStatusResponse, error) {
+	c.calls++
+	if c.calls < c.visibleAt {
+		return &runtimeapi.ImageStatusResponse{}, nil
+	}
+	return &runtimeapi.ImageStatusResponse{Image: &runtimeapi.Image{Id: request.Image.Image}}, nil
+}
 
 func TestBaseIdentityAndConfigSelectsNodePlatformFromImageIndex(t *testing.T) {
 	client := newBaseIdentityClient(t)

--- a/manager/pkg/controller/pool_manager.go
+++ b/manager/pkg/controller/pool_manager.go
@@ -68,6 +68,8 @@ const (
 	AnnotationSandboxID                    = sandboxpod.AnnotationSandboxID
 	AnnotationRuntimeGeneration            = sandboxpod.AnnotationRuntimeGeneration
 	AnnotationRootFSSnapshotterInstance    = sandboxpod.AnnotationRootFSSnapshotterInstance
+	AnnotationRootFSHeadID                 = sandboxpod.AnnotationRootFSHeadID
+	AnnotationRootFSHeadImage              = sandboxpod.AnnotationRootFSHeadImage
 	AnnotationWebhookStateVolumeID         = sandboxpod.AnnotationWebhookStateVolumeID
 	AnnotationHotClaimReservation          = sandboxpod.AnnotationHotClaimReservation
 	AnnotationHotClaimReservationState     = sandboxpod.AnnotationHotClaimReservationState

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -750,13 +750,16 @@ func (s *SandboxService) initializeClaimRootFSFromSnapshot(ctx context.Context, 
 	if head == nil {
 		return pod, true, fmt.Errorf("%w: snapshot %s", sandboxstore.ErrRootFSFilesystemNotFound, snapshotID)
 	}
-	pod, err = s.replaceRuntimeWithRootFSHead(ctx, pod, template, req, head)
+	var recreated bool
+	pod, recreated, err = s.activateRuntimeWithRootFSHead(ctx, pod, template, req, head)
 	if err != nil {
 		return pod, true, err
 	}
-	pod, err = s.waitForColdPodNetworkPolicy(ctx, pod, req.TeamID)
-	if err != nil {
-		return pod, true, fmt.Errorf("prepare rootfs snapshot runtime network policy: %w", err)
+	if recreated {
+		pod, err = s.waitForColdPodNetworkPolicy(ctx, pod, req.TeamID)
+		if err != nil {
+			return pod, true, fmt.Errorf("prepare rootfs snapshot runtime network policy: %w", err)
+		}
 	}
 	pod, err = s.waitForPodClaimReady(ctx, pod.Namespace, pod.Name)
 	if err != nil {

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -1359,9 +1359,19 @@ func TestClaimSandboxAppliesRootFSFromSnapshotBeforeRuntimeActivation(t *testing
 	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
 
 	idlePod := newClaimTestPod(templateNamespace, "idle-ready", templateID, true)
+	idlePod.UID = types.UID("warm-runtime-uid")
 	idlePod.Spec.NodeName = "node-a"
+	idlePod.Spec.Containers[0].Image = "registry.example.com/template@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	idlePod.Spec.Containers[0].ImagePullPolicy = corev1.PullIfNotPresent
 	idlePod.Status.HostIP = ctldURL.Hostname()
 	idlePod.Status.PodIP = "10.0.0.10"
+	idlePod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name:    "procd",
+		Image:   idlePod.Spec.Containers[0].Image,
+		ImageID: "containerd://sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		Ready:   true,
+		State:   corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+	}}
 	snapshotterInstance := "snapshotter-pod/0/containerd://snapshotter"
 	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
 		Name: idlePod.Spec.NodeName,
@@ -1388,27 +1398,25 @@ func TestClaimSandboxAppliesRootFSFromSnapshotBeforeRuntimeActivation(t *testing
 	}
 	indexer := newClaimTestPodIndexer(t, idlePod)
 	client := fake.NewSimpleClientset(idlePod.DeepCopy())
-	client.PrependReactor("delete", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
-		deleted, exists, err := indexer.GetByKey(templateNamespace + "/" + action.(k8stesting.DeleteAction).GetName())
-		if err == nil && exists {
-			_ = indexer.Delete(deleted)
+	client.PrependReactor("update", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		updated := action.(k8stesting.UpdateAction).GetObject().(*corev1.Pod)
+		if updated.Spec.Containers[0].Image != sourceHead.Image.Name {
+			return false, nil, nil
 		}
-		return false, nil, nil
-	})
-	scheduleCreatedClaimPodInIndexer(t, client, indexer, func(pod *corev1.Pod) {
-		if got := pod.Annotations[controller.AnnotationRootFSSnapshotterInstance]; got != snapshotterInstance {
+		if got := updated.Annotations[controller.AnnotationRootFSSnapshotterInstance]; got != snapshotterInstance {
 			t.Fatalf("rootfs snapshotter instance = %q, want %q", got, snapshotterInstance)
 		}
-		pod.UID = types.UID("rootfs-runtime-uid")
-		pod.Status.HostIP = ctldURL.Hostname()
-		pod.Status.PodIP = "10.0.0.11"
-		pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
-			Name: "procd", Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+		updated.Status.ContainerStatuses = []corev1.ContainerStatus{{
+			Name:    "procd",
+			Image:   sourceHead.Image.Name,
+			ImageID: "containerd://" + sourceHead.Image.ManifestDigest,
+			Ready:   true,
+			State:   corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
 		}}
-		pod.Status.Conditions = []corev1.PodCondition{
-			{Type: corev1.PodReady, Status: corev1.ConditionTrue},
-			{Type: v1alpha1.SandboxPodReadinessConditionType, Status: corev1.ConditionTrue},
+		if err := indexer.Update(updated.DeepCopy()); err != nil {
+			return true, nil, err
 		}
+		return false, nil, nil
 	})
 	installRuntimeObservationReactor(t, client, indexer, runtimecontrol.ObservedReady, func(*corev1.Pod) {
 		if len(calls) == 0 || calls[0] != "materialize" {
@@ -1459,6 +1467,14 @@ func TestClaimSandboxAppliesRootFSFromSnapshotBeforeRuntimeActivation(t *testing
 	record := store.records[resp.SandboxID]
 	if record == nil || record.DesiredState != sandboxstore.SandboxDesiredStateActive {
 		t.Fatalf("record = %+v, want active claimed sandbox", record)
+	}
+	if record.CurrentPodName != idlePod.Name {
+		t.Fatalf("restored pod = %q, want warm pod %q", record.CurrentPodName, idlePod.Name)
+	}
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "create" || action.GetVerb() == "delete" {
+			t.Fatalf("warm snapshot restore used %s instead of updating the claimed Pod", action.GetVerb())
+		}
 	}
 }
 

--- a/manager/pkg/service/sandbox_service_restore.go
+++ b/manager/pkg/service/sandbox_service_restore.go
@@ -501,23 +501,26 @@ func (s *SandboxService) finishRestoredSandboxRuntime(ctx context.Context, pod *
 	if rootFSHead != nil {
 		resetCopiedSessionState = strings.TrimSpace(rootFSHead.SourceSandboxID) != "" && strings.TrimSpace(rootFSHead.SourceSandboxID) != strings.TrimSpace(record.ID)
 		phaseStarted := time.Now()
-		pod, err = s.replaceRuntimeWithRootFSHead(ctx, pod, template, req, rootFSHead)
+		var recreated bool
+		pod, recreated, err = s.activateRuntimeWithRootFSHead(ctx, pod, template, req, rootFSHead)
 		s.observeClaimPhase(record.TemplateID, claimType, "materialize_rootfs_head", phaseStarted, err)
 		if err != nil {
 			return pod, err
 		}
-		claimType = "cold"
-		phaseStarted = time.Now()
-		pod, err = s.waitForColdPodNetworkPolicy(ctx, pod, record.TeamID)
-		s.observeClaimPhase(record.TemplateID, claimType, "rootfs_head_network_policy", phaseStarted, err)
-		if err != nil {
-			return pod, err
-		}
-		phaseStarted = time.Now()
-		pod, err = s.waitForPodClaimReady(ctx, pod.Namespace, pod.Name)
-		s.observeClaimPhase(record.TemplateID, claimType, "rootfs_head_runtime_ready", phaseStarted, err)
-		if err != nil {
-			return pod, err
+		if recreated {
+			claimType = "cold"
+			phaseStarted = time.Now()
+			pod, err = s.waitForColdPodNetworkPolicy(ctx, pod, record.TeamID)
+			s.observeClaimPhase(record.TemplateID, claimType, "rootfs_head_network_policy", phaseStarted, err)
+			if err != nil {
+				return pod, err
+			}
+			phaseStarted = time.Now()
+			pod, err = s.waitForPodClaimReady(ctx, pod.Namespace, pod.Name)
+			s.observeClaimPhase(record.TemplateID, claimType, "rootfs_head_runtime_ready", phaseStarted, err)
+			if err != nil {
+				return pod, err
+			}
 		}
 	}
 	pod, runtimeRevision, err := s.publishRuntimeAssignment(ctx, pod, resetCopiedSessionState)

--- a/manager/pkg/service/sandbox_service_rootfs.go
+++ b/manager/pkg/service/sandbox_service_rootfs.go
@@ -11,17 +11,14 @@ import (
 	"time"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/sandboxstore"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
-	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
 	"github.com/sandbox0-ai/sandbox0/pkg/managerapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/rootfshead"
 	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const sandboxRootFSContainerName = "procd"
@@ -296,63 +293,6 @@ func currentRootFSHeadID(ctx context.Context, tx sandboxstore.SandboxStoreTx, sa
 		return "", err
 	}
 	return head.Reference.HeadID, nil
-}
-
-func (s *SandboxService) replaceRuntimeWithRootFSHead(ctx context.Context, current *corev1.Pod, template *v1alpha1.SandboxTemplate, req *ClaimRequest, head *sandboxstore.SandboxRootFSHead) (*corev1.Pod, error) {
-	if s == nil || s.ctldClient == nil || current == nil || template == nil || req == nil || head == nil {
-		return current, fmt.Errorf("rootfs Head runtime replacement inputs are required")
-	}
-	nodeName := strings.TrimSpace(current.Spec.NodeName)
-	if nodeName == "" {
-		return current, fmt.Errorf("rootfs Head runtime source pod is not scheduled")
-	}
-	ctldAddress, err := s.ctldAddressForPod(ctx, current)
-	if err != nil {
-		return current, err
-	}
-	materialized, err := s.ctldClient.MaterializeRootFSHead(ctx, ctldAddress, ctldapi.MaterializeRootFSHeadRequest{
-		Reference: head.Reference,
-		Image:     head.Image,
-	}, sandboxRootFSOperationTimeout)
-	if err != nil {
-		message := ""
-		if materialized != nil {
-			message = materialized.Error
-		}
-		return current, fmt.Errorf("materialize sandbox rootfs Head: %w", rootFSResponseError(err, message))
-	}
-	if materialized == nil || !materialized.Materialized || materialized.ImageName != head.Image.Name {
-		return current, fmt.Errorf("materialize sandbox rootfs Head: ctld did not confirm image %s", head.Image.Name)
-	}
-	if s.nodeLister == nil {
-		return current, fmt.Errorf("resolve rootfs snapshotter instance: node cache is not configured")
-	}
-	node, err := s.nodeLister.Get(nodeName)
-	if err != nil {
-		return current, fmt.Errorf("resolve rootfs snapshotter instance on node %s: %w", nodeName, err)
-	}
-	snapshotterInstance := strings.TrimSpace(node.Annotations[dataplane.NodeRootFSSnapshotterInstanceAnnotation])
-	if snapshotterInstance == "" {
-		return current, fmt.Errorf("rootfs snapshotter instance is not published on node %s", nodeName)
-	}
-
-	rootFSTemplate := template.DeepCopy()
-	rootFSTemplate.Spec.MainContainer.Image = head.Image.Name
-	rootFSTemplate.Spec.MainContainer.ImagePullPolicy = string(corev1.PullNever)
-	if err := s.k8sClient.CoreV1().Pods(current.Namespace).Delete(ctx, current.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-		return current, fmt.Errorf("delete template runtime before rootfs Head attach: %w", err)
-	}
-	if err := s.waitForSandboxRuntimePodDeletion(ctx, current.Namespace, current.Name); err != nil {
-		return current, err
-	}
-	replacementRequest := *req
-	replacementRequest.PreferredNodeName = nodeName
-	replacementRequest.RootFSSnapshotterInstance = snapshotterInstance
-	replacement, err := s.createNewPod(ctx, rootFSTemplate, &replacementRequest)
-	if err != nil {
-		return current, fmt.Errorf("create rootfs Head runtime: %w", err)
-	}
-	return replacement, nil
 }
 
 const rootFSPlatformVariantLabel = "sandbox0.ai/platform-variant"

--- a/manager/pkg/service/sandbox_service_rootfs_runtime.go
+++ b/manager/pkg/service/sandbox_service_rootfs_runtime.go
@@ -1,0 +1,273 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	managerconfig "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/sandboxstore"
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	"github.com/sandbox0-ai/sandbox0/pkg/dataplane"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+)
+
+// activateRuntimeWithRootFSHead activates a materialized Head on the claimed
+// Pod. Reusing the Pod preserves its sandbox, network identity, and mounts; a
+// replacement is retained only for Pods whose immutable pull policy would
+// force the node-local image through a registry.
+func (s *SandboxService) activateRuntimeWithRootFSHead(
+	ctx context.Context,
+	current *corev1.Pod,
+	template *v1alpha1.SandboxTemplate,
+	req *ClaimRequest,
+	head *sandboxstore.SandboxRootFSHead,
+) (*corev1.Pod, bool, error) {
+	if s == nil || s.ctldClient == nil || current == nil || template == nil || req == nil || head == nil {
+		return current, false, fmt.Errorf("rootfs Head runtime activation inputs are required")
+	}
+	if err := head.Reference.Validate(); err != nil {
+		return current, false, fmt.Errorf("validate rootfs Head reference: %w", err)
+	}
+	if err := head.Image.Validate(); err != nil {
+		return current, false, fmt.Errorf("validate rootfs Head image: %w", err)
+	}
+	nodeName := strings.TrimSpace(current.Spec.NodeName)
+	if nodeName == "" {
+		return current, false, fmt.Errorf("rootfs Head runtime source pod is not scheduled")
+	}
+	containerIndex := procdContainerIndex(current.Spec.Containers)
+	if containerIndex < 0 {
+		return current, false, fmt.Errorf("pod %s/%s has no %s container", current.Namespace, current.Name, sandboxRootFSContainerName)
+	}
+
+	snapshotterInstance, err := s.rootFSSnapshotterInstanceForNode(nodeName)
+	if err != nil {
+		return current, false, err
+	}
+	if err := s.materializeRootFSHead(ctx, current, head); err != nil {
+		return current, false, err
+	}
+
+	// imagePullPolicy is immutable on an existing Pod. Always would make
+	// kubelet contact sandbox0.local even though ctld has installed the image.
+	if current.Spec.Containers[containerIndex].ImagePullPolicy == corev1.PullAlways {
+		if s.logger != nil {
+			s.logger.Warn("Falling back to a replacement Pod for rootfs Head activation",
+				zap.String("pod", current.Namespace+"/"+current.Name),
+				zap.String("reason", "procd imagePullPolicy is Always"),
+			)
+		}
+		replacement, err := s.createRootFSHeadReplacementPod(ctx, current, template, req, head, snapshotterInstance)
+		return replacement, true, err
+	}
+
+	updated, err := s.patchPodRootFSHead(ctx, current, head, snapshotterInstance)
+	if err != nil {
+		return current, false, err
+	}
+	ready, err := s.waitForPodRootFSHeadReady(ctx, updated.Namespace, updated.Name, head)
+	if err != nil {
+		return updated, false, err
+	}
+	return ready, false, nil
+}
+
+func (s *SandboxService) materializeRootFSHead(ctx context.Context, pod *corev1.Pod, head *sandboxstore.SandboxRootFSHead) error {
+	ctldAddress, err := s.ctldAddressForPod(ctx, pod)
+	if err != nil {
+		return err
+	}
+	materialized, err := s.ctldClient.MaterializeRootFSHead(ctx, ctldAddress, ctldapi.MaterializeRootFSHeadRequest{
+		Reference: head.Reference,
+		Image:     head.Image,
+	}, sandboxRootFSOperationTimeout)
+	if err != nil {
+		message := ""
+		if materialized != nil {
+			message = materialized.Error
+		}
+		return fmt.Errorf("materialize sandbox rootfs Head: %w", rootFSResponseError(err, message))
+	}
+	if materialized == nil || !materialized.Materialized || materialized.ImageName != head.Image.Name {
+		return fmt.Errorf("materialize sandbox rootfs Head: ctld did not confirm image %s", head.Image.Name)
+	}
+	return nil
+}
+
+func (s *SandboxService) rootFSSnapshotterInstanceForNode(nodeName string) (string, error) {
+	if s.nodeLister == nil {
+		return "", fmt.Errorf("resolve rootfs snapshotter instance: node cache is not configured")
+	}
+	node, err := s.nodeLister.Get(nodeName)
+	if err != nil {
+		return "", fmt.Errorf("resolve rootfs snapshotter instance on node %s: %w", nodeName, err)
+	}
+	instance := strings.TrimSpace(node.Annotations[dataplane.NodeRootFSSnapshotterInstanceAnnotation])
+	if instance == "" {
+		return "", fmt.Errorf("rootfs snapshotter instance is not published on node %s", nodeName)
+	}
+	return instance, nil
+}
+
+func (s *SandboxService) patchPodRootFSHead(
+	ctx context.Context,
+	expected *corev1.Pod,
+	head *sandboxstore.SandboxRootFSHead,
+	snapshotterInstance string,
+) (*corev1.Pod, error) {
+	var updated *corev1.Pod
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := s.k8sClient.CoreV1().Pods(expected.Namespace).Get(ctx, expected.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if expected.UID != "" && current.UID != expected.UID {
+			return fmt.Errorf("pod %s/%s identity changed from %s to %s", expected.Namespace, expected.Name, expected.UID, current.UID)
+		}
+		containerIndex := procdContainerIndex(current.Spec.Containers)
+		if containerIndex < 0 {
+			return fmt.Errorf("pod %s/%s has no %s container", current.Namespace, current.Name, sandboxRootFSContainerName)
+		}
+		if current.Spec.Containers[containerIndex].ImagePullPolicy == corev1.PullAlways {
+			return fmt.Errorf("pod %s/%s rootfs Head image cannot be updated in place with imagePullPolicy Always", current.Namespace, current.Name)
+		}
+		desired := current.DeepCopy()
+		desired.Spec.Containers[containerIndex].Image = head.Image.Name
+		if desired.Annotations == nil {
+			desired.Annotations = make(map[string]string)
+		}
+		desired.Annotations[controller.AnnotationRootFSHeadID] = head.Reference.HeadID
+		desired.Annotations[controller.AnnotationRootFSHeadImage] = head.Image.Name
+		desired.Annotations[controller.AnnotationRootFSSnapshotterInstance] = snapshotterInstance
+		updated, err = s.k8sClient.CoreV1().Pods(expected.Namespace).Update(ctx, desired, metav1.UpdateOptions{})
+		return err
+	})
+	if err != nil {
+		return expected, fmt.Errorf("activate rootfs Head image on pod %s/%s: %w", expected.Namespace, expected.Name, err)
+	}
+	return updated, nil
+}
+
+func (s *SandboxService) waitForPodRootFSHeadReady(
+	ctx context.Context,
+	namespace string,
+	name string,
+	head *sandboxstore.SandboxRootFSHead,
+) (*corev1.Pod, error) {
+	timeout := managerconfig.EffectiveRuntimeReadyTimeout(s.config.RuntimeReadyTimeout)
+	readyCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	lastReason := "rootfs Head container is not ready"
+	evaluate := func() (*corev1.Pod, bool, error) {
+		if s.podLister == nil {
+			return nil, false, fmt.Errorf("pod lister is not configured")
+		}
+		pod, err := s.podLister.Pods(namespace).Get(name)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				lastReason = fmt.Sprintf("pod %s/%s is not visible", namespace, name)
+				return nil, false, nil
+			}
+			return nil, false, err
+		}
+		ready, reason := podRootFSHeadReady(pod, head)
+		if reason != "" {
+			lastReason = reason
+		}
+		return pod, ready, nil
+	}
+	if pod, ready, err := evaluate(); err != nil || ready {
+		return pod, err
+	}
+	events, unregister := s.ensurePodEventWaiter().register(namespace, name)
+	defer unregister()
+	if pod, ready, err := evaluate(); err != nil || ready {
+		return pod, err
+	}
+	for {
+		select {
+		case <-readyCtx.Done():
+			return nil, fmt.Errorf("pod %s/%s rootfs Head not ready after %s: %s: %w", namespace, name, timeout, lastReason, readyCtx.Err())
+		case event := <-events:
+			if event.deleted {
+				return nil, fmt.Errorf("pod %s/%s rootfs Head not ready: pod is deleting", namespace, name)
+			}
+			pod, ready, err := evaluate()
+			if err != nil || ready {
+				return pod, err
+			}
+		}
+	}
+}
+
+func podRootFSHeadReady(pod *corev1.Pod, head *sandboxstore.SandboxRootFSHead) (bool, string) {
+	if pod == nil || head == nil {
+		return false, "pod or rootfs Head is nil"
+	}
+	if pod.Annotations[controller.AnnotationRootFSHeadID] != head.Reference.HeadID ||
+		pod.Annotations[controller.AnnotationRootFSHeadImage] != head.Image.Name {
+		return false, "rootfs Head annotations have not been observed"
+	}
+	containerIndex := procdContainerIndex(pod.Spec.Containers)
+	if containerIndex < 0 || pod.Spec.Containers[containerIndex].Image != head.Image.Name {
+		return false, "procd spec image has not been updated"
+	}
+	for index := range pod.Status.ContainerStatuses {
+		status := &pod.Status.ContainerStatuses[index]
+		if status.Name != sandboxRootFSContainerName {
+			continue
+		}
+		if status.State.Running == nil {
+			return false, "procd container is not running"
+		}
+		if status.Image == head.Image.Name || strings.Contains(status.ImageID, head.Image.ManifestDigest) {
+			return true, ""
+		}
+		return false, "procd is still running the previous image"
+	}
+	return false, "procd container status is missing"
+}
+
+func procdContainerIndex(containers []corev1.Container) int {
+	for index := range containers {
+		if containers[index].Name == sandboxRootFSContainerName {
+			return index
+		}
+	}
+	return -1
+}
+
+func (s *SandboxService) createRootFSHeadReplacementPod(
+	ctx context.Context,
+	current *corev1.Pod,
+	template *v1alpha1.SandboxTemplate,
+	req *ClaimRequest,
+	head *sandboxstore.SandboxRootFSHead,
+	snapshotterInstance string,
+) (*corev1.Pod, error) {
+	rootFSTemplate := template.DeepCopy()
+	rootFSTemplate.Spec.MainContainer.Image = head.Image.Name
+	rootFSTemplate.Spec.MainContainer.ImagePullPolicy = string(corev1.PullNever)
+	if err := s.k8sClient.CoreV1().Pods(current.Namespace).Delete(ctx, current.Name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+		return current, fmt.Errorf("delete template runtime before rootfs Head attach: %w", err)
+	}
+	if err := s.waitForSandboxRuntimePodDeletion(ctx, current.Namespace, current.Name); err != nil {
+		return current, err
+	}
+	replacementRequest := *req
+	replacementRequest.PreferredNodeName = current.Spec.NodeName
+	replacementRequest.RootFSSnapshotterInstance = snapshotterInstance
+	replacement, err := s.createNewPod(ctx, rootFSTemplate, &replacementRequest)
+	if err != nil {
+		return current, fmt.Errorf("create rootfs Head runtime: %w", err)
+	}
+	return replacement, nil
+}

--- a/manager/pkg/service/sandbox_service_rootfs_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_test.go
@@ -611,6 +611,14 @@ func TestFinishRestoredSandboxRuntimeMaterializesHeadBeforeRuntimeActivation(t *
 
 			const sandboxID = "sandbox-1"
 			currentPod := rootFSTestPod("pod-current", sandboxID, "team-1")
+			currentPod.UID = types.UID("warm-runtime-uid")
+			currentPod.Spec.Containers[0].Image = "registry.example.com/template@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+			currentPod.Spec.Containers[0].ImagePullPolicy = corev1.PullIfNotPresent
+			currentPod.Spec.Containers = append(currentPod.Spec.Containers, corev1.Container{
+				Name: "sidecar", Image: "registry.example.com/sidecar:v1", ImagePullPolicy: corev1.PullAlways,
+			})
+			currentPod.Status.ContainerStatuses[0].Image = currentPod.Spec.Containers[0].Image
+			currentPod.Status.ContainerStatuses[0].ImageID = "containerd://sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 			currentPod.Status.HostIP = ctldURL.Hostname()
 			currentPod.Status.PodIP = "10.0.0.10"
 			head := rootFSHeadTestFixture(t, sandboxID, "team-1", "head-v1", 3)
@@ -633,28 +641,28 @@ func TestFinishRestoredSandboxRuntimeMaterializesHeadBeforeRuntimeActivation(t *
 					dataplane.NodeRootFSSnapshotterInstanceAnnotation: snapshotterInstance,
 				},
 			}}
-			client.PrependReactor("delete", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
-				deleted, exists, err := indexer.GetByKey(currentPod.Namespace + "/" + action.(ktesting.DeleteAction).GetName())
-				if err == nil && exists {
-					_ = indexer.Delete(deleted)
+			client.PrependReactor("update", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+				updated := action.(ktesting.UpdateAction).GetObject().(*corev1.Pod)
+				if updated.Spec.Containers[0].Image != head.Image.Name {
+					return false, nil, nil
 				}
-				return false, nil, nil
-			})
-			scheduleCreatedClaimPodInIndexer(t, client, indexer, func(pod *corev1.Pod) {
-				require.Len(t, pod.Spec.Containers, 1)
-				assert.Equal(t, head.Image.Name, pod.Spec.Containers[0].Image)
-				assert.Equal(t, corev1.PullNever, pod.Spec.Containers[0].ImagePullPolicy)
-				assert.Equal(t, snapshotterInstance, pod.Annotations[controller.AnnotationRootFSSnapshotterInstance])
-				pod.UID = types.UID("rootfs-runtime-uid")
-				pod.Status.HostIP = ctldURL.Hostname()
-				pod.Status.PodIP = "10.0.0.11"
-				pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
-					Name: "procd", Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				require.Equal(t, types.UID("warm-runtime-uid"), updated.UID)
+				assert.Equal(t, corev1.PullIfNotPresent, updated.Spec.Containers[0].ImagePullPolicy)
+				require.Len(t, updated.Spec.Containers, 2)
+				assert.Equal(t, "registry.example.com/sidecar:v1", updated.Spec.Containers[1].Image)
+				assert.Equal(t, corev1.PullAlways, updated.Spec.Containers[1].ImagePullPolicy)
+				assert.Equal(t, snapshotterInstance, updated.Annotations[controller.AnnotationRootFSSnapshotterInstance])
+				assert.Equal(t, head.Reference.HeadID, updated.Annotations[controller.AnnotationRootFSHeadID])
+				assert.Equal(t, head.Image.Name, updated.Annotations[controller.AnnotationRootFSHeadImage])
+				updated.Status.ContainerStatuses = []corev1.ContainerStatus{{
+					Name:    "procd",
+					Image:   head.Image.Name,
+					ImageID: "containerd://" + head.Image.ManifestDigest,
+					Ready:   true,
+					State:   corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
 				}}
-				pod.Status.Conditions = []corev1.PodCondition{
-					{Type: corev1.PodReady, Status: corev1.ConditionTrue},
-					{Type: v1alpha1.SandboxPodReadinessConditionType, Status: corev1.ConditionTrue},
-				}
+				require.NoError(t, indexer.Update(updated.DeepCopy()))
+				return false, nil, nil
 			})
 			installRuntimeObservationReactor(t, client, indexer, runtimecontrol.ObservedReady, func(activePod *corev1.Pod) {
 				require.Equal(t, []string{"materialize", "bind"}, calls)
@@ -692,11 +700,141 @@ func TestFinishRestoredSandboxRuntimeMaterializesHeadBeforeRuntimeActivation(t *
 			restoredPod, err := svc.finishRestoredSandboxRuntime(context.Background(), currentPod, record, "hot")
 
 			require.NoError(t, err)
-			assert.NotEqual(t, currentPod.Name, restoredPod.Name)
+			assert.Equal(t, currentPod.Name, restoredPod.Name)
+			assert.Equal(t, currentPod.UID, restoredPod.UID)
+			assert.Equal(t, currentPod.Status.PodIP, restoredPod.Status.PodIP)
 			assert.Equal(t, []string{"materialize", "bind", "runtime"}, calls)
 			assert.Equal(t, head.Reference.HeadID, materializeReq.Reference.HeadID)
+			for _, action := range client.Actions() {
+				assert.NotEqual(t, "create", action.GetVerb(), "warm rootfs activation must not create a second Pod")
+				assert.NotEqual(t, "delete", action.GetVerb(), "warm rootfs activation must not delete the claimed Pod")
+			}
 		})
 	}
+}
+
+func TestPodRootFSHeadReadyRejectsStaleContainerStatus(t *testing.T) {
+	head := rootFSHeadTestFixture(t, "sandbox-1", "team-1", "head-v1", 3)
+	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
+	pod.Spec.Containers[0].Image = head.Image.Name
+	pod.Annotations[controller.AnnotationRootFSHeadID] = head.Reference.HeadID
+	pod.Annotations[controller.AnnotationRootFSHeadImage] = head.Image.Name
+	pod.Status.ContainerStatuses[0].Image = "registry.example.com/previous:latest"
+	pod.Status.ContainerStatuses[0].ImageID = "containerd://sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	ready, reason := podRootFSHeadReady(pod, head)
+
+	assert.False(t, ready)
+	assert.Contains(t, reason, "previous image")
+	pod.Status.ContainerStatuses[0].ImageID = "containerd://" + head.Image.ManifestDigest
+	ready, reason = podRootFSHeadReady(pod, head)
+	assert.True(t, ready)
+	assert.Empty(t, reason)
+}
+
+func TestWaitForPodRootFSHeadReadyWaitsForNewContainerStatus(t *testing.T) {
+	head := rootFSHeadTestFixture(t, "sandbox-1", "team-1", "head-v1", 3)
+	pod := rootFSTestPod("pod-1", "sandbox-1", "team-1")
+	pod.Spec.Containers[0].Image = head.Image.Name
+	pod.Annotations[controller.AnnotationRootFSHeadID] = head.Reference.HeadID
+	pod.Annotations[controller.AnnotationRootFSHeadImage] = head.Image.Name
+	pod.Status.ContainerStatuses[0].Image = "registry.example.com/previous:latest"
+	indexer := newClaimTestPodIndexer(t, pod)
+	svc := &SandboxService{
+		podLister: corelisters.NewPodLister(indexer),
+		logger:    zap.NewNop(),
+	}
+	handler := svc.PodEventHandler()
+	go func() {
+		time.Sleep(80 * time.Millisecond)
+		updated := pod.DeepCopy()
+		updated.Status.ContainerStatuses[0].Image = head.Image.Name
+		updated.Status.ContainerStatuses[0].ImageID = "containerd://" + head.Image.ManifestDigest
+		if err := indexer.Update(updated); err != nil {
+			t.Errorf("update pod: %v", err)
+			return
+		}
+		handler.UpdateFunc(pod, updated)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	readyPod, err := svc.waitForPodRootFSHeadReady(ctx, pod.Namespace, pod.Name, head)
+
+	require.NoError(t, err)
+	ready, reason := podRootFSHeadReady(readyPod, head)
+	assert.True(t, ready, reason)
+}
+
+func TestActivateRuntimeWithRootFSHeadReplacesAlwaysPullPod(t *testing.T) {
+	withClaimTestPublicKey(t)
+
+	var materializeReq ctldapi.MaterializeRootFSHeadRequest
+	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/rootfs/heads/materialize", r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&materializeReq))
+		require.NoError(t, json.NewEncoder(w).Encode(ctldapi.MaterializeRootFSHeadResponse{
+			Materialized: true,
+			ImageName:    materializeReq.Image.Name,
+		}))
+	}))
+	defer ctld.Close()
+	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
+
+	current := rootFSTestPod("pod-current", "sandbox-1", "team-1")
+	current.Spec.Containers[0].Image = "registry.example.com/template:latest"
+	current.Spec.Containers[0].ImagePullPolicy = corev1.PullAlways
+	current.Status.HostIP = ctldURL.Hostname()
+	indexer := newClaimTestPodIndexer(t, current)
+	client := fake.NewSimpleClientset(current.DeepCopy())
+	client.PrependReactor("delete", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+		deleted, exists, err := indexer.GetByKey(current.Namespace + "/" + action.(ktesting.DeleteAction).GetName())
+		if err == nil && exists {
+			_ = indexer.Delete(deleted)
+		}
+		return false, nil, nil
+	})
+	snapshotterInstance := "snapshotter-pod/0/containerd://snapshotter"
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: current.Spec.NodeName,
+		Annotations: map[string]string{
+			dataplane.NodeRootFSSnapshotterInstanceAnnotation: snapshotterInstance,
+		},
+	}}
+	head := rootFSHeadTestFixture(t, "sandbox-1", "team-1", "head-v1", 3)
+	template := &v1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "template-1", Namespace: current.Namespace},
+		Spec: v1alpha1.SandboxTemplateSpec{MainContainer: v1alpha1.ContainerSpec{
+			Image: "registry.example.com/template:latest", ImagePullPolicy: string(corev1.PullAlways),
+		}},
+	}
+	svc := &SandboxService{
+		k8sClient:              client,
+		podLister:              corelisters.NewPodLister(indexer),
+		nodeLister:             newClaimTestNodeLister(t, node),
+		secretLister:           newClaimTestSecretLister(t),
+		ctldClient:             ctldapi.NewClientWithTimeout(time.Second),
+		internalTokenGenerator: staticTokenGenerator{},
+		config: SandboxServiceConfig{
+			CtldEnabled: true,
+			CtldPort:    ctldPort,
+		},
+		clock:  systemTime{},
+		logger: zap.NewNop(),
+	}
+
+	replacement, recreated, err := svc.activateRuntimeWithRootFSHead(context.Background(), current, template, &ClaimRequest{
+		TeamID: "team-1", UserID: "user-1", Template: "template-1", SandboxID: "sandbox-1", RuntimeGeneration: 4,
+	}, head)
+
+	require.NoError(t, err)
+	assert.True(t, recreated)
+	assert.NotEqual(t, current.Name, replacement.Name)
+	require.Len(t, replacement.Spec.Containers, 1)
+	assert.Equal(t, head.Image.Name, replacement.Spec.Containers[0].Image)
+	assert.Equal(t, corev1.PullNever, replacement.Spec.Containers[0].ImagePullPolicy)
+	assert.Equal(t, current.Spec.NodeName, replacement.Spec.NodeName)
+	assert.Equal(t, snapshotterInstance, replacement.Annotations[controller.AnnotationRootFSSnapshotterInstance])
 }
 
 func TestFinishRestoredSandboxRuntimeUsesTemplateBaselineWithoutPublishedHead(t *testing.T) {

--- a/pkg/sandboxpod/metadata.go
+++ b/pkg/sandboxpod/metadata.go
@@ -41,6 +41,8 @@ const (
 	AnnotationSandboxID                    = "sandbox0.ai/sandbox-id"
 	AnnotationRuntimeGeneration            = "sandbox0.ai/runtime-generation"
 	AnnotationRootFSSnapshotterInstance    = "sandbox0.ai/rootfs-snapshotter-instance"
+	AnnotationRootFSHeadID                 = "sandbox0.ai/rootfs-head-id"
+	AnnotationRootFSHeadImage              = "sandbox0.ai/rootfs-head-image"
 	AnnotationWebhookStateVolumeID         = "sandbox0.ai/webhook-state-volume-id"
 	AnnotationHotClaimReservation          = "sandbox0.ai/hot-claim-reservation"
 	AnnotationHotClaimReservationState     = "sandbox0.ai/hot-claim-reservation-state"


### PR DESCRIPTION
## Summary

- materialize persisted rootfs Heads on the claimed warm Pod node and update only the procd image in place
- preserve Pod UID, IP, mounts, sidecars, and hot-claim network state across resume, fork, and snapshot restore
- wait for CRI image visibility before kubelet activation and reject stale container status
- retain an explicit replacement-Pod fallback for immutable `imagePullPolicy: Always` templates

## Validation

- `go test -race ./manager/...`
- `go test -race ./ctld/...`
- `go test -race ./pkg/...`
- `go vet ./manager/pkg/service ./ctld/internal/ctld/rootfs ./pkg/sandboxpod`
- remote 3-node kind/gVisor-rootfs: 5 immediate write/pause/resume rounds preserved data and reused Pod UID/IP; resume 2.956-3.111s
- remote fork and snapshot restore reused Pod UID/IP and preserved/isolation-checked data; resume 3.056-3.077s
- remote pause, manager rollout restart, then resume reused Pod UID/IP and preserved data; resume 3.235s
- remote 128 MiB I/O: restored cold read 512 MiB/s, warm read 1828.6 MiB/s, write 320 MiB/s; 1000-file hash verified
