### PR TITLE
fix(ctld): classify rootfs store outages as unavailable

### DIFF
--- a/ctld/internal/ctld/rootfs/controller.go
+++ b/ctld/internal/ctld/rootfs/controller.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/rootfsstore"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/rootfshead"
 	"github.com/sandbox0-ai/sandbox0/storage-proxy/pkg/objectstore"
@@ -145,6 +146,9 @@ func statusForError(err error) int {
 	}
 	if errors.Is(err, ErrNotFound) {
 		return http.StatusNotFound
+	}
+	if errors.Is(err, rootfsstore.ErrBackendUnavailable) {
+		return http.StatusServiceUnavailable
 	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return http.StatusRequestTimeout

--- a/ctld/internal/ctld/rootfs/controller_v3.go
+++ b/ctld/internal/ctld/rootfs/controller_v3.go
@@ -241,11 +241,11 @@ func (c *Controller) SealRootFSHead(r *http.Request, req ctldapi.SealRootFSHeadR
 	}
 	if _, err := binding.writer.PutObject(requestContext(r), composed.Reference.Marker, composed.MarkerPayload); err != nil {
 		response.Error = err.Error()
-		return *response, http.StatusInternalServerError
+		return *response, statusForError(err)
 	}
 	if _, err := binding.writer.PutObject(requestContext(r), composed.Reference.Envelope, composed.EnvelopePayload); err != nil {
 		response.Error = err.Error()
-		return *response, http.StatusInternalServerError
+		return *response, statusForError(err)
 	}
 	createdBytes, createdObjects := binding.writer.CreatedMetrics()
 	response.Image = composed.Reference

--- a/ctld/internal/ctld/rootfs/controller_v3_test.go
+++ b/ctld/internal/ctld/rootfs/controller_v3_test.go
@@ -300,7 +300,7 @@ func TestControllerExposesAndAbandonsHeadWhenMarkerUploadFails(t *testing.T) {
 	partial, status := controller.SealRootFSHead(request, ctldapi.SealRootFSHeadRequest{
 		SandboxID: "sandbox-1", TeamID: "team-1", HeadID: "failed-head", ExpectedRuntimeGeneration: 1,
 	})
-	require.Equal(t, http.StatusInternalServerError, status)
+	require.Equal(t, http.StatusServiceUnavailable, status)
 	assert.Equal(t, "failed-head", partial.Reference.HeadID)
 	current, status := controller.GetRootFSSyncStatus(request, ctldapi.GetRootFSSyncStatusRequest{SandboxID: "sandbox-1", RuntimeGeneration: 1})
 	require.Equal(t, http.StatusOK, status)
@@ -318,6 +318,39 @@ func TestControllerExposesAndAbandonsHeadWhenMarkerUploadFails(t *testing.T) {
 	})
 	require.Equal(t, http.StatusOK, status, retried.Error)
 	assert.Equal(t, "replacement-head", retried.Reference.HeadID)
+}
+
+func TestControllerReturnsServiceUnavailableWhenSealCannotReachObjectStore(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	base, baseConfig := testRootFSBase(t)
+	store := &failingRootFSStore{Store: objectstore.NewMemoryStore(t.Name())}
+	controller := NewController(Config{
+		Context: ctx,
+		Runtime: &fakeV3Runtime{
+			fakeRuntime: &fakeRuntime{info: rootFSInfo("gvisor")},
+			upperdir:    t.TempDir(),
+			base:        base,
+			baseConfig:  baseConfig,
+		},
+		Store: store, WatchFenceRoot: t.TempDir(), CaptureLeases: &fakeCaptureLeases{},
+	})
+	request := httptest.NewRequest(http.MethodPut, "/", nil)
+	bound, status := controller.BindRootFSSync(request, ctldapi.BindRootFSSyncRequest{
+		Target: rootFSTarget(), SandboxID: "sandbox-1", TeamID: "team-1", RuntimeGeneration: 1,
+	})
+	require.Equal(t, http.StatusOK, status, bound.Error)
+	require.Eventually(t, func() bool {
+		current, currentStatus := controller.GetRootFSSyncStatus(request, ctldapi.GetRootFSSyncStatusRequest{SandboxID: "sandbox-1", RuntimeGeneration: 1})
+		return currentStatus == http.StatusOK && current.Status.InitialScanComplete
+	}, 5*time.Second, 10*time.Millisecond)
+
+	store.failHeads.Store(true)
+	response, status := controller.SealRootFSHead(request, ctldapi.SealRootFSHeadRequest{
+		SandboxID: "sandbox-1", TeamID: "team-1", HeadID: "unavailable-head", ExpectedRuntimeGeneration: 1,
+	})
+	assert.Equal(t, http.StatusServiceUnavailable, status)
+	assert.Contains(t, response.Error, rootfsstore.ErrBackendUnavailable.Error())
 }
 
 func TestControllerBindRootFSSyncRejectsCrossTeamParent(t *testing.T) {
@@ -441,6 +474,14 @@ func (a *fakePortalBackingAttacher) AttachRootFSBackings(_ context.Context, podU
 type failingRootFSStore struct {
 	objectstore.Store
 	failMarkers bool
+	failHeads   atomic.Bool
+}
+
+func (s *failingRootFSStore) Head(key string) (objectstore.Info, error) {
+	if s.failHeads.Load() {
+		return objectstore.Info{}, errors.New("injected object store head failure")
+	}
+	return s.Store.Head(key)
 }
 
 func (s *failingRootFSStore) Put(key string, reader io.Reader) error {

--- a/ctld/internal/ctld/rootfsstore/store.go
+++ b/ctld/internal/ctld/rootfsstore/store.go
@@ -17,6 +17,11 @@ import (
 	"golang.org/x/sync/singleflight"
 )
 
+// ErrBackendUnavailable identifies failures while communicating with the
+// object storage backend. Callers may use it to distinguish retryable
+// dependency failures from invalid rootfs data or requests.
+var ErrBackendUnavailable = errors.New("rootfs object store backend unavailable")
+
 type Writer struct {
 	store  objectstore.Store
 	prefix string
@@ -202,10 +207,10 @@ func PutImmutable(ctx context.Context, store objectstore.Store, prefix string, o
 		return false, ctx.Err()
 	}
 	if !objectstore.IsNotFound(err) {
-		return false, fmt.Errorf("inspect rootfs object %s: %w", object.Key, err)
+		return false, fmt.Errorf("%w: inspect rootfs object %s: %w", ErrBackendUnavailable, object.Key, err)
 	}
 	if err := store.Put(object.Key, bytes.NewReader(payload)); err != nil {
-		return false, fmt.Errorf("store rootfs object %s: %w", object.Key, err)
+		return false, fmt.Errorf("%w: store rootfs object %s: %w", ErrBackendUnavailable, object.Key, err)
 	}
 	if err := ctx.Err(); err != nil {
 		return true, err
@@ -225,12 +230,15 @@ func Read(ctx context.Context, store objectstore.Store, prefix string, object ro
 	}
 	reader, err := store.Get(object.Key, 0, object.Size)
 	if err != nil {
+		if !objectstore.IsNotFound(err) {
+			return nil, fmt.Errorf("%w: read rootfs object %s: %w", ErrBackendUnavailable, object.Key, err)
+		}
 		return nil, fmt.Errorf("read rootfs object %s: %w", object.Key, err)
 	}
 	payload, readErr := io.ReadAll(io.LimitReader(reader, object.Size+1))
 	closeErr := reader.Close()
 	if readErr != nil || closeErr != nil {
-		return nil, fmt.Errorf("read rootfs object %s: %w", object.Key, errors.Join(readErr, closeErr))
+		return nil, fmt.Errorf("%w: read rootfs object %s: %w", ErrBackendUnavailable, object.Key, errors.Join(readErr, closeErr))
 	}
 	if int64(len(payload)) != object.Size || digest.FromBytes(payload).String() != object.Digest {
 		return nil, fmt.Errorf("rootfs object %s failed size or digest validation", object.Key)

--- a/ctld/internal/ctld/rootfsstore/store_test.go
+++ b/ctld/internal/ctld/rootfsstore/store_test.go
@@ -3,6 +3,8 @@ package rootfsstore
 import (
 	"bytes"
 	"context"
+	"errors"
+	"io"
 	"sync"
 	"testing"
 
@@ -122,6 +124,22 @@ func TestReadRejectsCorruptPayload(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestPutImmutableMarksBackendFailuresUnavailable(t *testing.T) {
+	store := &failingStore{Store: objectstore.NewMemoryStore(t.Name()), headErr: errors.New("head failed")}
+	writer, err := NewTeamWriter(store, "team-1")
+	require.NoError(t, err)
+
+	_, err = writer.Put(context.Background(), rootfshead.ChunkMediaType, []byte("payload"))
+	assert.ErrorIs(t, err, ErrBackendUnavailable)
+	assert.ErrorContains(t, err, "head failed")
+
+	store.headErr = nil
+	store.putErr = errors.New("put failed")
+	_, err = writer.Put(context.Background(), rootfshead.ChunkMediaType, []byte("different payload"))
+	assert.ErrorIs(t, err, ErrBackendUnavailable)
+	assert.ErrorContains(t, err, "put failed")
+}
+
 func TestPrefixFromObjectRoundTrip(t *testing.T) {
 	store := objectstore.NewMemoryStore(t.Name())
 	writer, err := NewTeamWriter(store, "team-1")
@@ -134,6 +152,26 @@ func TestPrefixFromObjectRoundTrip(t *testing.T) {
 }
 
 type copyEncryptor struct{}
+
+type failingStore struct {
+	objectstore.Store
+	headErr error
+	putErr  error
+}
+
+func (s *failingStore) Head(key string) (objectstore.Info, error) {
+	if s.headErr != nil {
+		return objectstore.Info{}, s.headErr
+	}
+	return s.Store.Head(key)
+}
+
+func (s *failingStore) Put(key string, reader io.Reader) error {
+	if s.putErr != nil {
+		return s.putErr
+	}
+	return s.Store.Put(key, reader)
+}
 
 func (copyEncryptor) Encrypt(payload []byte) ([]byte, error) {
 	return append([]byte(nil), payload...), nil


### PR DESCRIPTION
## Summary

- tag rootfs object-store transport/backend failures at the storage boundary
- return HTTP 503 from rootfs seal publication while preserving validation and internal error semantics
- cover Head and Put failures plus the exact Seal regression path

## Validation

- `go test -race ./ctld/internal/ctld/rootfsstore ./ctld/internal/ctld/rootfs`
- `go test ./ctld/internal/ctld/... ./pkg/ctldapi`

## Rollout

This fixes the S3 dependency-fault canary that correctly blocked OSS but observed HTTP 500. After full CI, squash merge and publish an exact image; deploy only to the existing private green cohort, then repeat baseline and S3 fault drills before any shared-pool change.