### PR TITLE
fix(imagefs): bound and report revision claims

### DIFF
--- a/manager/pkg/templateimagefs/worker.go
+++ b/manager/pkg/templateimagefs/worker.go
@@ -28,8 +28,10 @@ import (
 const (
 	importerLabel       = "sandbox0.ai/imagefs-import"
 	defaultPollInterval = 500 * time.Millisecond
+	defaultClaimTimeout = 5 * time.Second
 	defaultLease        = 10 * time.Minute
 	defaultImportTTL    = 20 * time.Minute
+	claimErrorLogPeriod = 30 * time.Second
 )
 
 type queue interface {
@@ -49,6 +51,7 @@ type Config struct {
 	LeaseDuration  time.Duration
 	ImportTimeout  time.Duration
 	PollInterval   time.Duration
+	ClaimTimeout   time.Duration
 	EnsureInterval time.Duration
 	ImportCohort   s0fsrollout.Cohort
 	Admission      s0fsrollout.Admission
@@ -89,6 +92,9 @@ func NewWorker(q queue, heads headStore, k8sClient kubernetes.Interface, ctldCli
 	if cfg.PollInterval <= 0 {
 		cfg.PollInterval = defaultPollInterval
 	}
+	if cfg.ClaimTimeout <= 0 {
+		cfg.ClaimTimeout = defaultClaimTimeout
+	}
 	if cfg.EnsureInterval <= 0 {
 		cfg.EnsureInterval = 5 * time.Second
 	}
@@ -103,6 +109,8 @@ func NewWorker(q queue, heads headStore, k8sClient kubernetes.Interface, ctldCli
 
 func (w *Worker) Run(ctx context.Context) error {
 	var group sync.WaitGroup
+	var lastClaimError string
+	var lastClaimErrorAt time.Time
 	group.Add(1)
 	go func() {
 		defer group.Done()
@@ -110,19 +118,32 @@ func (w *Worker) Run(ctx context.Context) error {
 	}()
 	defer group.Wait()
 	for ctx.Err() == nil {
+		claimCtx, cancelClaim := context.WithTimeout(ctx, w.config.ClaimTimeout)
 		revision, err := w.queue.ClaimTemplateImageRevision(
-			ctx,
+			claimCtx,
 			w.config.WorkerID,
 			w.config.LeaseDuration,
 			w.config.ImportCohort.TeamIDs(),
 			w.config.ImportCohort.TemplateIDs(),
 		)
+		cancelClaim()
 		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			now := time.Now()
+			if err.Error() != lastClaimError || now.Sub(lastClaimErrorAt) >= claimErrorLogPeriod {
+				w.logger.Warn("Failed to claim template ImageFS revision", zap.Error(err))
+				lastClaimError = err.Error()
+				lastClaimErrorAt = now
+			}
 			if !waitForContext(ctx, w.config.PollInterval) {
 				return ctx.Err()
 			}
 			continue
 		}
+		lastClaimError = ""
+		lastClaimErrorAt = time.Time{}
 		if revision == nil {
 			if !waitForContext(ctx, w.config.PollInterval) {
 				return ctx.Err()

--- a/manager/pkg/templateimagefs/worker_test.go
+++ b/manager/pkg/templateimagefs/worker_test.go
@@ -2,7 +2,9 @@ package templateimagefs
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	api "github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/pkg/s0fsrollout"
@@ -10,10 +12,51 @@ import (
 	templstore "github.com/sandbox0-ai/sandbox0/pkg/template/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/kubernetes/fake"
 )
+
+func TestRunReportsClaimFailure(t *testing.T) {
+	queue := &workerQueueStub{claimErr: errors.New("claim queue unavailable")}
+	logCore, observedLogs := observer.New(zap.WarnLevel)
+	worker := &Worker{
+		queue:  queue,
+		config: Config{PollInterval: time.Millisecond, ClaimTimeout: time.Second, EnsureInterval: time.Second},
+		logger: zap.New(logCore),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- worker.Run(ctx) }()
+	require.Eventually(t, func() bool {
+		return observedLogs.FilterMessage("Failed to claim template ImageFS revision").Len() == 1
+	}, time.Second, time.Millisecond)
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+	require.GreaterOrEqual(t, queue.claimCalls, 1)
+	require.Equal(t, "claim queue unavailable", observedLogs.All()[0].ContextMap()["error"])
+}
+
+func TestRunBoundsStuckClaim(t *testing.T) {
+	queue := &workerQueueStub{blockClaim: true}
+	logCore, observedLogs := observer.New(zap.WarnLevel)
+	worker := &Worker{
+		queue:  queue,
+		config: Config{PollInterval: time.Millisecond, ClaimTimeout: 10 * time.Millisecond, EnsureInterval: time.Second},
+		logger: zap.New(logCore),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- worker.Run(ctx) }()
+	require.Eventually(t, func() bool {
+		entries := observedLogs.FilterMessage("Failed to claim template ImageFS revision").All()
+		return len(entries) == 1 && entries[0].ContextMap()["error"] == context.DeadlineExceeded.Error()
+	}, time.Second, time.Millisecond)
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
 
 func TestEnsureTemplateRevisionImportsInShadowWithoutSelecting(t *testing.T) {
 	tpl := imageFSWorkerTestTemplate()
@@ -112,6 +155,22 @@ type workerQueueStub struct {
 	ensureCalls int
 	selectCalls int
 	clearCalls  int
+	claimCalls  int
+	claimErr    error
+	blockClaim  bool
+}
+
+func (s *workerQueueStub) ListTemplates(context.Context) ([]*template.Template, error) {
+	return nil, nil
+}
+
+func (s *workerQueueStub) ClaimTemplateImageRevision(ctx context.Context, _ string, _ time.Duration, _, _ []string) (*template.TemplateImageRevision, error) {
+	s.claimCalls++
+	if s.blockClaim {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return nil, s.claimErr
 }
 
 func (s *workerQueueStub) EnsureTemplateImageRevision(_ context.Context, tpl *template.Template) (*template.TemplateImageRevision, bool, error) {


### PR DESCRIPTION
## Summary

- bound each Template ImageFS durable-queue claim to five seconds
- log claim failures immediately and then at most every 30 seconds for an unchanged error
- preserve the existing retry loop and shutdown behavior
- test both returned claim errors and stuck claims

## Production evidence

ali-ue1 green Stage 1 has a due revision in `resolving` with `attempt_count=0` and no lease. The manager reports that the ImageFS worker started, but the claim loop currently suppresses every error and can block indefinitely.

## Validation

- `go test ./manager/pkg/templateimagefs ./pkg/template/store/pg`
- `go test -race ./manager/pkg/templateimagefs`
- broader `go test ./manager/... ./pkg/template/... ./pkg/dbpool/...` passed for runnable packages; `manager/cmd/manager` cannot set up locally because generated `storage-proxy/proto/fs` is absent in the checkout

This does not change import cohorts, admission, carrier pooling, or claim routing.