### PR TITLE
fix(rootfs): keep mixed-version schema compatible

### DIFF
--- a/manager/pkg/sandboxstore/migrations/00016_prevent_rootfs_filesystem_self_reference.sql
+++ b/manager/pkg/sandboxstore/migrations/00016_prevent_rootfs_filesystem_self_reference.sql
@@ -5,11 +5,14 @@ SET source_filesystem_id = NULL,
     updated_at = NOW()
 WHERE source_filesystem_id = filesystem_id;
 
-ALTER TABLE manager.rootfs_filesystems
-    ADD CONSTRAINT rootfs_filesystems_source_not_self
-    CHECK (source_filesystem_id IS NULL OR source_filesystem_id <> filesystem_id);
+-- Do not add a CHECK constraint while a region may still run a legacy manager.
+-- The legacy same-sandbox restore statement can temporarily write this value,
+-- so enforcing it here would make the additive schema incompatible with an old
+-- data-plane cluster. Current writers already avoid self-references. Add the
+-- constraint in a later migration after every legacy writer has been retired
+-- and the cleanup above has been repeated.
 
 -- +goose Down
 
-ALTER TABLE manager.rootfs_filesystems
-    DROP CONSTRAINT rootfs_filesystems_source_not_self;
+-- The cleanup is intentionally irreversible. Restoring a corrupt
+-- self-reference would recreate a cycle in the legacy filesystem graph.

--- a/manager/pkg/sandboxstore/rootfs_integration_test.go
+++ b/manager/pkg/sandboxstore/rootfs_integration_test.go
@@ -88,6 +88,35 @@ func TestSandboxDesiredStateMigrationRepairsLegacyObservedStatuses(t *testing.T)
 	assert.Equal(t, int64(3), active)
 }
 
+func TestMixedVersionSchemaAllowsLegacySameSandboxRestore(t *testing.T) {
+	ctx := context.Background()
+	pool := newSandboxStoreIntegrationPool(t)
+
+	_, err := pool.Exec(ctx, `
+		INSERT INTO manager.rootfs_filesystems (filesystem_id, team_id)
+		VALUES ('legacy-sandbox', 'team-1')
+	`)
+	require.NoError(t, err)
+
+	// A manager from before the COW v3 rollout can write this transient value
+	// when it restores a snapshot into its source sandbox. The additive schema
+	// must accept that statement until every legacy writer has been retired.
+	_, err = pool.Exec(ctx, `
+		UPDATE manager.rootfs_filesystems
+		SET source_filesystem_id = filesystem_id
+		WHERE filesystem_id = 'legacy-sandbox'
+	`)
+	require.NoError(t, err)
+
+	var sourceFilesystemID string
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT source_filesystem_id
+		FROM manager.rootfs_filesystems
+		WHERE filesystem_id = 'legacy-sandbox'
+	`).Scan(&sourceFilesystemID))
+	assert.Equal(t, "legacy-sandbox", sourceFilesystemID)
+}
+
 func TestRootFSV3PersistenceSnapshotForkRestoreAndCAS(t *testing.T) {
 	ctx := context.Background()
 	pool := newSandboxStoreIntegrationPool(t)


### PR DESCRIPTION
## Summary

- keep migration 00016 cleanup of existing rootfs filesystem self-references
- defer the database CHECK constraint until every legacy manager writer has been retired
- add an integration test that exercises the same-sandbox update issued by a pre-COW-v3 manager

## Why

The ali-ue1 region must be able to run the current legacy data-plane cluster while a new S0FS/COW-v3 data plane is introduced as a separate rollout cohort. The old manager can temporarily write source_filesystem_id = filesystem_id during same-sandbox snapshot restore. Enforcing the new constraint in the shared regional PostgreSQL schema would break that old cluster even though the rest of the migration is additive.

This change does not make main-d4d0edd safe as an in-place upgrade of the existing cluster: the new manager/ctld protocol and rootfs format still cannot be rolled back to main-89dd389 after new v3 writes. sandbox0-infra#216 remains Draft. This PR is the schema prerequisite for a blue/green data-plane rollout.

## Validation

- go test ./manager/pkg/sandboxstore/...
- go test ./manager/cmd/manager
- git diff --check

## Follow-up

After the legacy data plane and writer are fully retired, run the cleanup again and add the self-reference CHECK constraint in a new migration.