### PR TITLE
fix(imagefs): skip superseded template revisions

### DIFF
--- a/manager/pkg/templateimagefs/worker.go
+++ b/manager/pkg/templateimagefs/worker.go
@@ -34,6 +34,8 @@ const (
 	claimErrorLogPeriod = 30 * time.Second
 )
 
+var errTemplateImageRevisionSuperseded = errors.New("template ImageFS revision is superseded")
+
 type queue interface {
 	templstore.TemplateStore
 	templstore.TemplateImageRevisionStore
@@ -206,6 +208,22 @@ func (w *Worker) process(parent context.Context, revision *template.TemplateImag
 		if errors.Is(err, template.ErrTemplateImageRevisionLeaseLost) {
 			return
 		}
+		if errors.Is(err, errTemplateImageRevisionSuperseded) {
+			if failErr := w.queue.FailTemplateImageRevision(
+				context.WithoutCancel(parent),
+				revision.RevisionID,
+				w.config.WorkerID,
+				template.TemplateImageRevisionReasonSuperseded,
+				err.Error(),
+			); failErr != nil {
+				if !errors.Is(failErr, template.ErrTemplateImageRevisionLeaseLost) {
+					w.logger.Warn("Failed to supersede template ImageFS revision", zap.String("revisionID", revision.RevisionID), zap.Error(failErr))
+				}
+				return
+			}
+			w.logger.Info("Template ImageFS revision superseded", zap.String("revisionID", revision.RevisionID), zap.Duration("duration", time.Since(started)))
+			return
+		}
 		retryAt := time.Now().UTC().Add(time.Duration(min(revision.AttemptCount+1, 12)) * 5 * time.Second)
 		if releaseErr := w.queue.ReleaseTemplateImageRevision(context.WithoutCancel(parent), revision.RevisionID, w.config.WorkerID, retryAt, err.Error()); releaseErr != nil && !errors.Is(releaseErr, template.ErrTemplateImageRevisionLeaseLost) {
 			w.logger.Warn("Failed to release template ImageFS revision", zap.String("revisionID", revision.RevisionID), zap.Error(releaseErr))
@@ -218,6 +236,18 @@ func (w *Worker) importRevision(ctx context.Context, revision *template.Template
 	tpl, err := w.queue.GetTemplate(ctx, revision.Scope, revision.TeamID, revision.TemplateID)
 	if err != nil || tpl == nil {
 		return fmt.Errorf("load template for ImageFS revision: %w", err)
+	}
+	desiredRevision, err := template.NewTemplateImageRevision(tpl)
+	if err != nil {
+		return fmt.Errorf("derive current template ImageFS revision: %w", err)
+	}
+	if desiredRevision.RevisionID != revision.RevisionID {
+		return fmt.Errorf(
+			"%w: claimed %s but current template requires %s",
+			errTemplateImageRevisionSuperseded,
+			revision.RevisionID,
+			desiredRevision.RevisionID,
+		)
 	}
 	namespace, err := templateNamespace(tpl)
 	if err != nil {

--- a/manager/pkg/templateimagefs/worker_test.go
+++ b/manager/pkg/templateimagefs/worker_test.go
@@ -137,6 +137,31 @@ func TestEnsureTemplateRevisionSelectsOnlyAdmittedPrivateTeam(t *testing.T) {
 	require.Equal(t, 0, queue.clearCalls)
 }
 
+func TestProcessSupersedesClaimWhoseSpecIsNoLongerCurrent(t *testing.T) {
+	claimedTemplate := imageFSWorkerTestTemplate()
+	claimed, err := template.NewTemplateImageRevision(claimedTemplate)
+	require.NoError(t, err)
+	currentTemplate := imageFSWorkerTestTemplate()
+	currentTemplate.Spec.MainContainer.Image = "python:3.14"
+	queue := &workerQueueStub{template: currentTemplate}
+	worker := &Worker{
+		queue: queue,
+		config: Config{
+			WorkerID:      "manager/green",
+			LeaseDuration: time.Hour,
+			ImportTimeout: time.Minute,
+		},
+		logger: zap.NewNop(),
+	}
+
+	worker.process(context.Background(), claimed)
+
+	require.Equal(t, 1, queue.failCalls)
+	require.Equal(t, claimed.RevisionID, queue.failedRevisionID)
+	require.Equal(t, template.TemplateImageRevisionReasonSuperseded, queue.failedReason)
+	require.Contains(t, queue.failedMessage, "current template requires")
+}
+
 func TestCreateImportPodPrimesFixedCarrierBaseOnTargetNode(t *testing.T) {
 	worker := &Worker{
 		k8s: fake.NewSimpleClientset(),
@@ -181,12 +206,17 @@ func TestTemplateNamespaceKeepsPublicAndTeamImportsIsolated(t *testing.T) {
 type workerQueueStub struct {
 	templstore.TemplateStore
 	templstore.TemplateImageRevisionStore
-	ensureCalls int
-	selectCalls int
-	clearCalls  int
-	claimCalls  int
-	claimErr    error
-	blockClaim  bool
+	ensureCalls      int
+	selectCalls      int
+	clearCalls       int
+	claimCalls       int
+	claimErr         error
+	blockClaim       bool
+	template         *template.Template
+	failCalls        int
+	failedRevisionID string
+	failedReason     string
+	failedMessage    string
 }
 
 type workerHeadStoreStub struct{}
@@ -221,6 +251,18 @@ func (s *workerQueueStub) SelectCurrentTemplateImageRevision(_ context.Context, 
 
 func (s *workerQueueStub) ClearCurrentTemplateImageRevision(_ context.Context, _, _, _ string) error {
 	s.clearCalls++
+	return nil
+}
+
+func (s *workerQueueStub) GetTemplate(context.Context, string, string, string) (*template.Template, error) {
+	return s.template, nil
+}
+
+func (s *workerQueueStub) FailTemplateImageRevision(_ context.Context, revisionID, _ string, reason, message string) error {
+	s.failCalls++
+	s.failedRevisionID = revisionID
+	s.failedReason = reason
+	s.failedMessage = message
 	return nil
 }
 

--- a/pkg/template/image_revision.go
+++ b/pkg/template/image_revision.go
@@ -14,11 +14,12 @@ import (
 )
 
 const (
-	TemplateImageRevisionStateResolving = "resolving"
-	TemplateImageRevisionStateImporting = "importing"
-	TemplateImageRevisionStateReady     = "ready"
-	TemplateImageRevisionStateFailed    = "failed"
-	PublicImageFSStorageScope           = rootfshead.PublicImageFSTeamID
+	TemplateImageRevisionStateResolving   = "resolving"
+	TemplateImageRevisionStateImporting   = "importing"
+	TemplateImageRevisionStateReady       = "ready"
+	TemplateImageRevisionStateFailed      = "failed"
+	TemplateImageRevisionReasonSuperseded = "Superseded"
+	PublicImageFSStorageScope             = rootfshead.PublicImageFSTeamID
 )
 
 // TemplateImageRevision is one immutable OCI resolution and S0FS ImageFS import.

--- a/pkg/template/store/pg/image_revision.go
+++ b/pkg/template/store/pg/image_revision.go
@@ -49,19 +49,43 @@ func (s *Store) EnsureTemplateImageRevision(ctx context.Context, tpl *template.T
 	if err != nil {
 		return nil, false, fmt.Errorf("create template image revision: %w", err)
 	}
+	created := tag.RowsAffected() == 1
 
-	stored, err := scanTemplateImageRevision(tx.QueryRow(ctx, `
-		SELECT `+templateImageRevisionSelectColumns+`
-		FROM scheduler_template_image_revisions
-		WHERE scope = $1 AND team_id = $2 AND template_id = $3 AND spec_hash = $4
-	`, revision.Scope, revision.TeamID, revision.TemplateID, revision.SpecHash))
+	loadStored := func() (*template.TemplateImageRevision, error) {
+		return scanTemplateImageRevision(tx.QueryRow(ctx, `
+			SELECT `+templateImageRevisionSelectColumns+`
+			FROM scheduler_template_image_revisions
+			WHERE scope = $1 AND team_id = $2 AND template_id = $3 AND spec_hash = $4
+		`, revision.Scope, revision.TeamID, revision.TemplateID, revision.SpecHash))
+	}
+	stored, err := loadStored()
 	if err != nil {
 		return nil, false, fmt.Errorf("load template image revision: %w", err)
+	}
+	if !created && stored.State == template.TemplateImageRevisionStateFailed &&
+		stored.Reason == template.TemplateImageRevisionReasonSuperseded {
+		if _, err := tx.Exec(ctx, `
+			UPDATE scheduler_template_image_revisions
+			SET resolved_digest = '', platform_os = '', platform_architecture = '',
+				platform_variant = '', image_fs_head_id = NULL, oci_config = NULL,
+				state = 'resolving', attempt_count = 0, next_attempt_at = NOW(),
+				lease_owner = NULL, lease_expires_at = NULL,
+				reason = '', message = '', started_at = NULL, completed_at = NULL
+			WHERE scope = $1 AND team_id = $2 AND template_id = $3 AND spec_hash = $4
+				AND state = 'failed' AND reason = $5
+		`, revision.Scope, revision.TeamID, revision.TemplateID, revision.SpecHash,
+			template.TemplateImageRevisionReasonSuperseded); err != nil {
+			return nil, false, fmt.Errorf("revive superseded template image revision: %w", err)
+		}
+		stored, err = loadStored()
+		if err != nil {
+			return nil, false, fmt.Errorf("reload revived template image revision: %w", err)
+		}
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return nil, false, fmt.Errorf("commit template image revision: %w", err)
 	}
-	return stored, tag.RowsAffected() == 1, nil
+	return stored, created, nil
 }
 
 // SelectCurrentTemplateImageRevision makes one immutable revision visible to

--- a/pkg/template/store/pg/store_integration_test.go
+++ b/pkg/template/store/pg/store_integration_test.go
@@ -71,6 +71,73 @@ func TestEnsureTemplateImageRevisionStaysShadowUntilSelected(t *testing.T) {
 	}
 }
 
+func TestEnsureTemplateImageRevisionRevivesOnlySupersededSpec(t *testing.T) {
+	store, _ := newTemplateStoreIntegrationTest(t)
+	ctx := context.Background()
+	tpl := &template.Template{
+		TemplateID: "revived-imagefs",
+		Scope:      naming.ScopeTeam,
+		TeamID:     "team-1",
+		UserID:     "user-1",
+		Spec:       integrationTemplateSpec("ubuntu:24.04"),
+		CreatedAt:  time.Now().UTC(),
+	}
+	if err := store.CreateTemplate(ctx, tpl); err != nil {
+		t.Fatalf("CreateTemplate() error = %v", err)
+	}
+	oldRevision, _, err := store.EnsureTemplateImageRevision(ctx, tpl)
+	if err != nil {
+		t.Fatalf("EnsureTemplateImageRevision() error = %v", err)
+	}
+	claimed, err := store.ClaimTemplateImageRevision(ctx, "worker-a", time.Minute, nil, nil)
+	if err != nil {
+		t.Fatalf("ClaimTemplateImageRevision() error = %v", err)
+	}
+	if claimed == nil || claimed.RevisionID != oldRevision.RevisionID {
+		t.Fatalf("claimed revision = %#v, want %q", claimed, oldRevision.RevisionID)
+	}
+	if err := store.FailTemplateImageRevision(
+		ctx,
+		claimed.RevisionID,
+		"worker-a",
+		template.TemplateImageRevisionReasonSuperseded,
+		"template changed",
+	); err != nil {
+		t.Fatalf("FailTemplateImageRevision() error = %v", err)
+	}
+
+	tpl.Spec = integrationTemplateSpec("ubuntu:24.10")
+	if err := store.UpdateTemplate(ctx, tpl); err != nil {
+		t.Fatalf("UpdateTemplate(new spec) error = %v", err)
+	}
+	if _, created, err := store.EnsureTemplateImageRevision(ctx, tpl); err != nil {
+		t.Fatalf("EnsureTemplateImageRevision(new spec) error = %v", err)
+	} else if !created {
+		t.Fatal("EnsureTemplateImageRevision(new spec) created = false, want true")
+	}
+
+	tpl.Spec = integrationTemplateSpec("ubuntu:24.04")
+	if err := store.UpdateTemplate(ctx, tpl); err != nil {
+		t.Fatalf("UpdateTemplate(old spec) error = %v", err)
+	}
+	revived, created, err := store.EnsureTemplateImageRevision(ctx, tpl)
+	if err != nil {
+		t.Fatalf("EnsureTemplateImageRevision(revived spec) error = %v", err)
+	}
+	if created {
+		t.Fatal("EnsureTemplateImageRevision(revived spec) created = true, want reused revision")
+	}
+	if revived.RevisionID != oldRevision.RevisionID {
+		t.Fatalf("revived revision = %q, want %q", revived.RevisionID, oldRevision.RevisionID)
+	}
+	if revived.State != template.TemplateImageRevisionStateResolving || revived.AttemptCount != 0 {
+		t.Fatalf("revived revision state = %q attempts = %d, want resolving/0", revived.State, revived.AttemptCount)
+	}
+	if revived.Reason != "" || revived.Message != "" || !revived.CompletedAt.IsZero() {
+		t.Fatalf("revived revision retained terminal status: %#v", revived)
+	}
+}
+
 func TestClaimTemplateImageRevisionFiltersShadowImportCohort(t *testing.T) {
 	store, _ := newTemplateStoreIntegrationTest(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- verify a claimed ImageFS revision still matches the current canonical template before creating its importer Pod
- terminate stale claims as `Superseded` instead of importing the current spec under an obsolete revision identity
- revive only superseded revisions when a template intentionally returns to an earlier spec

## Why

Production Stage 1 shadow import exposed two immutable revisions for `default`. The region-wide worker leased the older revision, but importer construction loads the current template spec. Without this guard, a stale revision can import a newer spec while retaining the stale revision ID and spec hash.

## Validation

- `go test ./manager/pkg/templateimagefs ./pkg/template ./pkg/template/store/pg`
- `go test ./manager/pkg/... ./pkg/template/...`
- `git diff --check`

## Rollout

The production green cluster remains shadow-only: S0FS admission is off, shared carrier pool is disabled, no revision is selected, and the latest status-only audit observed zero user sandbox and carrier Pods. After CI, this PR will be squash-merged, built without moving `latest`, then deployed only to green through the existing guarded GitOps workflow.
