### PR TITLE
Avoid blocking rootfs Head teardown

### DIFF
--- a/ctld/internal/ctld/rootfssnapshotter/snapshotter.go
+++ b/ctld/internal/ctld/rootfssnapshotter/snapshotter.go
@@ -601,7 +601,9 @@ func cloneLabels(values map[string]string) map[string]string {
 
 type fuseMount struct {
 	server *fuse.Server
+	target string
 	done   chan struct{}
+	detach func(string, int) error
 }
 
 func mountFUSEHead(target string, reader *rootfsreader.Reader, head rootfshead.Head) (mountedHead, error) {
@@ -615,7 +617,7 @@ func mountFUSEHead(target string, reader *rootfsreader.Reader, head rootfshead.H
 	if err != nil {
 		return nil, err
 	}
-	mounted := &fuseMount{server: server, done: make(chan struct{})}
+	mounted := &fuseMount{server: server, target: target, done: make(chan struct{}), detach: unix.Unmount}
 	go func() {
 		server.Wait()
 		close(mounted.done)
@@ -635,10 +637,22 @@ func mountFUSEHead(target string, reader *rootfsreader.Reader, head rootfshead.H
 }
 
 func (m *fuseMount) Unmount() error {
-	if m == nil || m.server == nil {
+	if m == nil || strings.TrimSpace(m.target) == "" {
 		return nil
 	}
-	return m.server.Unmount()
+	detach := m.detach
+	if detach == nil {
+		detach = unix.Unmount
+	}
+	// The last snapshot child can disappear while gVisor still holds a lowerdir
+	// reference during teardown. A regular go-fuse unmount waits for every FUSE
+	// loop to exit and would hold the per-Head lock indefinitely. Lazy detach
+	// removes the mount from this namespace immediately; the kernel releases the
+	// old FUSE connection after the remaining references drain.
+	if err := detach(m.target, unix.MNT_DETACH); err != nil && !errors.Is(err, syscall.EINVAL) && !errors.Is(err, syscall.ENOENT) {
+		return fmt.Errorf("detach rootfs FUSE Head: %w", err)
+	}
+	return nil
 }
 
 func (m *fuseMount) HealthError() error {

--- a/ctld/internal/ctld/rootfssnapshotter/snapshotter_test.go
+++ b/ctld/internal/ctld/rootfssnapshotter/snapshotter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 func TestMarkerCommitPinsDurableBaseAndMountsLazily(t *testing.T) {
@@ -272,6 +274,48 @@ func TestPrepareFailsWhenHeadObjectIsCorrupt(t *testing.T) {
 	fixture.snapshotter.metadata = metadata
 	_, err := fixture.snapshotter.Prepare(context.Background(), "sandbox-child", fixture.headChain)
 	assert.ErrorContains(t, err, "failed size or digest validation")
+}
+
+func TestFuseMountUnmountLazilyDetachesWithoutWaitingForServer(t *testing.T) {
+	done := make(chan struct{})
+	called := false
+	mounted := &fuseMount{
+		target: "/rootfs/head",
+		done:   done,
+		detach: func(target string, flags int) error {
+			called = true
+			assert.Equal(t, "/rootfs/head", target)
+			assert.Equal(t, unix.MNT_DETACH, flags)
+			return nil
+		},
+	}
+
+	require.NoError(t, mounted.Unmount())
+	assert.True(t, called)
+	select {
+	case <-done:
+		t.Fatal("lazy detach must not wait for or close the FUSE server loop")
+	default:
+	}
+}
+
+func TestFuseMountUnmountToleratesAlreadyDetachedTarget(t *testing.T) {
+	for _, detachErr := range []error{syscall.EINVAL, syscall.ENOENT} {
+		mounted := &fuseMount{
+			target: "/rootfs/head",
+			detach: func(string, int) error { return detachErr },
+		}
+		require.NoError(t, mounted.Unmount())
+	}
+}
+
+func TestFuseMountUnmountReturnsDetachFailure(t *testing.T) {
+	mounted := &fuseMount{
+		target: "/rootfs/head",
+		detach: func(string, int) error { return syscall.EPERM },
+	}
+
+	assert.ErrorContains(t, mounted.Unmount(), "detach rootfs FUSE Head")
 }
 
 type snapshotterFixture struct {


### PR DESCRIPTION
## Summary
- lazily detach an unused immutable rootfs Head FUSE mount instead of synchronously waiting for all go-fuse loops to exit
- preserve immediate error reporting for real detach failures while tolerating already-detached targets
- cover non-blocking lazy detach, idempotent kernel states, and errors

## Why
Production green canary `31815640454` reached Pod sandbox and carrier gate in about one second, but every `CreateContainer` for the same `sandbox0.local/rootfs-heads` image timed out at two minutes. Containerd had already been restarted at 23:39, while the external rootfs snapshotter remained the process started at 22:56.

`Remove(last child)` holds the per-Head lock while calling go-fuse `Server.Unmount()`. After the kernel unmount, go-fuse synchronously waits for every FUSE loop to exit. A gVisor teardown that still holds the old lowerdir can therefore pin that Head lock and block all later `Prepare` calls for the same Head. Linux `MNT_DETACH` removes the mount from this namespace immediately and lets old references drain naturally; the existing stale-mount recovery path already uses the same primitive.

## Validation
- `go test ./ctld/internal/ctld/rootfssnapshotter`
- `go test -race ./ctld/internal/ctld/rootfssnapshotter`
- `git diff --check`

## Rollout
Build a canary image, pin green, roll the OnDelete rootfs snapshotter, then rerun cold lifecycle, manager restart, and ctld failover drills before enabling shared pool.