### PR TITLE
fix(imagefs): allow large image imports to finish

### DIFF
--- a/manager/pkg/templateimagefs/worker.go
+++ b/manager/pkg/templateimagefs/worker.go
@@ -30,7 +30,7 @@ const (
 	defaultPollInterval = 500 * time.Millisecond
 	defaultClaimTimeout = 5 * time.Second
 	defaultLease        = 10 * time.Minute
-	defaultImportTTL    = 20 * time.Minute
+	defaultImportTTL    = 4 * time.Hour
 	claimErrorLogPeriod = 30 * time.Second
 )
 
@@ -191,6 +191,12 @@ func (w *Worker) ensureTemplateRevision(ctx context.Context, tpl *template.Templ
 }
 
 func (w *Worker) process(parent context.Context, revision *template.TemplateImageRevision) {
+	started := time.Now()
+	w.logger.Info("Template ImageFS import started",
+		zap.String("revisionID", revision.RevisionID),
+		zap.String("templateID", revision.TemplateID),
+		zap.Int("attempt", revision.AttemptCount),
+	)
 	ctx, cancel := context.WithTimeout(parent, w.config.ImportTimeout)
 	defer cancel()
 	stopRenew := make(chan struct{})
@@ -204,7 +210,7 @@ func (w *Worker) process(parent context.Context, revision *template.TemplateImag
 		if releaseErr := w.queue.ReleaseTemplateImageRevision(context.WithoutCancel(parent), revision.RevisionID, w.config.WorkerID, retryAt, err.Error()); releaseErr != nil && !errors.Is(releaseErr, template.ErrTemplateImageRevisionLeaseLost) {
 			w.logger.Warn("Failed to release template ImageFS revision", zap.String("revisionID", revision.RevisionID), zap.Error(releaseErr))
 		}
-		w.logger.Warn("Template ImageFS import failed", zap.String("revisionID", revision.RevisionID), zap.Error(err))
+		w.logger.Warn("Template ImageFS import failed", zap.String("revisionID", revision.RevisionID), zap.Duration("duration", time.Since(started)), zap.Error(err))
 	}
 }
 

--- a/manager/pkg/templateimagefs/worker_test.go
+++ b/manager/pkg/templateimagefs/worker_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	api "github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/sandboxstore"
 	"github.com/sandbox0-ai/sandbox0/pkg/s0fsrollout"
 	"github.com/sandbox0-ai/sandbox0/pkg/template"
 	templstore "github.com/sandbox0-ai/sandbox0/pkg/template/store"
@@ -18,6 +19,34 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/kubernetes/fake"
 )
+
+func TestNewWorkerDefaultsToLargeImageImportWindow(t *testing.T) {
+	worker, err := NewWorker(
+		&workerQueueStub{},
+		workerHeadStoreStub{},
+		fake.NewSimpleClientset(),
+		nil,
+		func(context.Context, *corev1.Pod) (string, error) { return "http://ctld", nil },
+		Config{WorkerID: "manager/green", BaseImageRef: "sandbox0ai/infra:carrier-base"},
+		zap.NewNop(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, 4*time.Hour, worker.config.ImportTimeout)
+}
+
+func TestNewWorkerPreservesExplicitImportTimeout(t *testing.T) {
+	worker, err := NewWorker(
+		&workerQueueStub{},
+		workerHeadStoreStub{},
+		fake.NewSimpleClientset(),
+		nil,
+		func(context.Context, *corev1.Pod) (string, error) { return "http://ctld", nil },
+		Config{WorkerID: "manager/green", BaseImageRef: "sandbox0ai/infra:carrier-base", ImportTimeout: 30 * time.Minute},
+		zap.NewNop(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, 30*time.Minute, worker.config.ImportTimeout)
+}
 
 func TestRunReportsClaimFailure(t *testing.T) {
 	queue := &workerQueueStub{claimErr: errors.New("claim queue unavailable")}
@@ -158,6 +187,12 @@ type workerQueueStub struct {
 	claimCalls  int
 	claimErr    error
 	blockClaim  bool
+}
+
+type workerHeadStoreStub struct{}
+
+func (workerHeadStoreStub) StageRootFSHead(context.Context, *sandboxstore.SandboxRootFSHead) error {
+	return nil
 }
 
 func (s *workerQueueStub) ListTemplates(context.Context) ([]*template.Template, error) {


### PR DESCRIPTION
## Summary

- extend the bounded background ImageFS import window from 20 minutes to 4 hours
- log each revision import start and include elapsed time on failure
- cover both the large-image default and explicit timeout overrides

## Production evidence

The green Stage 1 audit claimed the revision successfully, but the full OCI-to-S0FS capture was cancelled at exactly 20 minutes and immediately retried. The exact default image is 1.18 GB compressed / about 3.785 GB unpacked with 135,662 entries and 119,241 regular files. CaptureTree walks paths serially and persists content-addressed objects, so the existing 20-minute bound cannot cover this supported image size. Admission and the shared carrier pool remain off.

This changes only asynchronous template preprocessing. It does not relax claim/resume correctness, change the rootfs architecture, or alter the user-visible startup latency target.

## Validation

- go test ./manager/pkg/templateimagefs
- go test -race ./manager/pkg/templateimagefs
- go test ./manager/pkg/...
- git diff --check