### PR TITLE
fix: enforce sandbox max memory platform-wide

### DIFF
--- a/docs/sandbox/page.mdx
+++ b/docs/sandbox/page.mdx
@@ -89,7 +89,7 @@ Sandbox `env_vars` override template/container environment variables for new con
 
 ### Sandbox Resources
 
-Set `config.resources.memory` when one sandbox needs a different memory limit from its template. The minimum is `128Mi`. The platform maximum defaults to `32Gi` and can be changed by the operator with `services.manager.config.sandboxMaxMemory`.
+Set `config.resources.memory` when one sandbox needs a different memory limit from its template. The minimum is `128Mi`. The platform maximum defaults to `16Gi` and can be changed by the operator with `services.manager.config.sandboxMaxMemory`. Sandbox0 enforces that maximum on template defaults and on sandbox claim, update, resume, and fork operations.
 
 The request only accepts memory. Manager derives CPU from `services.manager.config.teamTemplateMemoryPerCpu` and applies the larger of that value and the `150m` minimum CPU limit to the sandbox runtime container. Existing running sandboxes can update memory with the Update Sandbox API.
 

--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -214,7 +214,7 @@ Kubernetes image volume support is part of the Sandbox0 cluster baseline. Unsupp
 
 ### Sandbox Memory Limits
 
-Sandbox claims and runtime updates can set `config.resources.memory`. The minimum accepted value is `128Mi`. The platform maximum defaults to `32Gi`. Manager derives CPU from the configured memory-per-CPU ratio and enforces a minimum CPU limit of `150m` for claimed sandboxes.
+Sandbox claims and runtime updates can set `config.resources.memory`. The minimum accepted value is `128Mi`. The platform maximum defaults to `16Gi`. The same maximum is enforced for template creation and updates, sandbox claims and updates, resumes, and forks. Manager derives CPU from the configured memory-per-CPU ratio and enforces a minimum CPU limit of `150m` for claimed sandboxes.
 
 The minimum applies when a sandbox is claimed, resumed, or resized. Upgrading manager does not resize sandbox pods that were already running before the upgrade.
 
@@ -497,7 +497,7 @@ Examples:
 - `services.clusterGateway.config.authMode` switches between `public`, `internal`, and `both`
 - `services.manager.config.autoscaler.*` is a legacy compatibility surface and is currently ignored; manager keeps each warm pool fixed at the template's `minIdle`
 - `services.manager.config.k8sClientQps` and `k8sClientBurst` tune the manager Kubernetes client token bucket rate limit; defaults are `50` and `100`
-- `services.manager.config.sandboxMaxMemory` caps per-sandbox memory overrides; the default is `32Gi`
+- `services.manager.config.sandboxMaxMemory` caps template defaults and every sandbox lifecycle operation; the default is `16Gi`
 - `services.manager.config.procdBinImageRef` overrides the derived procd artifact image used by sandbox Pods
 - `services.manager.config.allowColdStartWithoutReadyDataPlane` lets cold claims create Pending pods for external node autoscaler scale-from-zero deployments; keep it disabled unless the cluster autoscaler can provision matching sandbox nodes
 - `services.manager.config.autoscalerSafeToEvictAnnotationKeys` lists the platform autoscaler's pod annotation keys; manager writes `true` on idle pods and `false` on claimed pods without embedding a vendor-specific key

--- a/docs/template/configuration/page.mdx
+++ b/docs/template/configuration/page.mdx
@@ -61,12 +61,12 @@ The main sandbox container configuration.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `image` | string | — | Container image reference. Use a public image (e.g., `python:3.12-slim`) or the `Template image reference` returned by `s0 template image push` for private images. |
-| `resources.memory` | string | — | Memory limit for the sandbox (e.g., `"2Gi"`, `"512Mi"`). This is the default when a claim does not provide `config.resources.memory`; Sandbox0 manages CPU from platform configuration. |
+| `resources.memory` | string | — | Memory limit for the sandbox (e.g., `"2Gi"`, `"512Mi"`). This is the default when a claim does not provide `config.resources.memory`; it cannot exceed the platform maximum, which defaults to `16Gi`. Sandbox0 manages CPU from platform configuration. |
 | `resources.ephemeralStorage` | string | `8Gi` | Writable-layer and container-log storage for the sandbox runtime. Checkpointed pause/resume saves and restores the writable root filesystem, but this quota still bounds writes to `/tmp` or image-local paths. Use rootfs snapshots and claim-time `snapshot_id` to version initialized sandbox files, and use Sandbox Volumes for sharing or long-lived durable data independent of sandbox identity. |
 | `env` | array | `[]` | Per-container environment variables. Each entry has `name` and `value`. |
 
 <Callout variant="info">
-Set only `mainContainer.resources.memory`; CPU is platform-managed and is not part of the template API. The memory value becomes the default for claimed sandboxes, while `config.resources.memory` can override it at claim time or runtime. Warm-pool pods wait with a `128Mi` memory limit to reduce idle cost, then resize to the template default when claimed.
+Set only `mainContainer.resources.memory`; CPU is platform-managed and is not part of the template API. The memory value becomes the default for claimed sandboxes, while `config.resources.memory` can override it at claim time or runtime. The platform maximum applies to both values. Warm-pool pods wait with a `128Mi` memory limit to reduce idle cost, then resize to the template default when claimed.
 </Callout>
 
 ---

--- a/docs/template/page.mdx
+++ b/docs/template/page.mdx
@@ -46,7 +46,7 @@ Rootfs snapshot behavior:
 
 - snapshots do not create template IDs and do not appear in `s0 template list`
 - claiming with `snapshot_id` creates a new running sandbox; the requested template still supplies the image, default resources, mounts, services, and network defaults
-- resource overrides at claim or runtime update can change memory only; CPU follows the platform memory-per-CPU ratio with a `150m` minimum limit
+- template defaults and resource overrides at claim or runtime update can change memory only; all are capped by the platform maximum (`16Gi` by default), and CPU follows the platform memory-per-CPU ratio with a `150m` minimum limit
 - snapshot and fork accept a running or paused source; restore rolls an existing paused sandbox back
 
 See [Snapshot And Restore](/docs/sandbox/snapshot-restore) for lifecycle requirements and APIs, or [Initialize Once, Claim Many](/blog/2026-06/initialize-once-fork-many-custom-ai-agent-sandboxes) for the custom-rootfs pattern.

