### PR TITLE
Add Cloud feedback issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/cloud-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/cloud-feedback.yml
@@ -1,0 +1,44 @@
+name: Cloud feedback
+description: Share product feedback about Sandbox0 Cloud.
+title: "[Cloud feedback]: "
+labels:
+  - feedback
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Sandbox0 Cloud. GitHub issues are public.
+        Do not include API keys, tokens, kubeconfigs, customer data, private repository URLs, or other sensitive information.
+  - type: dropdown
+    id: category
+    attributes:
+      label: Feedback type
+      description: Choose the category that best fits your feedback.
+      options:
+        - Product experience
+        - Feature request
+        - Bug report
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: feedback
+    attributes:
+      label: What would you like to share?
+      description: Describe what happened, what you expected, or the problem this would solve.
+      placeholder: Tell us what would make Sandbox0 Cloud better.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context (optional)
+      description: Include a minimal reproduction, relevant non-sensitive logs, or the dashboard area involved when useful.
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Public issue acknowledgement
+      options:
+        - label: I removed API keys, tokens, kubeconfigs, customer data, private repository URLs, and other sensitive information.
+          required: true

--- a/docs/sandbox/previews/page.mdx
+++ b/docs/sandbox/previews/page.mdx
@@ -1,6 +1,6 @@
 # Private Previews
 
-Private previews let an authenticated client open an HTTP server that listens only on `localhost`, `127.0.0.1`, or `::1` inside a sandbox. They are intended for IDE and agent-product preview panes, not for publishing an application.
+Private previews let an authenticated client open an HTTP server that listens only on sandbox loopback addresses. They are intended for IDE and agent-product preview panes, not for publishing an application.
 
 Unlike [Sandbox Services](/docs/sandbox/services), a preview:
 


### PR DESCRIPTION
## Summary

- add a dedicated public GitHub Issue Form for Sandbox0 Cloud feedback
- apply the `feedback` label for triage
- require an acknowledgement that sensitive data was removed
- keep the Private Previews AI-facing metadata free of local loopback endpoints so the Cloud website build can pass its `llms.txt` safety check

## Validation

- parsed the Issue Form as YAML
- ran `git diff --check`
- generated and verified `llms.txt` from the sibling Cloud workspace