### PR TITLE
Preserve rootfs runtime identity across forks

### DIFF
--- a/manager/pkg/service/sandbox_service_rootfs_product.go
+++ b/manager/pkg/service/sandbox_service_rootfs_product.go
@@ -368,21 +368,22 @@ func (s *SandboxService) ForkSandbox(ctx context.Context, sourceSandboxID, teamI
 		hardExpiresAt = source.HardExpiresAt
 	}
 	target := &sandboxstore.SandboxRecord{
-		ID:                targetID,
-		TeamID:            teamID,
-		UserID:            userID,
-		TemplateID:        source.TemplateID,
-		TemplateName:      source.TemplateName,
-		TemplateNamespace: source.TemplateNamespace,
-		ClusterID:         source.ClusterID,
-		DesiredState:      sandboxstore.SandboxDesiredStatePaused,
-		Config:            targetConfig,
-		TemplateSpec:      *source.TemplateSpec.DeepCopy(),
-		ClaimedAt:         now,
-		ExpiresAt:         expiresAt,
-		HardExpiresAt:     hardExpiresAt,
-		CreatedAt:         now,
-		UpdatedAt:         now,
+		ID:                   targetID,
+		TeamID:               teamID,
+		UserID:               userID,
+		TemplateID:           source.TemplateID,
+		TemplateName:         source.TemplateName,
+		TemplateNamespace:    source.TemplateNamespace,
+		ClusterID:            source.ClusterID,
+		DesiredState:         sandboxstore.SandboxDesiredStatePaused,
+		Config:               targetConfig,
+		TemplateSpec:         *source.TemplateSpec.DeepCopy(),
+		RootFSRuntimeVersion: source.RootFSRuntimeVersion,
+		ClaimedAt:            now,
+		ExpiresAt:            expiresAt,
+		HardExpiresAt:        hardExpiresAt,
+		CreatedAt:            now,
+		UpdatedAt:            now,
 	}
 	checkpointCommitted := false
 	if checkpoint != nil {

--- a/manager/pkg/service/sandbox_service_rootfs_product_test.go
+++ b/manager/pkg/service/sandbox_service_rootfs_product_test.go
@@ -127,6 +127,7 @@ func TestSandboxRootFSProductSnapshotsRestoresAndForksPausedSandbox(t *testing.T
 		SandboxVolumeID: "volume-1",
 		MountPoint:      "/workspace/data",
 	}}
+	store.records["sandbox-1"].RootFSRuntimeVersion = sandboxstore.RootFSRuntimeS0FSV2
 	svc := rootFSProductTestService(store)
 
 	snapshot, err := svc.CreateSandboxRootFSSnapshot(context.Background(), "sandbox-1", "team-1", &CreateSandboxRootFSSnapshotRequest{
@@ -166,6 +167,7 @@ func TestSandboxRootFSProductSnapshotsRestoresAndForksPausedSandbox(t *testing.T
 	assert.Empty(t, forkResp.Sandbox.Mounts)
 	assert.Len(t, forkResp.Sandbox.Services, 1)
 	assert.Equal(t, "layer-v1", store.rootFSHeads[forkResp.Sandbox.ID].Reference.HeadID)
+	assert.Equal(t, sandboxstore.RootFSRuntimeS0FSV2, store.records[forkResp.Sandbox.ID].RootFSRuntimeVersion)
 
 	require.NoError(t, svc.DeleteSandboxRootFSSnapshot(context.Background(), snapshot.ID, "team-1"))
 	_, err = svc.GetSandboxRootFSSnapshot(context.Background(), snapshot.ID, "team-1")


### PR DESCRIPTION
## Summary

- copy the source sandbox rootfs runtime identity into the fork target record
- cover S0FS fork persistence in the rootfs product service test

## Production evidence

The exact private green cold canary run 31788626863 passed S0FS claim, write, pause, and snapshot, then found the fork target persisted as `legacy-v1`. The source record was already `s0fs-v2`; `ForkSandbox` copied the template and cluster identity but omitted `RootFSRuntimeVersion`.

## Correctness

Rootfs runtime identity is immutable lineage metadata. A fork must inherit it from the source so resume chooses the S0FS carrier path rather than legacy rootfs handling. Legacy sources continue to inherit `legacy-v1`.

## Validation

- targeted paused/running fork tests
- `go test ./manager/pkg/service -count=1`
- `git diff --check`