--- a/infra-operator/api/config/manager.go
+++ b/infra-operator/api/config/manager.go
@@ -124,7 +124,7 @@ type ManagerConfig struct {
 	TeamTemplateMemoryPerCPU string `yaml:"team_template_memory_per_cpu" json:"teamTemplateMemoryPerCpu"`
 	// SandboxMaxMemory is the maximum memory limit accepted for a single sandbox.
 	// +optional
-	// +kubebuilder:default="32Gi"
+	// +kubebuilder:default="16Gi"
 	SandboxMaxMemory string `yaml:"sandbox_max_memory" json:"sandboxMaxMemory"`
 	// +optional
 	SandboxRuntimeClassName string `yaml:"sandbox_runtime_class_name" json:"sandboxRuntimeClassName"`

--- a/infra-operator/api/config/scheduler.go
+++ b/infra-operator/api/config/scheduler.go
@@ -69,6 +69,11 @@ type SchedulerConfig struct {
 	// RegistryInternalRegistry is the registry service endpoint reserved for server-side access.
 	// +optional
 	RegistryInternalRegistry string `yaml:"registry_internal_registry" json:"-"`
+
+	// TeamTemplateMemoryPerCPU is derived from manager platform configuration.
+	TeamTemplateMemoryPerCPU string `yaml:"team_template_memory_per_cpu" json:"-"`
+	// SandboxMaxMemory is derived from manager platform configuration.
+	SandboxMaxMemory string `yaml:"sandbox_max_memory" json:"-"`
 }
 
 type DatabasePoolConfig struct {

--- a/infra-operator/api/v1alpha1/service_api_config_types.go
+++ b/infra-operator/api/v1alpha1/service_api_config_types.go
@@ -927,7 +927,7 @@ type ManagerConfig struct {
 	TeamTemplateMemoryPerCPU string `json:"teamTemplateMemoryPerCpu,omitempty"`
 	// SandboxMaxMemory is the maximum memory limit accepted for a single sandbox.
 	// +optional
-	// +kubebuilder:default="32Gi"
+	// +kubebuilder:default="16Gi"
 	SandboxMaxMemory string `json:"sandboxMaxMemory,omitempty"`
 	// +optional
 	SandboxRuntimeClassName string `json:"sandboxRuntimeClassName,omitempty"`

--- a/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
+++ b/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
@@ -3932,7 +3932,7 @@ spec:
                               unpack, runtime initialization, and readiness observation.
                             type: string
                           sandboxMaxMemory:
-                            default: 32Gi
+                            default: 16Gi
                             description: SandboxMaxMemory is the maximum memory limit
                               accepted for a single sandbox.
                             type: string

--- a/infra-operator/internal/controller/pkg/common/builtin_templates.go
+++ b/infra-operator/internal/controller/pkg/common/builtin_templates.go
@@ -42,7 +42,7 @@ type BuiltinTemplateOptions struct {
 	DatabaseMinConns     int32
 	TemplateStoreEnabled bool
 	Owner                string
-	MemoryPerCPU         resource.Quantity
+	ResourcePolicy       template.ResourcePolicy
 }
 
 // EnsureBuiltinTemplates creates or updates builtin templates in the template store.
@@ -89,10 +89,11 @@ func EnsureBuiltinTemplates(ctx context.Context, builtins []infrav1alpha1.Builti
 		}
 		desiredTemplateIDs[templateID] = struct{}{}
 
-		memoryPerCPU := builtinTemplateMemoryPerCPU(opts)
+		resourcePolicy := opts.ResourcePolicy
+		memoryPerCPU := resourcePolicy.MemoryPerCPU()
 		spec := BuildBuiltinTemplateSpec(templateID, builtin)
 		applyBuiltinTemplateResourcePolicy(&spec, builtin, memoryPerCPU)
-		if err := template.ValidateResourceRatio(spec, memoryPerCPU, "builtin template "+templateID); err != nil {
+		if err := resourcePolicy.ValidateTemplate(spec, "builtin template "+templateID); err != nil {
 			return fmt.Errorf("validate builtin template %s: %w", templateID, err)
 		}
 
@@ -162,19 +163,13 @@ func pruneUnconfiguredBuiltinTemplates(ctx context.Context, store builtinTemplat
 	return nil
 }
 
-func builtinTemplateMemoryPerCPU(opts BuiltinTemplateOptions) resource.Quantity {
-	if opts.MemoryPerCPU.Sign() <= 0 {
-		return template.MemoryPerCPUOrDefault("")
-	}
-	return opts.MemoryPerCPU
-}
-
-// TemplateMemoryPerCPUFromManagerConfig resolves the template resource shape used by manager API validation.
-func TemplateMemoryPerCPUFromManagerConfig(cfg *apiconfig.ManagerConfig) resource.Quantity {
+// TemplateResourcePolicyFromManagerConfig resolves the resource policy shared
+// by builtin synchronization and public template validation.
+func TemplateResourcePolicyFromManagerConfig(cfg *apiconfig.ManagerConfig) template.ResourcePolicy {
 	if cfg == nil {
-		return template.MemoryPerCPUOrDefault("")
+		return template.NewResourcePolicy("", "")
 	}
-	return template.MemoryPerCPUOrDefault(cfg.TeamTemplateMemoryPerCPU)
+	return template.NewResourcePolicy(cfg.TeamTemplateMemoryPerCPU, cfg.SandboxMaxMemory)
 }
 
 // BuildBuiltinTemplateSpec returns the effective SandboxTemplate spec for a builtin template config.

--- a/infra-operator/internal/controller/services/manager/manager.go
+++ b/infra-operator/internal/controller/services/manager/manager.go
@@ -327,7 +327,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, 
 		DatabaseMinConns:     config.DatabaseMinConns,
 		TemplateStoreEnabled: config.TemplateStoreEnabled,
 		Owner:                "manager",
-		MemoryPerCPU:         common.TemplateMemoryPerCPUFromManagerConfig(config),
+		ResourcePolicy:       common.TemplateResourcePolicyFromManagerConfig(config),
 	}); err != nil {
 		return err
 	}

--- a/infra-operator/internal/controller/services/scheduler/scheduler.go
+++ b/infra-operator/internal/controller/services/scheduler/scheduler.go
@@ -72,7 +72,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, imageRepo, imageTag string, 
 		DatabaseMinConns:     config.DatabasePool.MinConns,
 		TemplateStoreEnabled: true,
 		Owner:                "scheduler",
-		MemoryPerCPU:         common.TemplateMemoryPerCPUFromManagerConfig(compiledPlan.Manager.Config),
+		ResourcePolicy:       common.TemplateResourcePolicyFromManagerConfig(compiledPlan.Manager.Config),
 	}); err != nil {
 		return err
 	}
@@ -225,6 +225,10 @@ func (r *Reconciler) buildConfig(ctx context.Context, compiledPlan *infraplan.In
 	cfg := &apiconfig.SchedulerConfig{}
 	if compiledPlan != nil && compiledPlan.Scheduler.Config != nil {
 		cfg = compiledPlan.Scheduler.Config.DeepCopy()
+	}
+	if compiledPlan != nil && compiledPlan.Manager.Config != nil {
+		cfg.TeamTemplateMemoryPerCPU = compiledPlan.Manager.Config.TeamTemplateMemoryPerCPU
+		cfg.SandboxMaxMemory = compiledPlan.Manager.Config.SandboxMaxMemory
 	}
 	if dsn, err := compiledPlan.DatabaseDSN(ctx, r.Resources.Client); err == nil {
 		cfg.DatabaseURL = dsn

--- a/infra-operator/internal/controller/services/scheduler/scheduler_test.go
+++ b/infra-operator/internal/controller/services/scheduler/scheduler_test.go
@@ -158,6 +158,12 @@ func TestBuildConfigPropagatesRegistryHosts(t *testing.T) {
 						EnabledServiceConfig: infrav1alpha1.EnabledServiceConfig{Enabled: true},
 					},
 				},
+				Manager: &infrav1alpha1.ManagerServiceConfig{
+					Config: &infrav1alpha1.ManagerConfig{
+						TeamTemplateMemoryPerCPU: "2Gi",
+						SandboxMaxMemory:         "16Gi",
+					},
+				},
 			},
 		},
 	}
