### PR TITLE
Fix pause during manager cache warmup

### DIFF
--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -154,9 +154,12 @@ func (s *SandboxService) requestPauseSandboxRuntime(ctx context.Context, sandbox
 			return nil
 		}
 
-		pod, err := s.getSandboxPod(lockCtx, sandboxID)
+		pod, err := s.getRecordedSandboxRuntimePod(lockCtx, record)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
+				if recordedSandboxRuntimeIdentity(record) {
+					return k8serrors.NewConflict(schema.GroupResource{Resource: "sandbox"}, sandboxID, fmt.Errorf("recorded runtime pod disappeared before pause"))
+				}
 				status = managerapi.SandboxStatusPaused
 				return tx.MarkRuntimePaused(lockCtx, sandboxID, 0, s.clock.Now())
 			}
@@ -398,9 +401,14 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 		return err
 	}
 
-	pod, err := s.getSandboxPod(ctx, sandboxID)
+	pod, err := s.getRecordedSandboxRuntimePod(ctx, record)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
+			if !runtimeRecovery {
+				completionErr := fmt.Errorf("recorded runtime pod disappeared before rootfs checkpoint: %w", err)
+				abortOnError(completionErr)
+				return completionErr
+			}
 			if runtimeRecovery && s.logger != nil {
 				fields := []zap.Field{
 					zap.String("sandboxID", sandboxID),
@@ -1299,6 +1307,60 @@ func (s *SandboxService) getSandboxPod(ctx context.Context, sandboxID string) (*
 		return nil, err
 	}
 	return selectSandboxRuntimePod(sandboxID, pods)
+}
+
+// getRecordedSandboxRuntimePod resolves the durable runtime identity from the
+// informer cache and confirms a cache miss with an exact Kubernetes API read.
+// A restarting manager may serve requests before its namespace-scoped pod
+// cache is warm, so cache absence alone must never be treated as runtime loss.
+func (s *SandboxService) getRecordedSandboxRuntimePod(ctx context.Context, record *sandboxstore.SandboxRecord) (*corev1.Pod, error) {
+	if record == nil {
+		return nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "sandbox"}, "")
+	}
+	sandboxID := strings.TrimSpace(record.ID)
+	namespace := strings.TrimSpace(record.CurrentPodNamespace)
+	name := strings.TrimSpace(record.CurrentPodName)
+	if namespace == "" && name == "" {
+		return s.getSandboxPod(ctx, sandboxID)
+	}
+	if namespace == "" || name == "" {
+		return nil, k8serrors.NewConflict(schema.GroupResource{Resource: "sandbox"}, sandboxID, fmt.Errorf("recorded runtime pod identity is incomplete"))
+	}
+
+	if s.podLister != nil {
+		pod, err := s.podLister.Pods(namespace).Get(name)
+		if err == nil {
+			return validateRecordedSandboxRuntimePod(record, pod)
+		}
+		if !k8serrors.IsNotFound(err) {
+			return nil, err
+		}
+	}
+	if s.k8sClient == nil {
+		return nil, fmt.Errorf("confirm recorded runtime pod %s/%s: kubernetes client is not configured", namespace, name)
+	}
+	pod, err := s.k8sClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return validateRecordedSandboxRuntimePod(record, pod)
+}
+
+func recordedSandboxRuntimeIdentity(record *sandboxstore.SandboxRecord) bool {
+	return record != nil && strings.TrimSpace(record.CurrentPodNamespace) != "" && strings.TrimSpace(record.CurrentPodName) != ""
+}
+
+func validateRecordedSandboxRuntimePod(record *sandboxstore.SandboxRecord, pod *corev1.Pod) (*corev1.Pod, error) {
+	if record == nil || pod == nil {
+		return nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "pod"}, "")
+	}
+	if sandboxPodID(pod) != record.ID || !sandboxRuntimePodOwnedBySandbox(pod) {
+		return nil, k8serrors.NewConflict(schema.GroupResource{Resource: "pod"}, pod.Name, fmt.Errorf("pod does not belong to sandbox %s", record.ID))
+	}
+	if !sandboxRecordReferencesPod(record, pod) {
+		return nil, k8serrors.NewConflict(schema.GroupResource{Resource: "pod"}, pod.Name, fmt.Errorf("pod does not match the recorded runtime identity"))
+	}
+	return pod, nil
 }
 
 func selectSandboxRuntimePod(sandboxID string, pods []*corev1.Pod) (*corev1.Pod, error) {

--- a/manager/pkg/service/sandbox_service_pause_test.go
+++ b/manager/pkg/service/sandbox_service_pause_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -125,4 +126,70 @@ func TestPauseSandboxAndWaitRejectsAbortedCheckpoint(t *testing.T) {
 	assert.Contains(t, err.Error(), "pause did not complete")
 	require.Error(t, <-enqueuer.done)
 	assert.Equal(t, sandboxstore.SandboxDesiredStateActive, store.records["sandbox-1"].DesiredState)
+}
+
+func TestPauseSandboxAndWaitUsesRecordedPodWhileInformerCacheWarms(t *testing.T) {
+	ctld := newRootFSHeadCTLDServer(t, nil)
+	defer ctld.Close()
+
+	service, store, pod := newPauseAndWaitTestService(t, ctld)
+	service.podLister = newTestPodLister(t)
+	enqueuer := &completingPauseEnqueuer{service: service, done: make(chan error, 1)}
+	service.pauseEnqueuer = enqueuer
+	var procdCalls []string
+	defer attachRootFSTestProcd(t, pod, service, &procdCalls)()
+	client := fake.NewSimpleClientset(pod.DeepCopy())
+	service.k8sClient = client
+
+	response, err := service.PauseSandboxAndWait(context.Background(), "sandbox-1")
+	require.NoError(t, err)
+	require.NoError(t, <-enqueuer.done)
+	require.NotNil(t, response)
+	assert.True(t, response.Paused)
+	assert.Equal(t, managerapi.SandboxStatusPaused, response.Status)
+	require.NotNil(t, store.rootFSHeads["sandbox-1"])
+	assert.Equal(t, []string{"barrier:true", "pause"}, procdCalls)
+	assert.Equal(t, sandboxstore.SandboxDesiredStatePaused, store.records["sandbox-1"].DesiredState)
+
+	getCalls := 0
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "get" && action.GetResource().Resource == "pods" {
+			getCalls++
+		}
+	}
+	assert.GreaterOrEqual(t, getCalls, 2, "request and completion should confirm the recorded pod through the API")
+}
+
+func TestRequestPauseSandboxRuntimeDoesNotPauseWhenRecordedPodIsStronglyAbsent(t *testing.T) {
+	ctld := newRootFSHeadCTLDServer(t, nil)
+	defer ctld.Close()
+
+	service, store, _ := newPauseAndWaitTestService(t, ctld)
+	service.podLister = newTestPodLister(t)
+	service.k8sClient = fake.NewSimpleClientset()
+
+	_, err := service.RequestPauseSandboxRuntime(context.Background(), "sandbox-1")
+	require.Error(t, err)
+	assert.True(t, k8serrors.IsConflict(err))
+	assert.Equal(t, sandboxstore.SandboxDesiredStateActive, store.records["sandbox-1"].DesiredState)
+	assert.Nil(t, activeLifecycleTxnForTest(store, "sandbox-1"))
+}
+
+func TestCompleteManualPauseAbortsWhenRecordedPodDisappears(t *testing.T) {
+	ctld := newRootFSHeadCTLDServer(t, nil)
+	defer ctld.Close()
+
+	service, store, pod := newPauseAndWaitTestService(t, ctld)
+	txnID := addRootFSTestPauseTxn(store, pod, sandboxstore.SandboxLifecyclePhasePreparing)
+	store.rootFSHeads = map[string]*sandboxstore.SandboxRootFSHead{
+		"sandbox-1": rootFSHeadTestFixture(t, "sandbox-1", "team-1", "committed-head", 1),
+	}
+	service.podLister = newTestPodLister(t)
+	service.k8sClient = fake.NewSimpleClientset()
+
+	err := service.CompletePausingSandboxRuntime(context.Background(), "sandbox-1")
+	require.ErrorContains(t, err, "disappeared before rootfs checkpoint")
+	assert.Equal(t, sandboxstore.SandboxDesiredStateActive, store.records["sandbox-1"].DesiredState)
+	assert.Equal(t, "committed-head", store.rootFSHeads["sandbox-1"].Reference.HeadID)
+	assert.Equal(t, sandboxstore.SandboxLifecyclePhaseAborted, store.lifecycleTxns[txnID].Phase)
 }


### PR DESCRIPTION
## Summary
- resolve an active sandbox through its durable Pod identity and confirm informer misses with an exact Kubernetes API GET
- fail closed when a manual pause loses its recorded runtime instead of committing `Paused` without a rootfs checkpoint
- retain the existing nil-head behavior only for crash, health, lost-runtime, and rootfs recovery transactions

## Production failure
During the protected manager-restart canary, the replacement manager served the pause request before it acquired controller leadership. Its namespace-scoped informer did not yet contain the still-running sandbox Pod, so pause returned success and committed `Paused` without sealing a new rootfs head. The subsequent resume restored the prior head and lost the durable marker.

## Validation
- `go test ./manager/pkg/service -count=1`
- `make test manager` (race enabled)
- regression covers an empty informer with the recorded Pod still present in the Kubernetes API and verifies barrier + seal + durable paused state
- regressions verify strong Pod absence cannot silently pause and a mid-pause disappearance aborts while preserving the existing head
