### PR TITLE
Make S0FS rollback fail closed on dependency and admission outages

### DIFF
--- a/manager/pkg/http/handlers_sandbox.go
+++ b/manager/pkg/http/handlers_sandbox.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/appservice"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/sandboxstore"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	gatewayauthn "github.com/sandbox0-ai/sandbox0/pkg/gateway/authn"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
@@ -232,7 +233,11 @@ func (s *Server) getOwnedSandbox(c *gin.Context, sandboxID string, claims *inter
 				zap.Error(err),
 			)
 		}
-		spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, fmt.Sprintf("sandbox not found: %v", err))
+		if apierrors.IsNotFound(err) || errors.Is(err, sandboxstore.ErrSandboxRecordNotFound) {
+			spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "sandbox not found")
+		} else {
+			spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox state is unavailable")
+		}
 		return nil, false
 	}
 	if sandbox.TeamID != claims.TeamID {
@@ -506,6 +511,8 @@ func (s *Server) writeSandboxLifecycleTransitionError(c *gin.Context, action, sa
 		spec.JSONError(c, http.StatusTooManyRequests, "quota_exceeded", err.Error())
 	case errors.Is(err, service.ErrSandboxCheckpointRequiresCtld):
 		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox checkpoint pause requires ctld")
+	case ctldapi.IsUnavailableError(err):
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox rootfs dependency is unavailable")
 	case errors.Is(err, context.DeadlineExceeded):
 		spec.JSONError(c, http.StatusGatewayTimeout, spec.CodeUnavailable, fmt.Sprintf("timed out waiting for sandbox to %s", action))
 	case errors.Is(err, context.Canceled):

--- a/manager/pkg/http/handlers_sandbox_dependency_test.go
+++ b/manager/pkg/http/handlers_sandbox_dependency_test.go
@@ -1,0 +1,99 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/sandboxstore"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
+	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
+	"go.uber.org/zap"
+)
+
+type errorSandboxStore struct {
+	sandboxstore.SandboxStore
+	err error
+}
+
+func (s *errorSandboxStore) GetSandbox(context.Context, string) (*sandboxstore.SandboxRecord, error) {
+	return nil, s.err
+}
+
+func TestGetOwnedSandboxDistinguishesUnavailableStoreFromNotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name       string
+		storeErr   error
+		wantStatus int
+	}{
+		{name: "database unavailable", storeErr: errors.New("database unavailable"), wantStatus: http.StatusServiceUnavailable},
+		{name: "record not found", storeErr: sandboxstore.ErrSandboxRecordNotFound, wantStatus: http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sandboxService := service.NewSandboxServiceWithDependencies(service.SandboxServiceDependencies{
+				SandboxStore: &errorSandboxStore{err: tt.storeErr},
+				Logger:       zap.NewNop(),
+			})
+			server := &Server{sandboxService: sandboxService, logger: zap.NewNop()}
+			recorder := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(recorder)
+			ctx.Request = httptest.NewRequest(http.MethodGet, "/api/v1/sandboxes/sandbox-1", nil)
+
+			if _, ok := server.getOwnedSandbox(ctx, "sandbox-1", &internalauth.Claims{TeamID: "team-1"}, ""); ok {
+				t.Fatal("getOwnedSandbox returned ok")
+			}
+			if recorder.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", recorder.Code, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestSandboxHTTPMapsWrappedCtldUnavailableErrorsTo503(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	err := fmt.Errorf("checkpoint: %w", &ctldapi.RequestError{
+		StatusCode: http.StatusServiceUnavailable,
+		Message:    "object store unavailable",
+	})
+
+	tests := []struct {
+		name  string
+		write func(*Server, *gin.Context, error)
+	}{
+		{
+			name: "lifecycle",
+			write: func(server *Server, ctx *gin.Context, err error) {
+				server.writeSandboxLifecycleTransitionError(ctx, "pause", "sandbox-1", err)
+			},
+		},
+		{
+			name: "rootfs product",
+			write: func(server *Server, ctx *gin.Context, err error) {
+				server.writeSandboxRootFSError(ctx, "create rootfs snapshot", "sandbox-1", err)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(recorder)
+			server := &Server{logger: zap.NewNop()}
+
+			tt.write(server, ctx, err)
+
+			if recorder.Code != http.StatusServiceUnavailable {
+				t.Fatalf("status = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+			}
+		})
+	}
+}

--- a/manager/pkg/http/handlers_sandbox_rootfs.go
+++ b/manager/pkg/http/handlers_sandbox_rootfs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/sandboxstore"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	"go.uber.org/zap"
@@ -164,6 +165,8 @@ func (s *Server) writeSandboxRootFSError(c *gin.Context, action, sandboxID strin
 		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox checkpoint requires ctld")
 	case errors.Is(err, service.ErrSandboxRootFSStoreUnavailable):
 		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox rootfs store is unavailable")
+	case ctldapi.IsUnavailableError(err):
+		spec.JSONError(c, http.StatusServiceUnavailable, spec.CodeUnavailable, "sandbox rootfs dependency is unavailable")
 	default:
 		spec.JSONError(c, http.StatusInternalServerError, spec.CodeInternal, fmt.Sprintf("failed to %s: %v", action, err))
 	}

--- a/manager/pkg/templateimagefs/worker.go
+++ b/manager/pkg/templateimagefs/worker.go
@@ -189,6 +189,16 @@ func (w *Worker) ensureTemplateRevision(ctx context.Context, tpl *template.Templ
 	if w.config.Admission.Admits(tpl.Scope, tpl.TeamID, tpl.TemplateID) {
 		return w.queue.SelectCurrentTemplateImageRevision(ctx, revision)
 	}
+	// Admission off has two distinct rollout states. A shadow-imported template
+	// that has never selected a revision stays on the legacy path. Once a
+	// revision has been selected, however, off is a traffic-stop rollback: keep
+	// the existing selection so the scheduler cannot fall through to a legacy
+	// cluster while the green manager rejects new claims. Resume does not use
+	// admission and continues to serve existing S0FS sandboxes.
+	if w.config.Admission.Mode() == s0fsrollout.AdmissionModeOff &&
+		tpl.Status != nil && tpl.Status.ImageRevision != nil {
+		return nil
+	}
 	return w.queue.ClearCurrentTemplateImageRevision(ctx, tpl.Scope, tpl.TeamID, tpl.TemplateID)
 }
 

--- a/manager/pkg/templateimagefs/worker_test.go
+++ b/manager/pkg/templateimagefs/worker_test.go
@@ -98,6 +98,22 @@ func TestEnsureTemplateRevisionImportsInShadowWithoutSelecting(t *testing.T) {
 	require.Equal(t, 1, queue.clearCalls)
 }
 
+func TestEnsureTemplateRevisionKeepsSelectedRevisionWhenAdmissionTurnsOff(t *testing.T) {
+	tpl := imageFSWorkerTestTemplate()
+	tpl.Status = &api.SandboxTemplateStatus{ImageRevision: &api.TemplateImageRevisionStatus{
+		RevisionID:    "tir-selected",
+		ImageFSHeadID: "head-selected",
+		State:         api.TemplateImageRevisionStateReady,
+	}}
+	queue := &workerQueueStub{}
+	worker := &Worker{queue: queue, config: Config{Admission: mustAdmission(t, "off", nil, nil)}}
+
+	require.NoError(t, worker.ensureTemplateRevision(context.Background(), tpl))
+	require.Equal(t, 1, queue.ensureCalls)
+	require.Equal(t, 0, queue.selectCalls)
+	require.Equal(t, 0, queue.clearCalls)
+}
+
 func TestEnsureTemplateRevisionSkipsTemplateOutsideImportCohort(t *testing.T) {
 	tpl := imageFSWorkerTestTemplate()
 	queue := &workerQueueStub{}

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -1456,6 +1456,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
+        "503":
+          description: Sandbox state store unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
     put:
       tags: [sandboxes]
       summary: Update sandbox configuration
@@ -1490,6 +1496,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
+        "503":
+          description: Sandbox state store unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
     delete:
       tags: [sandboxes]
       summary: Delete (terminate) a sandbox
@@ -1518,6 +1530,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
+        "503":
+          description: Sandbox state store unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
   /api/v1/sandboxes/{id}/status:
     get:
       tags: [sandboxes]
@@ -1537,6 +1555,12 @@ paths:
                 $ref: "#/components/schemas/SuccessSandboxStatusResponse"
         "404":
           description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "503":
+          description: Sandbox state store unavailable
           content:
             application/json:
               schema:

--- a/pkg/ctldapi/client.go
+++ b/pkg/ctldapi/client.go
@@ -95,6 +95,12 @@ func IsNotFoundError(err error) bool {
 	return errors.As(err, &reqErr) && reqErr != nil && reqErr.StatusCode == http.StatusNotFound
 }
 
+// IsUnavailableError reports whether err contains a ctld HTTP 503 response.
+func IsUnavailableError(err error) bool {
+	var reqErr *RequestError
+	return errors.As(err, &reqErr) && reqErr != nil && reqErr.StatusCode == http.StatusServiceUnavailable
+}
+
 func (c *Client) Probe(ctx context.Context, ctldAddress, sandboxID string, kind sandboxprobe.Kind) (*sandboxprobe.Response, error) {
 	path := fmt.Sprintf("/api/v1/sandboxes/%s/probes/%s", url.PathEscape(sandboxID), url.PathEscape(string(kind)))
 	return PostJSON[sandboxprobe.Response](ctx, c.httpClientOrDefault(), ctldAddress, path, nil)

--- a/pkg/ctldapi/client_test.go
+++ b/pkg/ctldapi/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -64,6 +65,22 @@ func TestPostJSONReturnsStatusErrorWithTypedMessage(t *testing.T) {
 	want := "ctld request failed with status 409: volume is busy"
 	if err.Error() != want {
 		t.Fatalf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestIsUnavailableErrorRecognizesWrappedRequestError(t *testing.T) {
+	t.Parallel()
+
+	err := fmt.Errorf("seal rootfs: %w", &RequestError{
+		StatusCode: http.StatusServiceUnavailable,
+		Message:    "object store unavailable",
+	})
+
+	if !IsUnavailableError(err) {
+		t.Fatal("IsUnavailableError returned false")
+	}
+	if IsUnavailableError(&RequestError{StatusCode: http.StatusConflict}) {
+		t.Fatal("IsUnavailableError returned true for a conflict")
 	}
 }
 


### PR DESCRIPTION
## Summary
- distinguish sandbox state-store outages from real not-found records and return HTTP 503 without exposing backend errors
- preserve wrapped ctld HTTP 503 responses across pause and rootfs product handlers
- when a migrated template switches from cold to off, retain its already-selected ImageFS revision so scheduler routing cannot fall through to a legacy cluster
- document the additive 503 responses in the OpenAPI source contract

## Why
Stage 2D intentionally blocks green-only PostgreSQL and S3 access. The current handlers fail closed but misclassify PostgreSQL errors as 404 and wrapped ctld object-store errors as 500. Stage 2E also requires cold -> off to stop new claims while existing S0FS sandboxes remain resumable; clearing the current revision during off would incorrectly return the template to legacy routing.

Shadow import behavior is unchanged: an off template that has never selected a revision remains unselected. The selection is only retained after a prior cold/shared admission wave selected it.

## Validation
- `go test ./manager/pkg/... ./pkg/ctldapi ./pkg/apispec`
- `go test ./manager/pkg/templateimagefs ./scheduler/pkg/http ./pkg/s0fsrollout ./manager/pkg/http ./pkg/ctldapi ./pkg/apispec`
- `go test -race ./manager/pkg/templateimagefs ./manager/pkg/http ./pkg/ctldapi`
- `git diff --check`