@@ -174,5 +180,11 @@ func TestBuildConfigPropagatesRegistryHosts(t *testing.T) {
 	}
 	if cfg.RegistryInternalRegistry != "demo-registry.sandbox0-system.svc:5000" {
 		t.Fatalf("unexpected internal registry %q", cfg.RegistryInternalRegistry)
+	}
+	if cfg.TeamTemplateMemoryPerCPU != "2Gi" {
+		t.Fatalf("unexpected template memory per CPU %q", cfg.TeamTemplateMemoryPerCPU)
+	}
+	if cfg.SandboxMaxMemory != "16Gi" {
+		t.Fatalf("unexpected sandbox max memory %q", cfg.SandboxMaxMemory)
 	}
 }

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -44,6 +44,7 @@ import (
 	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
 	"github.com/sandbox0-ai/sandbox0/pkg/quota"
 	registryprovider "github.com/sandbox0-ai/sandbox0/pkg/registry"
+	s0template "github.com/sandbox0-ai/sandbox0/pkg/template"
 	templmigrations "github.com/sandbox0-ai/sandbox0/pkg/template/migrations"
 	templreconciler "github.com/sandbox0-ai/sandbox0/pkg/template/reconciler"
 	templstorepg "github.com/sandbox0-ai/sandbox0/pkg/template/store/pg"
@@ -539,6 +540,7 @@ func main() {
 		TemplateStore:           templateStore,
 		TemplateReconciler:      templateReconciler,
 		TemplateStoreEnabled:    cfg.TemplateStoreEnabled,
+		TemplateResourcePolicy:  s0template.NewResourcePolicy(cfg.TeamTemplateMemoryPerCPU, cfg.SandboxMaxMemory),
 		ClusterService:          clusterService,
 		QuotaRepository:         quotaRepo,
 		AuthValidator:           authValidator,

--- a/manager/pkg/http/server.go
+++ b/manager/pkg/http/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/observability"
 	httpobs "github.com/sandbox0-ai/sandbox0/pkg/observability/http"
 	"github.com/sandbox0-ai/sandbox0/pkg/quota"
+	"github.com/sandbox0-ai/sandbox0/pkg/template"
 	templatehttp "github.com/sandbox0-ai/sandbox0/pkg/template/http"
 	"github.com/sandbox0-ai/sandbox0/pkg/template/store"
 	"go.opentelemetry.io/otel/trace"
@@ -82,6 +83,7 @@ type ServerDependencies struct {
 	TemplateStore           store.TemplateStore
 	TemplateReconciler      TemplateReconciler
 	TemplateStoreEnabled    bool
+	TemplateResourcePolicy  template.ResourcePolicy
 	ClusterService          *clusterservice.ClusterService
 	QuotaRepository         *quota.Repository
 	AuthValidator           *internalauth.Validator
@@ -134,6 +136,7 @@ func NewServerWithDependencies(deps ServerDependencies) *Server {
 			SourceResolver:       deps.SandboxService,
 			Reconciler:           deps.TemplateReconciler,
 			StatsProvider:        &clusterTemplateStatsProvider{clusterService: deps.ClusterService},
+			ResourcePolicy:       deps.TemplateResourcePolicy,
 			PrivateRegistryHosts: registryHosts,
 			Logger:               deps.Logger,
 		}

--- a/manager/pkg/service/sandbox_service_claim.go
+++ b/manager/pkg/service/sandbox_service_claim.go
@@ -388,6 +388,12 @@ func (s *SandboxService) ClaimSandbox(ctx context.Context, req *ClaimRequest) (*
 		}
 	}
 	s.observeClaimPhase(req.Template, "unknown", "resolve_template", phaseStarted, nil)
+	phaseStarted = time.Now()
+	if _, err := s.effectiveSandboxResourceQuota(template, req.Config); err != nil {
+		s.observeClaimPhase(req.Template, "unknown", "validate_resources", phaseStarted, err)
+		return nil, err
+	}
+	s.observeClaimPhase(req.Template, "unknown", "validate_resources", phaseStarted, nil)
 	if strings.TrimSpace(req.SandboxID) == "" {
 		req.SandboxID, err = s.generateStableSandboxID(template)
 		if err != nil {

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -46,6 +46,30 @@ import (
 
 const testAutoscalerSafeToEvictAnnotation = "example.com/safe-to-evict"
 
+func TestClaimSandboxRejectsTemplateMemoryAbovePlatformMaximum(t *testing.T) {
+	template := newSandboxResourceTestTemplate(t)
+	template.Name = naming.TemplateNameForCluster(naming.ScopeTeam, "team-a", "default")
+	template.Spec.MainContainer.Resources.CPU = resource.MustParse("8")
+	template.Spec.MainContainer.Resources.Memory = resource.MustParse("32Gi")
+	svc := &SandboxService{
+		templateLister: staticTemplateLister{templates: []*v1alpha1.SandboxTemplate{template}},
+		config:         SandboxServiceConfig{SandboxMaxMemory: "16Gi"},
+		logger:         zap.NewNop(),
+	}
+
+	_, err := svc.ClaimSandbox(context.Background(), &ClaimRequest{
+		Template: "default",
+		TeamID:   "team-a",
+		UserID:   "user-a",
+	})
+	if err == nil || !errors.Is(err, ErrInvalidClaimRequest) {
+		t.Fatalf("ClaimSandbox() error = %v, want ErrInvalidClaimRequest", err)
+	}
+	if got := err.Error(); !strings.Contains(got, "sandbox memory limit must be <= 16Gi") {
+		t.Fatalf("ClaimSandbox() error = %q, want max-memory rejection", got)
+	}
+}
+
 func TestClaimIdlePodRequiresPodReady(t *testing.T) {
 	template := &v1alpha1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{

--- a/manager/pkg/service/sandbox_service_resources.go
+++ b/manager/pkg/service/sandbox_service_resources.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/sandboxstore"
@@ -15,11 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
-)
-
-const (
-	defaultSandboxMinMemory = "128Mi"
-	defaultSandboxMaxMemory = "32Gi"
 )
 
 func (s *SandboxService) effectiveSandboxResourceQuota(template *v1alpha1.SandboxTemplate, cfg *sandboxstore.SandboxConfig) (v1alpha1.ResourceQuota, error) {
@@ -34,6 +28,9 @@ func (s *SandboxService) effectiveSandboxResourceQuota(template *v1alpha1.Sandbo
 		}
 		quota.Memory = memory
 		quota.CPU = s0template.CPUForMemory(memory, s.sandboxMemoryPerCPU())
+	}
+	if err := s.resourcePolicy().ValidateMaxMemory(quota.Memory, "sandbox memory limit"); err != nil {
+		return v1alpha1.ResourceQuota{}, fmt.Errorf("%w: %v", ErrInvalidClaimRequest, err)
 	}
 	return v1alpha1.NormalizeSandboxResourceQuota(quota), nil
 }
@@ -207,46 +204,20 @@ func ensureSandboxResizePolicy(container *corev1.Container) {
 }
 
 func (s *SandboxService) validateSandboxMemory(value string) (resource.Quantity, error) {
-	raw := strings.TrimSpace(value)
-	if raw == "" {
-		return resource.Quantity{}, fmt.Errorf("%w: config.resources.memory is required", ErrInvalidClaimRequest)
-	}
-	memory, err := resource.ParseQuantity(raw)
+	memory, err := s.resourcePolicy().ParseMemory(value, "config.resources.memory")
 	if err != nil {
-		return resource.Quantity{}, fmt.Errorf("%w: config.resources.memory is invalid: %v", ErrInvalidClaimRequest, err)
-	}
-	if memory.Sign() <= 0 {
-		return resource.Quantity{}, fmt.Errorf("%w: config.resources.memory must be > 0", ErrInvalidClaimRequest)
-	}
-	minMemory := sandboxMemoryQuantityOrDefault(defaultSandboxMinMemory, defaultSandboxMinMemory)
-	if memory.Cmp(minMemory) < 0 {
-		return resource.Quantity{}, fmt.Errorf("%w: config.resources.memory must be >= %s", ErrInvalidClaimRequest, minMemory.String())
-	}
-	maxMemory := s.sandboxMaxMemory()
-	if memory.Cmp(maxMemory) > 0 {
-		return resource.Quantity{}, fmt.Errorf("%w: config.resources.memory must be <= %s", ErrInvalidClaimRequest, maxMemory.String())
+		return resource.Quantity{}, fmt.Errorf("%w: %v", ErrInvalidClaimRequest, err)
 	}
 	return memory, nil
 }
 
 func (s *SandboxService) sandboxMemoryPerCPU() resource.Quantity {
-	if s == nil {
-		return s0template.MemoryPerCPUOrDefault("")
-	}
-	return s0template.MemoryPerCPUOrDefault(s.config.SandboxMemoryPerCPU)
+	return s.resourcePolicy().MemoryPerCPU()
 }
 
-func (s *SandboxService) sandboxMaxMemory() resource.Quantity {
+func (s *SandboxService) resourcePolicy() s0template.ResourcePolicy {
 	if s == nil {
-		return sandboxMemoryQuantityOrDefault("", defaultSandboxMaxMemory)
+		return s0template.NewResourcePolicy("", "")
 	}
-	return sandboxMemoryQuantityOrDefault(s.config.SandboxMaxMemory, defaultSandboxMaxMemory)
-}
-
-func sandboxMemoryQuantityOrDefault(value, fallback string) resource.Quantity {
-	parsed, err := resource.ParseQuantity(strings.TrimSpace(value))
-	if err == nil && parsed.Sign() > 0 {
-		return parsed
-	}
-	return resource.MustParse(fallback)
+	return s0template.NewResourcePolicy(s.config.SandboxMemoryPerCPU, s.config.SandboxMaxMemory)
 }

--- a/manager/pkg/service/sandbox_service_resources_test.go
+++ b/manager/pkg/service/sandbox_service_resources_test.go
@@ -67,6 +67,21 @@ func TestEffectiveSandboxResourceQuotaAppliesMinimumCPUToTemplateWithoutCPU(t *t
 	assertQuantity(t, quota.CPU, "150m")
 }
 
+func TestEffectiveSandboxResourceQuotaRejectsTemplateAbovePlatformMaximum(t *testing.T) {
+	svc := &SandboxService{config: SandboxServiceConfig{SandboxMaxMemory: "16Gi"}}
+	template := newSandboxResourceTestTemplate(t)
+	template.Spec.MainContainer.Resources.CPU = resource.MustParse("8")
+	template.Spec.MainContainer.Resources.Memory = resource.MustParse("32Gi")
+
+	_, err := svc.effectiveSandboxResourceQuota(template, nil)
+	if err == nil || !errors.Is(err, ErrInvalidClaimRequest) {
+		t.Fatalf("effectiveSandboxResourceQuota() error = %v, want ErrInvalidClaimRequest", err)
+	}
+	if got := err.Error(); !contains(got, "sandbox memory limit must be <= 16Gi") {
+		t.Fatalf("effectiveSandboxResourceQuota() error = %q, want max-memory rejection", got)
+	}
+}
+
 func TestValidateSandboxMemoryBounds(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -76,8 +91,8 @@ func TestValidateSandboxMemoryBounds(t *testing.T) {
 	}{
 		{name: "minimum accepted", memory: "128Mi"},
 		{name: "below minimum rejected", memory: "127Mi", wantErr: "must be >= 128Mi"},
-		{name: "default max accepted", memory: "32Gi"},
-		{name: "above default max rejected", memory: "33Gi", wantErr: "must be <= 32Gi"},
+		{name: "default max accepted", memory: "16Gi"},
+		{name: "above default max rejected", memory: "17Gi", wantErr: "must be <= 16Gi"},
 		{name: "custom max accepted", maxMemory: "64Gi", memory: "64Gi"},
 		{name: "above custom max rejected", maxMemory: "64Gi", memory: "65Gi", wantErr: "must be <= 64Gi"},
 		{name: "invalid rejected", memory: "large", wantErr: "is invalid"},
@@ -466,6 +481,42 @@ func TestUpdateSandboxAppliesMinimumCPUResourcesAndPersistsConfig(t *testing.T) 
 		t.Fatalf("config annotation = %s, want resources memory", got)
 	}
 	assertResizeSubresourceUpdate(t, client.Actions())
+}
+
+func TestUpdateSandboxRejectsMemoryAbovePlatformMaximum(t *testing.T) {
+	template := newSandboxResourceTestTemplate(t)
+	pod := newSandboxResourceTestActivePod(t, template, "sandbox-1")
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	if err := indexer.Add(pod.DeepCopy()); err != nil {
+		t.Fatalf("add pod: %v", err)
+	}
+	svc := &SandboxService{
+		k8sClient:      client,
+		podLister:      corelisters.NewPodLister(indexer),
+		templateLister: staticTemplateLister{templates: []*v1alpha1.SandboxTemplate{template}},
+		clock:          systemTime{},
+		config: SandboxServiceConfig{
+			SandboxMemoryPerCPU: "4Gi",
+			SandboxMaxMemory:    "16Gi",
+		},
+		logger: zap.NewNop(),
+	}
+
+	_, err := svc.UpdateSandbox(context.Background(), "sandbox-1", &SandboxUpdateConfig{
+		Resources: &managerapi.SandboxResourceConfig{Memory: "17Gi"},
+	})
+	if err == nil || !errors.Is(err, ErrInvalidClaimRequest) {
+		t.Fatalf("UpdateSandbox() error = %v, want ErrInvalidClaimRequest", err)
+	}
+	if got := err.Error(); !contains(got, "config.resources.memory must be <= 16Gi") {
+		t.Fatalf("UpdateSandbox() error = %q, want max-memory rejection", got)
+	}
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "patch" && action.GetSubresource() == "resize" {
+			t.Fatal("sandbox resources were resized after max-memory rejection")
+		}
+	}
 }
 
 func TestUpdatePausedSandboxValidatesAndPersistsMemory(t *testing.T) {

--- a/manager/pkg/service/sandbox_service_rootfs_product.go
+++ b/manager/pkg/service/sandbox_service_rootfs_product.go
@@ -352,6 +352,12 @@ func (s *SandboxService) ForkSandbox(ctx context.Context, sourceSandboxID, teamI
 		}
 		return nil, err
 	}
+	if _, err := s.effectiveSandboxResourceQuota(template, &targetConfig); err != nil {
+		if checkpoint != nil {
+			checkpoint.close(s, false)
+		}
+		return nil, err
+	}
 	expiresAt := expirationFromTTL(now, targetConfig.TTL)
 	if expiresAt.IsZero() && targetConfig.TTL == nil {
 		expiresAt = source.ExpiresAt

--- a/manager/pkg/service/sandbox_service_rootfs_product_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_product_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -543,6 +544,29 @@ func TestSandboxRootFSProductForkRejectsInvalidLifecycleConfig(t *testing.T) {
 	})
 
 	require.ErrorIs(t, err, ErrInvalidClaimRequest)
+	assert.Len(t, store.records, 1)
+}
+
+func TestSandboxRootFSProductForkRejectsMemoryAbovePlatformMaximum(t *testing.T) {
+	now := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	source := rootFSProductTestRecord("sandbox-1", "team-1", sandboxstore.SandboxDesiredStatePaused, now)
+	source.TemplateSpec.MainContainer.Resources.CPU = resource.MustParse("8")
+	source.TemplateSpec.MainContainer.Resources.Memory = resource.MustParse("32Gi")
+	store := &memorySandboxStore{
+		records: map[string]*sandboxstore.SandboxRecord{
+			"sandbox-1": source,
+		},
+		rootFSStates: map[string]*sandboxstore.SandboxRootFSState{
+			"sandbox-1": rootFSProductTestState("sandbox-1", "team-1", "layer-v1"),
+		},
+	}
+	svc := rootFSProductTestService(store)
+	svc.config.SandboxMaxMemory = "16Gi"
+
+	_, err := svc.ForkSandbox(context.Background(), "sandbox-1", "team-1", "user-2", nil)
+
+	require.ErrorIs(t, err, ErrInvalidClaimRequest)
+	assert.Contains(t, err.Error(), "sandbox memory limit must be <= 16Gi")
 	assert.Len(t, store.records, 1)
 }
 

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -5058,7 +5058,7 @@ components:
       properties:
         memory:
           type: string
-          description: Sandbox memory limit. Must be at least 128Mi and no more than the platform sandbox maximum, which defaults to 32Gi.
+          description: Sandbox memory limit. Must be at least 128Mi and no more than the platform sandbox maximum, which defaults to 16Gi. The same maximum applies to template defaults and every sandbox lifecycle operation.
     SandboxAppServiceRouteAuth:
       type: object
       properties:
@@ -7669,7 +7669,7 @@ components:
       properties:
         memory:
           type: string
-          description: Memory limit used by default when a sandbox claim does not provide a memory override. Sandbox0 derives the internal CPU limit from platform configuration.
+          description: Memory limit used by default when a sandbox claim does not provide a memory override. It cannot exceed the platform sandbox maximum, which defaults to 16Gi. Sandbox0 derives the internal CPU limit from platform configuration.
         ephemeralStorage:
           type: string
           description: Ephemeral storage limit for the sandbox writable layer and container logs. Defaults to 8Gi when omitted.

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -2018,7 +2018,7 @@ type ResourceQuota struct {
 	// EphemeralStorage Ephemeral storage limit for the sandbox writable layer and container logs. Defaults to 8Gi when omitted.
 	EphemeralStorage *string `json:"ephemeralStorage,omitempty"`
 
-	// Memory Memory limit used by default when a sandbox claim does not provide a memory override. Sandbox0 derives the internal CPU limit from platform configuration.
+	// Memory Memory limit used by default when a sandbox claim does not provide a memory override. It cannot exceed the platform sandbox maximum, which defaults to 16Gi. Sandbox0 derives the internal CPU limit from platform configuration.
 	Memory string `json:"memory"`
 }
 
@@ -2494,7 +2494,7 @@ type SandboxRefreshRequest struct {
 
 // SandboxResourceConfig Instance-level sandbox resource override. Sandbox0 exposes memory only and derives CPU from the platform memory-per-CPU ratio, with a minimum CPU limit of 150m.
 type SandboxResourceConfig struct {
-	// Memory Sandbox memory limit. Must be at least 128Mi and no more than the platform sandbox maximum, which defaults to 32Gi.
+	// Memory Sandbox memory limit. Must be at least 128Mi and no more than the platform sandbox maximum, which defaults to 16Gi. The same maximum applies to template defaults and every sandbox lifecycle operation.
 	Memory *string `json:"memory,omitempty"`
 }
 

--- a/pkg/template/http/from_sandbox_test.go
+++ b/pkg/template/http/from_sandbox_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/template"
 	templatestore "github.com/sandbox0-ai/sandbox0/pkg/template/store"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -300,6 +302,69 @@ func TestCreateTemplateFromSandboxRequiresCreateAndSourceReadPermissions(t *test
 				t.Fatalf("source resolver calls = %d, want 0", resolver.calls)
 			}
 		})
+	}
+}
+
+func TestCreateTemplateFromSandboxRejectsMemoryAbovePlatformMaximum(t *testing.T) {
+	t.Parallel()
+
+	sandboxID, err := naming.SandboxName("default", "source-template", "abcde")
+	if err != nil {
+		t.Fatalf("SandboxName() error = %v", err)
+	}
+	sourceSpec := validTemplateSpec()
+	sourceSpec.MainContainer.Resources.Memory = resource.MustParse("32Gi")
+	store := &testTemplateStore{}
+	buildStore := &fromSandboxBuildStore{
+		create: func(context.Context, *template.Template, *template.TemplateBuild) (*template.Template, bool, error) {
+			t.Fatal("CreateTemplateBuild must not run for memory above the platform maximum")
+			return nil, false, nil
+		},
+	}
+	resolver := &fromSandboxSourceResolver{
+		resolve: func(context.Context, string, string) (*template.SandboxTemplateSource, error) {
+			return &template.SandboxTemplateSource{
+				TeamID:    "team-1",
+				ClusterID: "cluster-1",
+				Spec:      sourceSpec,
+			}, nil
+		},
+	}
+	handler := &Handler{
+		Store:          store,
+		BuildStore:     buildStore,
+		SourceResolver: resolver,
+		ResourcePolicy: template.NewResourcePolicy("2Gi", "16Gi"),
+		Logger:         zap.NewNop(),
+	}
+	router := gin.New()
+	router.Use(withClaims(&internalauth.Claims{
+		TeamID:      "team-1",
+		UserID:      "user-1",
+		Permissions: []string{gatewayauthn.PermTemplateCreate, gatewayauthn.PermSandboxRead},
+	}))
+	router.POST("/api/v1/templates/from-sandbox", handler.CreateTemplateFromSandbox)
+
+	body, err := json.Marshal(TemplateFromSandboxRequest{
+		TemplateID: "derived",
+		SandboxID:  sandboxID,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/templates/from-sandbox", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusForbidden, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "spec.mainContainer.resources.memory must be") || !strings.Contains(rec.Body.String(), "16Gi") {
+		t.Fatalf("response = %s, want max-memory rejection", rec.Body.String())
+	}
+	if resolver.calls != 1 {
+		t.Fatalf("source resolver calls = %d, want 1", resolver.calls)
 	}
 }
 

--- a/pkg/template/http/handlers.go
+++ b/pkg/template/http/handlers.go
@@ -69,6 +69,7 @@ type Handler struct {
 	ClusterStore         ClusterStore
 	Reconciler           Reconciler
 	StatsProvider        TemplateStatsProvider
+	ResourcePolicy       template.ResourcePolicy
 	PrivateRegistryHosts []string
 	Logger               *zap.Logger
 }
@@ -374,13 +375,13 @@ func (h *Handler) CreateTemplate(c *gin.Context) {
 		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 		return
 	}
-	memoryPerCPU := configuredTemplateMemoryPerCPU()
-	deriveTemplateCPU(&templateSpec, memoryPerCPU)
+	resourcePolicy := h.ResourcePolicy
+	deriveTemplateCPU(&templateSpec, resourcePolicy.MemoryPerCPU())
 	if err := validateTemplateSpec(templateSpec); err != nil {
 		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 		return
 	}
-	if err := validateTemplateSpecForClaimsWithMemoryPerCPU(templateSpec, claims, memoryPerCPU); err != nil {
+	if err := validateTemplateSpecForClaims(templateSpec, claims, resourcePolicy); err != nil {
 		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, err.Error())
 		return
 	}
@@ -572,14 +573,14 @@ func (h *Handler) CreateTemplateFromSandbox(c *gin.Context) {
 	}
 
 	templateSpec := templateSpecFromSandboxSource(source.Spec, req.SpecOverrides)
-	memoryPerCPU := configuredTemplateMemoryPerCPU()
+	resourcePolicy := h.ResourcePolicy
 	templateSpec.MainContainer.Resources.CPU = resource.Quantity{}
-	deriveTemplateCPU(&templateSpec, memoryPerCPU)
+	deriveTemplateCPU(&templateSpec, resourcePolicy.MemoryPerCPU())
 	if err := validateTemplateSpec(templateSpec); err != nil {
 		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, "source template is not reusable: "+err.Error())
 		return
 	}
-	if err := validateTemplateSpecForClaimsWithMemoryPerCPU(templateSpec, claims, memoryPerCPU); err != nil {
+	if err := validateTemplateSpecForClaims(templateSpec, claims, resourcePolicy); err != nil {
 		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, err.Error())
 		return
 	}
@@ -785,13 +786,13 @@ func (h *Handler) UpdateTemplate(c *gin.Context) {
 		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 		return
 	}
-	memoryPerCPU := configuredTemplateMemoryPerCPU()
-	deriveTemplateCPU(&templateSpec, memoryPerCPU)
+	resourcePolicy := h.ResourcePolicy
+	deriveTemplateCPU(&templateSpec, resourcePolicy.MemoryPerCPU())
 	if err := validateTemplateSpec(templateSpec); err != nil {
 		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, err.Error())
 		return
 	}
