### PR TITLE
Derive builtin template CPU from configured ratio

### DIFF
--- a/infra-operator/internal/controller/pkg/common/builtin_templates.go
+++ b/infra-operator/internal/controller/pkg/common/builtin_templates.go
@@ -89,8 +89,10 @@ func EnsureBuiltinTemplates(ctx context.Context, builtins []infrav1alpha1.Builti
 		}
 		desiredTemplateIDs[templateID] = struct{}{}
 
+		memoryPerCPU := builtinTemplateMemoryPerCPU(opts)
 		spec := BuildBuiltinTemplateSpec(templateID, builtin)
-		if err := template.ValidateResourceRatio(spec, builtinTemplateMemoryPerCPU(opts), "builtin template "+templateID); err != nil {
+		applyBuiltinTemplateResourcePolicy(&spec, builtin, memoryPerCPU)
+		if err := template.ValidateResourceRatio(spec, memoryPerCPU, "builtin template "+templateID); err != nil {
 			return fmt.Errorf("validate builtin template %s: %w", templateID, err)
 		}
 
@@ -124,6 +126,16 @@ func EnsureBuiltinTemplates(ctx context.Context, builtins []infrav1alpha1.Builti
 		return err
 	}
 	return nil
+}
+
+// applyBuiltinTemplateResourcePolicy keeps legacy builtin presets aligned with
+// the configured platform ratio. A full spec is an explicit resource contract
+// and remains validation-only.
+func applyBuiltinTemplateResourcePolicy(spec *templatev1alpha1.SandboxTemplateSpec, builtin infrav1alpha1.BuiltinTemplateConfig, memoryPerCPU resource.Quantity) {
+	if spec == nil || builtin.Spec != nil {
+		return
+	}
+	spec.MainContainer.Resources.CPU = template.CPUForMemory(spec.MainContainer.Resources.Memory, memoryPerCPU)
 }
 
 type builtinTemplatePruneStore interface {

--- a/infra-operator/internal/controller/pkg/common/builtin_templates_test.go
+++ b/infra-operator/internal/controller/pkg/common/builtin_templates_test.go
@@ -296,6 +296,47 @@ func TestBuiltinTemplatePresetsSatisfyResourceRatio(t *testing.T) {
 	}
 }
 
+func TestApplyBuiltinTemplateResourcePolicyUsesConfiguredRatioForPreset(t *testing.T) {
+	t.Parallel()
+
+	builtin := infrav1alpha1.BuiltinTemplateConfig{}
+	spec := BuildBuiltinTemplateSpec(template.CodingAgentTemplateID, builtin)
+	memoryPerCPU := resource.MustParse("2Gi")
+
+	applyBuiltinTemplateResourcePolicy(&spec, builtin, memoryPerCPU)
+
+	wantCPU := resource.MustParse("2")
+	if spec.MainContainer.Resources.CPU.Cmp(wantCPU) != 0 {
+		t.Fatalf("cpu = %s, want %s", spec.MainContainer.Resources.CPU.String(), wantCPU.String())
+	}
+	if err := template.ValidateResourceRatio(spec, memoryPerCPU, "builtin template"); err != nil {
+		t.Fatalf("ValidateResourceRatio: %v", err)
+	}
+}
+
+func TestApplyBuiltinTemplateResourcePolicyPreservesExplicitSpec(t *testing.T) {
+	t.Parallel()
+
+	explicitCPU := resource.MustParse("1")
+	builtin := infrav1alpha1.BuiltinTemplateConfig{
+		Spec: &templatev1alpha1.SandboxTemplateSpec{
+			MainContainer: templatev1alpha1.ContainerSpec{
+				Resources: templatev1alpha1.ResourceQuota{
+					CPU:    explicitCPU,
+					Memory: resource.MustParse("4Gi"),
+				},
+			},
+		},
+	}
+	spec := BuildBuiltinTemplateSpec("custom", builtin)
+
+	applyBuiltinTemplateResourcePolicy(&spec, builtin, resource.MustParse("2Gi"))
+
+	if spec.MainContainer.Resources.CPU.Cmp(explicitCPU) != 0 {
+		t.Fatalf("cpu = %s, want explicit %s", spec.MainContainer.Resources.CPU.String(), explicitCPU.String())
+	}
+}
+
 func TestBuildBuiltinTemplateSpecPreservesExplicitZeroMinIdle(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed

- derive CPU for legacy builtin template presets from the configured memory-per-CPU policy before validation
- preserve explicit full builtin specs as validation-only contracts
- cover the 2Gi/CPU policy and explicit-spec behavior with focused tests

## Why

`teamTemplateMemoryPerCpu` is configurable, but builtin presets were fixed at 4Gi/CPU. Setting production to 2Gi/CPU therefore caused builtin synchronization to fail validation.

## Validation

- `go test ./infra-operator/internal/controller/... ./pkg/template/...`
- `git diff --check`

## Deployment dependency

This runtime change must be available in the production infra image before sandbox0-infra renders `teamTemplateMemoryPerCpu: 2Gi`.