### PR TITLE
Gate manager readiness on controller leadership

### DIFF
--- a/manager/cmd/manager/app.go
+++ b/manager/cmd/manager/app.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/generated/informers/externalversions"
@@ -13,6 +14,22 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 )
+
+// startManagerControllers marks the HTTP server ready only after leader-scoped
+// controllers have started, and withdraws readiness when their context ends.
+func startManagerControllers(ctx context.Context, start func(context.Context), ready *atomic.Bool) {
+	if start != nil {
+		start(ctx)
+	}
+	if ready == nil {
+		return
+	}
+	ready.Store(true)
+	go func() {
+		<-ctx.Done()
+		ready.Store(false)
+	}()
+}
 
 // managerApp owns process-level startup, leader election, and shutdown. Feature
 // construction stays outside this lifecycle object so dependencies are fully

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -596,6 +597,11 @@ func main() {
 		zap.Strings("allowed_callers", validatorConfig.AllowedCallers),
 	)
 
+	// A manager that has not acquired controller leadership cannot complete
+	// controller-backed lifecycle mutations such as pause. Keep it out of the
+	// Service until those workers have started.
+	var controllerReady atomic.Bool
+
 	// Create HTTP server
 	httpServer := httpserver.NewServerWithDependencies(httpserver.ServerDependencies{
 		SandboxService:          sandboxService,
@@ -613,6 +619,7 @@ func main() {
 		Logger:                  logger,
 		Port:                    cfg.HTTPPort,
 		ObservabilityProvider:   obsProvider,
+		ReadinessCheck:          controllerReady.Load,
 		PublicRootDomain:        cfg.PublicRootDomain,
 		PublicRegionID:          cfg.PublicRegionID,
 	})
@@ -655,8 +662,10 @@ func main() {
 		crdInformerFactory:    crdInformerFactory,
 		metricsPort:           cfg.MetricsPort,
 		leaderElectionEnabled: cfg.LeaderElection,
-		startControllers:      controllers.Start,
-		cacheSyncs:            informerRuntime.cacheSyncs(),
+		startControllers: func(ctx context.Context) {
+			startManagerControllers(ctx, controllers.Start, &controllerReady)
+		},
+		cacheSyncs: informerRuntime.cacheSyncs(),
 	}
 	app.Run()
 }

--- a/manager/cmd/manager/main_test.go
+++ b/manager/cmd/manager/main_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -21,6 +22,34 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/client-go/rest"
 )
+
+func TestStartManagerControllersOwnsReadiness(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var ready atomic.Bool
+	started := false
+
+	startManagerControllers(ctx, func(context.Context) {
+		if ready.Load() {
+			t.Fatal("manager became ready before controllers started")
+		}
+		started = true
+	}, &ready)
+	if !started {
+		t.Fatal("controllers were not started")
+	}
+	if !ready.Load() {
+		t.Fatal("manager did not become ready after controllers started")
+	}
+
+	cancel()
+	deadline := time.Now().Add(time.Second)
+	for ready.Load() && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if ready.Load() {
+		t.Fatal("manager remained ready after controller context ended")
+	}
+}
 
 type recordingTemplateReconcilerQuiescer struct {
 	called  chan struct{}

--- a/manager/pkg/http/server.go
+++ b/manager/pkg/http/server.go
@@ -47,6 +47,7 @@ type Server struct {
 	logger                  *zap.Logger
 	port                    int
 	obsProvider             *observability.Provider
+	isReady                 func() bool
 	// Public exposure config
 	publicRootDomain string
 	publicRegionID   string
@@ -90,6 +91,7 @@ type ServerDependencies struct {
 	Logger                  *zap.Logger
 	Port                    int
 	ObservabilityProvider   *observability.Provider
+	ReadinessCheck          func() bool
 	PublicRootDomain        string
 	PublicRegionID          string
 }
@@ -121,6 +123,7 @@ func NewServerWithDependencies(deps ServerDependencies) *Server {
 		logger:                  deps.Logger,
 		port:                    deps.Port,
 		obsProvider:             deps.ObservabilityProvider,
+		isReady:                 deps.ReadinessCheck,
 		publicRootDomain:        deps.PublicRootDomain,
 		publicRegionID:          deps.PublicRegionID,
 	}
@@ -297,6 +300,10 @@ func (s *Server) healthCheck(c *gin.Context) {
 }
 
 func (s *Server) readinessCheck(c *gin.Context) {
+	if s.isReady != nil && !s.isReady() {
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "manager controllers are not ready")
+		return
+	}
 	spec.JSONSuccess(c, http.StatusOK, gin.H{
 		"status": "ready",
 	})

--- a/manager/pkg/http/server_test.go
+++ b/manager/pkg/http/server_test.go
@@ -35,6 +35,40 @@ func TestSetupRoutesMountsTemplateFromSandboxEndpoints(t *testing.T) {
 	}
 }
 
+func TestReadinessCheckRequiresConfiguredCondition(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ready := false
+	server := &Server{isReady: func() bool { return ready }}
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	server.readinessCheck(ctx)
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status before readiness = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+	}
+
+	ready = true
+	recorder = httptest.NewRecorder()
+	ctx, _ = gin.CreateTestContext(recorder)
+	server.readinessCheck(ctx)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status after readiness = %d, want %d", recorder.Code, http.StatusOK)
+	}
+}
+
+func TestReadinessCheckDefaultsToReady(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	server := &Server{}
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+
+	server.readinessCheck(ctx)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+}
+
 func managerHasRoute(router *gin.Engine, method, path string) bool {
 	for _, route := range router.Routes() {
 		if route.Method == method && route.Path == path {


### PR DESCRIPTION
## Summary

- keep `/readyz` unavailable until leader-scoped manager controllers have started
- withdraw readiness when the controller context ends
- preserve the existing ready-by-default behavior for server users without a readiness callback

## Production evidence

A protected green cold-S0FS canary that restarted manager exposed a leader handoff race: the replacement Pod became Service-ready before it acquired controller leadership, so a pause mutation was accepted before the pause worker started. The same end-to-end canary without manager restart passed, isolating the fault to readiness during handoff.

This is a minimal lifecycle fix; it does not change the rootfs architecture or add a coordination layer.

## Tests

- `go test ./manager/pkg/http ./manager/cmd/manager -count=1`
- `make test manager`
- `git diff --check`