### PR TITLE
fix(manager): keep disabled template reconciler nil

### DIFF
--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -440,14 +440,14 @@ func main() {
 	}
 	registryService := registryservice.NewRegistryService(registryProvider, logger)
 	templateStore := templstorepg.NewStore(pool)
-	var templateReconciler *templreconciler.SingleClusterReconciler
+	var singleClusterReconciler *templreconciler.SingleClusterReconciler
 	if cfg.TemplateStoreEnabled {
 		templateApplier := templateservice.NewTemplateApplier(templateService)
 		reconcileInterval := cfg.ResyncPeriod.Duration
 		if reconcileInterval == 0 {
 			reconcileInterval = 30 * time.Second
 		}
-		templateReconciler = templreconciler.NewSingleClusterReconciler(
+		singleClusterReconciler = templreconciler.NewSingleClusterReconciler(
 			templateStore,
 			templateApplier,
 			cfg.DefaultClusterId,
@@ -458,6 +458,7 @@ func main() {
 	} else {
 		logger.Info("Template reconciliation disabled; durable template build queue remains enabled")
 	}
+	templateReconciler := optionalManagerTemplateReconciler(singleClusterReconciler)
 	var templateBuildWorker *templatebuild.TemplateBuildWorker
 	switch {
 	case registryProvider == nil:
@@ -660,6 +661,19 @@ func main() {
 
 type templateReconcilerQuiescer interface {
 	Quiesce(context.Context) error
+}
+
+type managerTemplateReconciler interface {
+	templateReconcilerRunner
+	templateReconcilerQuiescer
+	httpserver.TemplateReconciler
+}
+
+func optionalManagerTemplateReconciler(reconciler *templreconciler.SingleClusterReconciler) managerTemplateReconciler {
+	if reconciler == nil {
+		return nil
+	}
+	return reconciler
 }
 
 const (

--- a/manager/cmd/manager/template_reconciler_test.go
+++ b/manager/cmd/manager/template_reconciler_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"testing"
+
+	httpserver "github.com/sandbox0-ai/sandbox0/manager/pkg/http"
+)
+
+func TestDisabledManagerTemplateReconcilerRemainsNilForConsumers(t *testing.T) {
+	reconciler := optionalManagerTemplateReconciler(nil)
+	if reconciler != nil {
+		t.Fatal("disabled template reconciler must be represented by a nil interface")
+	}
+
+	controllers := managerControllerSet{templateReconciler: reconciler}
+	if controllers.templateReconciler != nil {
+		t.Fatal("disabled template reconciler must remain nil for controller startup")
+	}
+
+	var quiescer templateReconcilerQuiescer = reconciler
+	if quiescer != nil {
+		t.Fatal("disabled template reconciler must remain nil for quiesce signals")
+	}
+
+	var httpReconciler httpserver.TemplateReconciler = reconciler
+	if httpReconciler != nil {
+		t.Fatal("disabled template reconciler must remain nil for HTTP handlers")
+	}
+}


### PR DESCRIPTION
## Summary
- represent a disabled single-cluster template reconciler as a nil interface
- prevent leader startup and quiesce consumers from invoking a typed nil pointer
- add regression coverage for all reconciler consumers

## Validation
- go test ./manager/...