### PR TITLE
fix(ctld): allow seal retry after backend recovery

### DIFF
--- a/ctld/internal/ctld/rootfs/controller_v3_test.go
+++ b/ctld/internal/ctld/rootfs/controller_v3_test.go
@@ -351,6 +351,13 @@ func TestControllerReturnsServiceUnavailableWhenSealCannotReachObjectStore(t *te
 	})
 	assert.Equal(t, http.StatusServiceUnavailable, status)
 	assert.Contains(t, response.Error, rootfsstore.ErrBackendUnavailable.Error())
+
+	store.failHeads.Store(false)
+	retried, status := controller.SealRootFSHead(request, ctldapi.SealRootFSHeadRequest{
+		SandboxID: "sandbox-1", TeamID: "team-1", HeadID: "recovered-head", ExpectedRuntimeGeneration: 1,
+	})
+	require.Equal(t, http.StatusOK, status, retried.Error)
+	assert.Equal(t, "recovered-head", retried.Reference.HeadID)
 }
 
 func TestControllerBindRootFSSyncRejectsCrossTeamParent(t *testing.T) {

--- a/ctld/internal/ctld/rootfscow/session.go
+++ b/ctld/internal/ctld/rootfscow/session.go
@@ -1247,6 +1247,12 @@ func (s *Session) setProtectionError(err error) {
 func (s *Session) recordSealError(err error) {
 	s.mu.Lock()
 	s.sealing = false
+	// A failed seal has not published an immutable Head, so its request ID must
+	// not fence a later retry. Callers may generate a fresh Head ID when the
+	// dependency recovers.
+	if s.sealResult == nil {
+		s.sealHeadID = ""
+	}
 	s.sealError = err
 	if !s.backgroundStopped {
 		s.accepting = true

--- a/manager/pkg/sandboxstore/store.go
+++ b/manager/pkg/sandboxstore/store.go
@@ -134,6 +134,7 @@ type SandboxStore interface {
 	ListSandboxes(ctx context.Context, req *ListSandboxesRequest) ([]*SandboxRecord, error)
 	ListActiveLifecycleTxns(ctx context.Context, kind string, limit int) ([]*SandboxLifecycleTxn, error)
 	GetActiveLifecycleTxn(ctx context.Context, sandboxID string) (*SandboxLifecycleTxn, error)
+	GetLifecycleTxn(ctx context.Context, txnID string) (*SandboxLifecycleTxn, error)
 	ListHardExpiredSandboxes(ctx context.Context, now time.Time, limit int) ([]*SandboxRecord, error)
 	MarkSandboxDeleted(ctx context.Context, sandboxID string, deletedAt time.Time) error
 	SaveRootFSHead(ctx context.Context, head *SandboxRootFSHead) error
@@ -457,6 +458,16 @@ func (s *PGSandboxStore) GetActiveLifecycleTxn(ctx context.Context, sandboxID st
 		return nil, nil
 	}
 	return getActiveLifecycleTxn(ctx, s.pool, sandboxID)
+}
+
+// GetLifecycleTxn returns a lifecycle transaction by its durable id.
+func (s *PGSandboxStore) GetLifecycleTxn(ctx context.Context, txnID string) (*SandboxLifecycleTxn, error) {
+	if s == nil || s.pool == nil || strings.TrimSpace(txnID) == "" {
+		return nil, nil
+	}
+	return scanLifecycleTxn(s.pool.QueryRow(ctx, lifecycleTxnSelectSQL()+`
+		WHERE txn_id = $1
+	`, strings.TrimSpace(txnID)))
 }
 
 func (s *PGSandboxStore) ListHardExpiredSandboxes(ctx context.Context, now time.Time, limit int) ([]*SandboxRecord, error) {

--- a/manager/pkg/service/sandbox_runtime_identity_test.go
+++ b/manager/pkg/service/sandbox_runtime_identity_test.go
@@ -187,6 +187,15 @@ func (s *memorySandboxStore) GetActiveLifecycleTxn(_ context.Context, sandboxID 
 	return nil, nil
 }
 
+func (s *memorySandboxStore) GetLifecycleTxn(_ context.Context, txnID string) (*sandboxstore.SandboxLifecycleTxn, error) {
+	if s == nil {
+		return nil, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return sandboxstore.CloneSandboxLifecycleTxn(s.lifecycleTxns[txnID]), nil
+}
+
 func (s *memorySandboxStore) MarkSandboxDeleted(_ context.Context, sandboxID string, deletedAt time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/manager/pkg/service/sandbox_service_lifecycle.go
+++ b/manager/pkg/service/sandbox_service_lifecycle.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/networkpolicy"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/sandboxstore"
 	"github.com/sandbox0-ai/sandbox0/pkg/carrier"
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/managerapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/procdapi"
@@ -107,28 +108,31 @@ type pauseSandboxRuntimeOptions struct {
 // RequestPauseSandboxRuntime records a durable pause transaction and returns
 // without waiting for rootfs checkpoint upload.
 func (s *SandboxService) RequestPauseSandboxRuntime(ctx context.Context, sandboxID string) (string, error) {
-	return s.requestPauseSandboxRuntime(ctx, sandboxID, pauseSandboxRuntimeOptions{source: sandboxstore.SandboxLifecycleSourceManual})
+	status, _, err := s.requestPauseSandboxRuntime(ctx, sandboxID, pauseSandboxRuntimeOptions{source: sandboxstore.SandboxLifecycleSourceManual})
+	return status, err
 }
 
 func (s *SandboxService) requestAutoPauseSandboxRuntime(ctx context.Context, sandboxID string) (string, error) {
-	return s.requestPauseSandboxRuntime(ctx, sandboxID, pauseSandboxRuntimeOptions{
+	status, _, err := s.requestPauseSandboxRuntime(ctx, sandboxID, pauseSandboxRuntimeOptions{
 		source:     sandboxstore.SandboxLifecycleSourceAuto,
 		cancelable: true,
 	})
+	return status, err
 }
 
-func (s *SandboxService) requestPauseSandboxRuntime(ctx context.Context, sandboxID string, opts pauseSandboxRuntimeOptions) (string, error) {
+func (s *SandboxService) requestPauseSandboxRuntime(ctx context.Context, sandboxID string, opts pauseSandboxRuntimeOptions) (string, string, error) {
 	if s == nil {
-		return "", fmt.Errorf("sandbox service is nil")
+		return "", "", fmt.Errorf("sandbox service is nil")
 	}
 	if s.sandboxStore == nil {
 		if err := s.pauseSandboxRuntime(ctx, sandboxID, true); err != nil {
-			return "", err
+			return "", "", err
 		}
-		return managerapi.SandboxStatusPaused, nil
+		return managerapi.SandboxStatusPaused, "", nil
 	}
 
 	status := managerapi.SandboxStatusStarting
+	txnID := ""
 	err := s.sandboxStore.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx sandboxstore.SandboxStoreTx, record *sandboxstore.SandboxRecord) error {
 		activeTxn, err := tx.GetActiveLifecycleTxn(lockCtx, sandboxID)
 		if err != nil {
@@ -138,6 +142,7 @@ func (s *SandboxService) requestPauseSandboxRuntime(ctx context.Context, sandbox
 			if activeTxn.Kind != sandboxstore.SandboxLifecycleKindPause {
 				return errSandboxLifecycleResuming
 			}
+			txnID = activeTxn.ID
 			projected, err := s.projectSandboxRecordFromCache(lockCtx, record, activeTxn)
 			if projected != nil {
 				status = projected.Status
@@ -185,8 +190,9 @@ func (s *SandboxService) requestPauseSandboxRuntime(ctx context.Context, sandbox
 		if err != nil {
 			return err
 		}
+		txnID = uuid.NewString()
 		return tx.BeginLifecycleTxn(lockCtx, &sandboxstore.SandboxLifecycleTxn{
-			ID:                   uuid.NewString(),
+			ID:                   txnID,
 			SandboxID:            sandboxID,
 			Kind:                 sandboxstore.SandboxLifecycleKindPause,
 			Phase:                sandboxstore.SandboxLifecyclePhasePreparing,
@@ -202,27 +208,40 @@ func (s *SandboxService) requestPauseSandboxRuntime(ctx context.Context, sandbox
 	if err != nil {
 		if errors.Is(err, errSandboxLifecycleResuming) {
 			if waitErr := s.waitForSandboxLifecycleTxnExit(ctx, sandboxID); waitErr != nil {
-				return "", waitErr
+				return "", "", waitErr
 			}
 			return s.requestPauseSandboxRuntime(ctx, sandboxID, opts)
 		}
 		if errors.Is(err, sandboxstore.ErrSandboxRecordNotFound) {
 			if fallbackErr := s.pauseSandboxRuntime(ctx, sandboxID, true); fallbackErr != nil {
-				return "", fallbackErr
+				return "", "", fallbackErr
 			}
-			return managerapi.SandboxStatusPaused, nil
+			return managerapi.SandboxStatusPaused, "", nil
 		}
-		return "", err
+		return "", "", err
 	}
 	if status != managerapi.SandboxStatusPaused {
 		s.enqueueSandboxPause(sandboxID)
 	}
-	return status, nil
+	return status, txnID, nil
 }
 
 const sandboxLifecycleBarrierWaitTimeout = 30 * time.Second
 
 var errSandboxLifecycleCanceled = errors.New("sandbox lifecycle transaction canceled")
+
+const sandboxLifecycleTxnUnavailablePrefix = "dependency_unavailable: "
+
+func sandboxLifecycleTxnAbortReason(err error) string {
+	if err == nil {
+		return ""
+	}
+	reason := err.Error()
+	if ctldapi.IsUnavailableError(err) {
+		return sandboxLifecycleTxnUnavailablePrefix + reason
+	}
+	return reason
+}
 
 func (s *SandboxService) enqueueSandboxPause(sandboxID string) {
 	if s == nil || strings.TrimSpace(sandboxID) == "" {
@@ -394,7 +413,7 @@ func (s *SandboxService) CompletePausingSandboxRuntime(ctx context.Context, sand
 	runtimeRecovery := crashRecovery || healthRecovery || lostRecovery || rootFSRecovery
 	abortOnError := func(completionErr error) {
 		if !runtimeRecovery && completionErr != nil {
-			_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, completionErr.Error())
+			_ = s.abortLifecycleTxn(ctx, sandboxID, txn.ID, sandboxLifecycleTxnAbortReason(completionErr))
 		}
 	}
 	if canceled, err := s.abortPauseIfCancelRequested(ctx, sandboxID, txn.ID); err != nil || canceled {

--- a/manager/pkg/service/sandbox_service_pause.go
+++ b/manager/pkg/service/sandbox_service_pause.go
@@ -2,10 +2,14 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/sandboxstore"
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/managerapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/procdapi"
 )
@@ -18,11 +22,12 @@ type PauseSandboxResponse struct {
 	ResourceUsage *procdapi.SandboxResourceUsage `json:"resource_usage,omitempty"`
 	UpdatedMemory string                         `json:"updated_memory,omitempty"`
 	UpdatedCPU    string                         `json:"updated_cpu,omitempty"`
+	txnID         string
 }
 
 // PauseSandbox accepts a checkpointed pause request and returns the lifecycle state.
 func (s *SandboxService) PauseSandbox(ctx context.Context, sandboxID string) (*PauseSandboxResponse, error) {
-	status, err := s.RequestPauseSandboxRuntime(ctx, sandboxID)
+	status, txnID, err := s.requestPauseSandboxRuntime(ctx, sandboxID, pauseSandboxRuntimeOptions{source: sandboxstore.SandboxLifecycleSourceManual})
 	if err != nil {
 		return nil, err
 	}
@@ -30,6 +35,7 @@ func (s *SandboxService) PauseSandbox(ctx context.Context, sandboxID string) (*P
 		SandboxID: sandboxID,
 		Paused:    status == managerapi.SandboxStatusPaused,
 		Status:    status,
+		txnID:     txnID,
 	}, nil
 }
 
@@ -54,6 +60,15 @@ func (s *SandboxService) PauseSandboxAndWait(ctx context.Context, sandboxID stri
 		return nil, fmt.Errorf("get sandbox after pause: %w", err)
 	}
 	if sandbox == nil || sandbox.Status != managerapi.SandboxStatusPaused || !sandbox.Paused {
+		if response.txnID != "" {
+			txn, txnErr := s.sandboxStore.GetLifecycleTxn(pauseCtx, response.txnID)
+			if txnErr != nil {
+				return nil, fmt.Errorf("load sandbox pause outcome: %w", txnErr)
+			}
+			if outcomeErr := sandboxPauseOutcomeError(txn); outcomeErr != nil {
+				return nil, outcomeErr
+			}
+		}
 		status := "unknown"
 		if sandbox != nil && strings.TrimSpace(sandbox.Status) != "" {
 			status = sandbox.Status
@@ -65,6 +80,24 @@ func (s *SandboxService) PauseSandboxAndWait(ctx context.Context, sandboxID stri
 		Paused:    true,
 		Status:    managerapi.SandboxStatusPaused,
 	}, nil
+}
+
+func sandboxPauseOutcomeError(txn *sandboxstore.SandboxLifecycleTxn) error {
+	if txn == nil || txn.Kind != sandboxstore.SandboxLifecycleKindPause || txn.Phase != sandboxstore.SandboxLifecyclePhaseAborted {
+		return nil
+	}
+	reason := strings.TrimSpace(txn.Error)
+	if reason == "" {
+		reason = "checkpoint transaction aborted"
+	}
+	if strings.HasPrefix(reason, sandboxLifecycleTxnUnavailablePrefix) {
+		reason = strings.TrimSpace(strings.TrimPrefix(reason, sandboxLifecycleTxnUnavailablePrefix))
+		return fmt.Errorf("sandbox pause checkpoint failed: %w", &ctldapi.RequestError{
+			StatusCode: http.StatusServiceUnavailable,
+			Message:    reason,
+		})
+	}
+	return fmt.Errorf("sandbox pause checkpoint failed: %w", errors.New(reason))
 }
 
 // ResumeSandbox creates or reuses a runtime and restores the latest rootfs checkpoint.

--- a/manager/pkg/service/sandbox_service_pause_test.go
+++ b/manager/pkg/service/sandbox_service_pause_test.go
@@ -123,7 +123,29 @@ func TestPauseSandboxAndWaitRejectsAbortedCheckpoint(t *testing.T) {
 	response, err := service.PauseSandboxAndWait(context.Background(), "sandbox-1")
 	require.Error(t, err)
 	assert.Nil(t, response)
-	assert.Contains(t, err.Error(), "pause did not complete")
+	assert.Contains(t, err.Error(), "sandbox pause checkpoint failed")
+	require.Error(t, <-enqueuer.done)
+	assert.Equal(t, sandboxstore.SandboxDesiredStateActive, store.records["sandbox-1"].DesiredState)
+}
+
+func TestPauseSandboxAndWaitPreservesUnavailableCheckpointOutcome(t *testing.T) {
+	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":"object store unavailable"}`))
+	}))
+	defer ctld.Close()
+
+	service, store, pod := newPauseAndWaitTestService(t, ctld)
+	enqueuer := &completingPauseEnqueuer{service: service, done: make(chan error, 1)}
+	service.pauseEnqueuer = enqueuer
+	var procdCalls []string
+	defer attachRootFSTestProcd(t, pod, service, &procdCalls)()
+
+	response, err := service.PauseSandboxAndWait(context.Background(), "sandbox-1")
+	require.Error(t, err)
+	assert.Nil(t, response)
+	assert.True(t, ctldapi.IsUnavailableError(err), "error should preserve the ctld 503 outcome: %v", err)
 	require.Error(t, <-enqueuer.done)
 	assert.Equal(t, sandboxstore.SandboxDesiredStateActive, store.records["sandbox-1"].DesiredState)
 }

--- a/tests/integration/internal/tests/manager/api_test.go
+++ b/tests/integration/internal/tests/manager/api_test.go
@@ -1155,6 +1155,16 @@ func (s *memorySandboxStoreForManagerIntegration) GetActiveLifecycleTxn(_ contex
 	return nil, nil
 }
 
+func (s *memorySandboxStoreForManagerIntegration) GetLifecycleTxn(_ context.Context, txnID string) (*sandboxstore.SandboxLifecycleTxn, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	txn := s.lifecycleTxns[txnID]
+	if txn == nil {
+		return nil, nil
+	}
+	return cloneSandboxLifecycleTxnForManagerIntegration(txn), nil
+}
+
 func (s *memorySandboxStoreForManagerIntegration) MarkSandboxDeleted(_ context.Context, sandboxID string, deletedAt time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
## Summary
- release a failed seal request ID when no immutable Head result was completed
- preserve successful seal idempotency and conflicting Head protection
- cover S3 recovery with a new Head ID in the controller regression test

## Production evidence
- green S3 fault run 31834910338 returned the expected dependency failure, then could not recover because later Head IDs were rejected as `rootfs sync session is sealed`

## Test plan
- `go test -race ./ctld/internal/ctld/rootfscow ./ctld/internal/ctld/rootfs`
- `git diff --check`