-	if err := validateTemplateSpecForClaimsWithMemoryPerCPU(templateSpec, claims, memoryPerCPU); err != nil {
+	if err := validateTemplateSpecForClaims(templateSpec, claims, resourcePolicy); err != nil {
 		spec.JSONError(c, http.StatusForbidden, spec.CodeForbidden, err.Error())
 		return
 	}

--- a/pkg/template/http/handlers_test.go
+++ b/pkg/template/http/handlers_test.go
@@ -363,6 +363,42 @@ func TestCreateTemplate_DerivesCPUWhenOmitted(t *testing.T) {
 	assertTemplateResponseOmitsCPU(t, rec.Body.Bytes())
 }
 
+func TestCreateTemplate_RejectsMemoryAbovePlatformMaximum(t *testing.T) {
+	t.Parallel()
+
+	store := &testTemplateStore{}
+	h := &Handler{
+		Store:          store,
+		ResourcePolicy: template.NewResourcePolicy("2Gi", "16Gi"),
+		Logger:         zap.NewNop(),
+	}
+	router := gin.New()
+	router.Use(withClaims(&internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	router.POST("/api/v1/templates", h.CreateTemplate)
+
+	body := []byte(`{
+		"template_id":"demo",
+		"spec":{
+			"mainContainer":{"image":"ubuntu:22.04","resources":{"memory":"32Gi"}},
+			"pool":{"minIdle":0,"maxIdle":1}
+		}
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/templates", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusForbidden, rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "spec.mainContainer.resources.memory must be") || !strings.Contains(rec.Body.String(), "16Gi") {
+		t.Fatalf("response = %s, want max-memory rejection", rec.Body.String())
+	}
+	if store.createCalled {
+		t.Fatal("expected create not called for memory above platform maximum")
+	}
+}
+
 func TestDeriveTemplateCPUUsesConfiguredMemoryPerCPU(t *testing.T) {
 	t.Parallel()
 
@@ -820,6 +856,45 @@ func TestUpdateTemplate_DerivesCPUWhenOmitted(t *testing.T) {
 	assertTemplateResponseOmitsCPU(t, rec.Body.Bytes())
 }
 
+func TestUpdateTemplate_RejectsMemoryAbovePlatformMaximum(t *testing.T) {
+	t.Parallel()
+
+	store := &testTemplateStore{
+		getTemplateFn: func(context.Context, string, string, string) (*template.Template, error) {
+			return &template.Template{TemplateID: "demo", Scope: "team", TeamID: "team-1", Spec: validTemplateSpec()}, nil
+		},
+	}
+	h := &Handler{
+		Store:          store,
+		ResourcePolicy: template.NewResourcePolicy("2Gi", "16Gi"),
+		Logger:         zap.NewNop(),
+	}
+	router := gin.New()
+	router.Use(withClaims(&internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	router.PUT("/api/v1/templates/:id", h.UpdateTemplate)
+
+	body := []byte(`{
+		"spec":{
+			"mainContainer":{"image":"ubuntu:22.04","resources":{"memory":"32Gi"}},
+			"pool":{"minIdle":0,"maxIdle":1}
+		}
+	}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/templates/demo", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusForbidden, rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "spec.mainContainer.resources.memory must be") || !strings.Contains(rec.Body.String(), "16Gi") {
+		t.Fatalf("response = %s, want max-memory rejection", rec.Body.String())
+	}
+	if store.updateCalled {
+		t.Fatal("expected update not called for memory above platform maximum")
+	}
+}
+
 func TestUpdateTemplate_RejectsInvalidPoolRange(t *testing.T) {
 	t.Parallel()
 
@@ -1024,9 +1099,9 @@ func TestValidateTemplateSpecForClaims_WildcardPermissionRejected(t *testing.T) 
 		Pool: v1alpha1.PoolStrategy{MinIdle: 0, MaxIdle: 1},
 	}
 
-	err := validateTemplateSpecForClaimsWithMemoryPerCPU(spec, &internalauth.Claims{
+	err := validateTemplateSpecForClaims(spec, &internalauth.Claims{
 		Permissions: []string{"*"},
-	}, configuredTemplateMemoryPerCPU())
+	}, template.ResourcePolicy{})
 	if err == nil {
 		t.Fatalf("expected wildcard permission to be rejected")
 	}
@@ -1305,7 +1380,7 @@ func TestValidateTemplateSpec_AllowsExpandedSecurityContext(t *testing.T) {
 	if err := validateTemplateSpec(spec); err != nil {
 		t.Fatalf("validateTemplateSpec: %v", err)
 	}
-	if err := validateTemplateSpecForClaimsWithMemoryPerCPU(spec, &internalauth.Claims{IsSystem: true}, configuredTemplateMemoryPerCPU()); err != nil {
+	if err := validateTemplateSpecForClaims(spec, &internalauth.Claims{IsSystem: true}, template.ResourcePolicy{}); err != nil {
 		t.Fatalf("expected system token to allow expanded security context, got %v", err)
 	}
 }
@@ -1339,11 +1414,11 @@ func TestValidateTemplateSpecForClaims_RequiresSystemIdentityForEmptyDirMounts(t
 		}},
 	}
 
-	err := validateTemplateSpecForClaimsWithMemoryPerCPU(spec, &internalauth.Claims{TeamID: "team-1"}, configuredTemplateMemoryPerCPU())
+	err := validateTemplateSpecForClaims(spec, &internalauth.Claims{TeamID: "team-1"}, template.ResourcePolicy{})
 	if err == nil || err.Error() != "spec.pod requires system identity" {
 		t.Fatalf("expected team token to reject pod emptyDir mounts, got %v", err)
 	}
-	if err := validateTemplateSpecForClaimsWithMemoryPerCPU(spec, &internalauth.Claims{IsSystem: true}, configuredTemplateMemoryPerCPU()); err != nil {
+	if err := validateTemplateSpecForClaims(spec, &internalauth.Claims{IsSystem: true}, template.ResourcePolicy{}); err != nil {
 		t.Fatalf("expected system token to allow pod emptyDir mounts, got %v", err)
 	}
 }
@@ -1362,7 +1437,7 @@ func TestValidateTemplateSpecForClaims_RejectsMismatchedMainResources(t *testing
 		Pool: v1alpha1.PoolStrategy{MinIdle: 0, MaxIdle: 1},
 	}
 
-	err := validateTemplateSpecForClaimsWithMemoryPerCPU(spec, &internalauth.Claims{TeamID: "team-1"}, configuredTemplateMemoryPerCPU())
+	err := validateTemplateSpecForClaims(spec, &internalauth.Claims{TeamID: "team-1"}, template.ResourcePolicy{})
 	if err == nil {
 		t.Fatal("expected aggregate resource ratio to be rejected")
 	}
@@ -1386,7 +1461,7 @@ func TestValidateTemplateSpecForClaims_RejectsSystemOwnedMismatchedMainResources
 	}
 
 	claims := &internalauth.Claims{IsSystem: true}
-	err := validateTemplateSpecForClaimsWithMemoryPerCPU(spec, claims, configuredTemplateMemoryPerCPU())
+	err := validateTemplateSpecForClaims(spec, claims, template.ResourcePolicy{})
 	if err == nil {
 		t.Fatal("expected system token to reject resource ratio mismatch")
 	}

--- a/pkg/template/http/template_validation.go
+++ b/pkg/template/http/template_validation.go
@@ -6,19 +6,17 @@ import (
 	"path/filepath"
 	"strings"
 
-	config "github.com/sandbox0-ai/sandbox0/infra-operator/api/config"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	s0template "github.com/sandbox0-ai/sandbox0/pkg/template"
 	"github.com/sandbox0-ai/sandbox0/pkg/volumeportal"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-func validateTemplateSpecForClaimsWithMemoryPerCPU(
+func validateTemplateSpecForClaims(
 	spec v1alpha1.SandboxTemplateSpec,
 	claims *internalauth.Claims,
-	memoryPerCPU resource.Quantity,
+	resourcePolicy s0template.ResourcePolicy,
 ) error {
 	isSystem := claims != nil && claims.IsSystemToken()
 	if !isSystem {
@@ -40,7 +38,7 @@ func validateTemplateSpecForClaimsWithMemoryPerCPU(
 	if isSystem {
 		subject = "system template"
 	}
-	if err := s0template.ValidateResourceRatio(spec, memoryPerCPU, subject); err != nil {
+	if err := resourcePolicy.ValidateTemplate(spec, subject); err != nil {
 		return err
 	}
 	return nil
@@ -279,14 +277,6 @@ func validateReservedMountPath(path, field string) error {
 		}
 	}
 	return nil
-}
-
-func configuredTemplateMemoryPerCPU() resource.Quantity {
-	cfg := config.LoadManagerConfig()
-	if cfg == nil {
-		return s0template.MemoryPerCPUOrDefault("")
-	}
-	return s0template.MemoryPerCPUOrDefault(cfg.TeamTemplateMemoryPerCPU)
 }
 
 func validateCIDRs(values []string, field string) error {

--- a/pkg/template/resource_policy.go
+++ b/pkg/template/resource_policy.go
@@ -9,13 +9,111 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-const DefaultMemoryPerCPU = "4Gi"
+const (
+	DefaultMemoryPerCPU     = "4Gi"
+	DefaultSandboxMinMemory = "128Mi"
+	DefaultSandboxMaxMemory = "16Gi"
+)
+
+// ResourcePolicy defines the platform-wide resource bounds shared by
+// templates and sandbox lifecycle operations. Its zero value uses platform
+// defaults.
+type ResourcePolicy struct {
+	memoryPerCPU resource.Quantity
+	maxMemory    resource.Quantity
+}
+
+// NewResourcePolicy resolves configured resource settings with platform defaults.
+func NewResourcePolicy(memoryPerCPU, maxMemory string) ResourcePolicy {
+	return ResourcePolicy{
+		memoryPerCPU: positiveQuantityOrDefault(memoryPerCPU, DefaultMemoryPerCPU),
+		maxMemory:    positiveQuantityOrDefault(maxMemory, DefaultSandboxMaxMemory),
+	}
+}
+
+// MemoryPerCPU returns the effective memory-per-CPU ratio.
+func (p ResourcePolicy) MemoryPerCPU() resource.Quantity {
+	if p.memoryPerCPU.Sign() <= 0 {
+		return resource.MustParse(DefaultMemoryPerCPU)
+	}
+	return p.memoryPerCPU.DeepCopy()
+}
+
+// MaxMemory returns the effective maximum memory limit for one sandbox.
+func (p ResourcePolicy) MaxMemory() resource.Quantity {
+	if p.maxMemory.Sign() <= 0 {
+		return resource.MustParse(DefaultSandboxMaxMemory)
+	}
+	return p.maxMemory.DeepCopy()
+}
+
+// ParseMemory parses and validates a sandbox memory limit against the shared
+// platform bounds.
+func (p ResourcePolicy) ParseMemory(value, field string) (resource.Quantity, error) {
+	if strings.TrimSpace(field) == "" {
+		field = "memory"
+	}
+	raw := strings.TrimSpace(value)
+	if raw == "" {
+		return resource.Quantity{}, fmt.Errorf("%s is required", field)
+	}
+	memory, err := resource.ParseQuantity(raw)
+	if err != nil {
+		return resource.Quantity{}, fmt.Errorf("%s is invalid: %w", field, err)
+	}
+	if err := p.ValidateMemory(memory, field); err != nil {
+		return resource.Quantity{}, err
+	}
+	return memory, nil
+}
+
+// ValidateMemory validates a parsed sandbox memory limit against the shared
+// platform bounds.
+func (p ResourcePolicy) ValidateMemory(memory resource.Quantity, field string) error {
+	if strings.TrimSpace(field) == "" {
+		field = "memory"
+	}
+	if memory.Sign() <= 0 {
+		return fmt.Errorf("%s must be > 0", field)
+	}
+	minMemory := resource.MustParse(DefaultSandboxMinMemory)
+	if memory.Cmp(minMemory) < 0 {
+		return fmt.Errorf("%s must be >= %s", field, minMemory.String())
+	}
+	return p.ValidateMaxMemory(memory, field)
+}
+
+// ValidateMaxMemory enforces the configurable platform ceiling. Callers that
+// accept raw user input should use ValidateMemory to enforce the fixed lower
+// bound as well.
+func (p ResourcePolicy) ValidateMaxMemory(memory resource.Quantity, field string) error {
+	if strings.TrimSpace(field) == "" {
+		field = "memory"
+	}
+	maxMemory := p.MaxMemory()
+	if memory.Cmp(maxMemory) > 0 {
+		return fmt.Errorf("%s must be <= %s", field, maxMemory.String())
+	}
+	return nil
+}
+
+// ValidateTemplate enforces the platform memory ceiling and resource ratio on a template.
+func (p ResourcePolicy) ValidateTemplate(spec v1alpha1.SandboxTemplateSpec, subject string) error {
+	if err := p.ValidateMaxMemory(spec.MainContainer.Resources.Memory, "spec.mainContainer.resources.memory"); err != nil {
+		return err
+	}
+	return ValidateResourceRatio(spec, p.MemoryPerCPU(), subject)
+}
 
 // MemoryPerCPUOrDefault parses memory-per-CPU settings and falls back to the platform default.
 func MemoryPerCPUOrDefault(value string) resource.Quantity {
+	return positiveQuantityOrDefault(value, DefaultMemoryPerCPU)
+}
+
+func positiveQuantityOrDefault(value, fallback string) resource.Quantity {
 	parsed, err := resource.ParseQuantity(strings.TrimSpace(value))
 	if err != nil || parsed.Sign() <= 0 {
-		return resource.MustParse(DefaultMemoryPerCPU)
+		return resource.MustParse(fallback)
 	}
 	return parsed
 }

--- a/pkg/template/resource_policy_test.go
+++ b/pkg/template/resource_policy_test.go
@@ -34,6 +34,77 @@ func TestMemoryPerCPUOrDefault(t *testing.T) {
 	}
 }
 
+func TestResourcePolicyDefaultsAndOverrides(t *testing.T) {
+	t.Parallel()
+
+	defaults := ResourcePolicy{}
+	if got := defaults.MemoryPerCPU(); got.Cmp(resource.MustParse(DefaultMemoryPerCPU)) != 0 {
+		t.Fatalf("default memory per CPU = %s, want %s", got.String(), DefaultMemoryPerCPU)
+	}
+	if got := defaults.MaxMemory(); got.Cmp(resource.MustParse(DefaultSandboxMaxMemory)) != 0 {
+		t.Fatalf("default max memory = %s, want %s", got.String(), DefaultSandboxMaxMemory)
+	}
+
+	configured := NewResourcePolicy("2Gi", "32Gi")
+	if got := configured.MemoryPerCPU(); got.Cmp(resource.MustParse("2Gi")) != 0 {
+		t.Fatalf("configured memory per CPU = %s, want 2Gi", got.String())
+	}
+	if got := configured.MaxMemory(); got.Cmp(resource.MustParse("32Gi")) != 0 {
+		t.Fatalf("configured max memory = %s, want 32Gi", got.String())
+	}
+}
+
+func TestResourcePolicyParseMemory(t *testing.T) {
+	t.Parallel()
+
+	policy := NewResourcePolicy("", "16Gi")
+	tests := []struct {
+		name    string
+		memory  string
+		wantErr string
+	}{
+		{name: "minimum accepted", memory: "128Mi"},
+		{name: "maximum accepted", memory: "16Gi"},
+		{name: "below minimum rejected", memory: "127Mi", wantErr: "must be >= 128Mi"},
+		{name: "above maximum rejected", memory: "17Gi", wantErr: "must be <= 16Gi"},
+		{name: "invalid rejected", memory: "large", wantErr: "is invalid"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := policy.ParseMemory(tt.memory, "config.resources.memory")
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ParseMemory() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ParseMemory() error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestResourcePolicyValidateTemplateRejectsMemoryAboveMaximum(t *testing.T) {
+	t.Parallel()
+
+	policy := NewResourcePolicy("2Gi", "16Gi")
+	spec := v1alpha1.SandboxTemplateSpec{
+		MainContainer: v1alpha1.ContainerSpec{
+			Resources: v1alpha1.ResourceQuota{
+				CPU:    resource.MustParse("16"),
+				Memory: resource.MustParse("32Gi"),
+			},
+		},
+	}
+	err := policy.ValidateTemplate(spec, "team-owned template")
+	if err == nil || !strings.Contains(err.Error(), "spec.mainContainer.resources.memory must be <= 16Gi") {
+		t.Fatalf("ValidateTemplate() error = %v, want max-memory rejection", err)
+	}
+}
+
 func TestCPUForMemory(t *testing.T) {
 	t.Parallel()
 

--- a/scheduler/pkg/http/server.go
+++ b/scheduler/pkg/http/server.go
@@ -144,6 +144,7 @@ func NewServerWithDependencies(deps ServerDependencies) (*Server, error) {
 		AllocationStore: allocationStore,
 		ClusterStore:    repo,
 		Reconciler:      reconciler,
+		ResourcePolicy:  template.NewResourcePolicy(cfg.TeamTemplateMemoryPerCPU, cfg.SandboxMaxMemory),
 		PrivateRegistryHosts: privateRegistryHosts(
 			cfg.RegistryPushRegistry,
 			cfg.RegistryPullRegistry,


### PR DESCRIPTION
## Summary

- centralize sandbox memory validation in a shared `template.ResourcePolicy`
- enforce the configured maximum for template create/update/from-sandbox, builtin template sync, claim, update, resume/recovery, and fork paths
- change the platform default from `32Gi` to `16Gi` and update the OpenAPI contract, generated CRD, and docs

## Behavior

- template defaults can no longer bypass `services.manager.config.sandboxMaxMemory`
- lifecycle operations reject legacy or inherited resource settings above the current platform maximum
- already-running sandboxes are not resized or terminated by this change

## Validation

- `make proto manifests apispec`
- `go mod tidy` (no diff)
- `helm lint infra-operator/chart`
- `golangci-lint v2.5.0 run ./...`
- all non-E2E Go packages with `-race -count=1`
- gateway admission statement coverage: `100.0%`

[sandbox0-infra#213](https://github.com/sandbox0-ai/sandbox0-infra/pull/213) pins the existing production region to `16Gi`; changing the CRD default alone would not rewrite an already-defaulted live CR.
