### PR TITLE
fix(manager): make shared rollout recovery and upgrades safe

### DIFF
--- a/infra-operator/api/config/operator.go
+++ b/infra-operator/api/config/operator.go
@@ -30,9 +30,10 @@ const (
 )
 
 type OperatorConfig struct {
-	ImageRepo       string `json:"imageRepo" yaml:"imageRepo"`
-	ImageTag        string `json:"imageTag" yaml:"imageTag"`
-	ImagePullPolicy string `json:"imagePullPolicy" yaml:"imagePullPolicy"`
+	ImageRepo                 string `json:"imageRepo" yaml:"imageRepo"`
+	ImageTag                  string `json:"imageTag" yaml:"imageTag"`
+	RootFSSnapshotterImageTag string `json:"rootfsSnapshotterImageTag" yaml:"rootfsSnapshotterImageTag"`
+	ImagePullPolicy           string `json:"imagePullPolicy" yaml:"imagePullPolicy"`
 }
 
 func LoadOperatorConfig(configPath string) (OperatorConfig, error) {
@@ -42,6 +43,7 @@ func LoadOperatorConfig(configPath string) (OperatorConfig, error) {
 	}
 
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		config.RootFSSnapshotterImageTag = config.ImageTag
 		return config, nil
 	}
 
@@ -59,6 +61,9 @@ func LoadOperatorConfig(configPath string) (OperatorConfig, error) {
 	}
 	if config.ImageTag == "" {
 		config.ImageTag = DefaultImageTag
+	}
+	if config.RootFSSnapshotterImageTag == "" {
+		config.RootFSSnapshotterImageTag = config.ImageTag
 	}
 
 	return config, nil

--- a/infra-operator/api/config/operator_test.go
+++ b/infra-operator/api/config/operator_test.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadOperatorConfigDefaultsRootFSSnapshotterImageTagToServiceTag(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("imageTag: service-next\n"), 0o600))
+
+	config, err := LoadOperatorConfig(path)
+
+	require.NoError(t, err)
+	assert.Equal(t, "service-next", config.ImageTag)
+	assert.Equal(t, "service-next", config.RootFSSnapshotterImageTag)
+}
+
+func TestLoadOperatorConfigKeepsExplicitRootFSSnapshotterImageTag(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("imageTag: service-next\nrootfsSnapshotterImageTag: snapshotter-stable\n"), 0o600))
+
+	config, err := LoadOperatorConfig(path)
+
+	require.NoError(t, err)
+	assert.Equal(t, "service-next", config.ImageTag)
+	assert.Equal(t, "snapshotter-stable", config.RootFSSnapshotterImageTag)
+}

--- a/infra-operator/chart/templates/configmap.yaml
+++ b/infra-operator/chart/templates/configmap.yaml
@@ -8,6 +8,7 @@ data:
   config.yaml: |
     imageRepo: {{ .Values.image.repository }}
     imageTag: {{ .Values.image.tag | default .Chart.AppVersion }}
+    rootfsSnapshotterImageTag: {{ .Values.config.rootfsSnapshotterImageTag | default (.Values.image.tag | default .Chart.AppVersion) }}
     {{ if .Values.config.imagePullPolicy }}
     imagePullPolicy: {{ .Values.config.imagePullPolicy }}
     {{ end }}

--- a/infra-operator/chart/values.yaml
+++ b/infra-operator/chart/values.yaml
@@ -38,3 +38,5 @@ affinity: {}
 
 config:
   imagePullPolicy: ""
+  # Pin this independently so ordinary service releases do not restart live rootfs mounts.
+  rootfsSnapshotterImageTag: ""

--- a/infra-operator/internal/controller/operator_config.go
+++ b/infra-operator/internal/controller/operator_config.go
@@ -53,6 +53,18 @@ func (r *Sandbox0InfraReconciler) getImageTag(ctx context.Context) string {
 	return config.ImageTag
 }
 
+func (r *Sandbox0InfraReconciler) getRootFSSnapshotterImageTag(ctx context.Context) string {
+	logger := log.FromContext(ctx)
+
+	config, err := operatorconfig.LoadOperatorConfig(operatorconfig.DefaultConfigPath)
+	if err != nil {
+		logger.Error(err, "Failed to load operator config")
+		return operatorconfig.DefaultImageTag
+	}
+
+	return config.RootFSSnapshotterImageTag
+}
+
 func (r *Sandbox0InfraReconciler) getImagePullPolicy(ctx context.Context) *corev1.PullPolicy {
 	logger := log.FromContext(ctx)
 

--- a/infra-operator/internal/controller/sandbox0infra_controller.go
+++ b/infra-operator/internal/controller/sandbox0infra_controller.go
@@ -460,7 +460,7 @@ func (r *Sandbox0InfraReconciler) workflowStepRunner(
 			if err := rbacReconciler.ReconcileCtldRBAC(ctx, infra); err != nil {
 				return err
 			}
-			return ctldReconciler.Reconcile(ctx, infra, imageRepo, imageTag, compiledPlan.Services.ClusterGateway.URL)
+			return ctldReconciler.Reconcile(ctx, infra, imageRepo, imageTag, r.getRootFSSnapshotterImageTag(ctx), compiledPlan.Services.ClusterGateway.URL)
 		}, nil
 	case "ctld-ready":
 		return func(ctx context.Context) error {

--- a/infra-operator/internal/controller/services/ctld/ctld.go
+++ b/infra-operator/internal/controller/services/ctld/ctld.go
@@ -76,7 +76,7 @@ func NewReconciler(resources *common.ResourceManager) *Reconciler {
 	return &Reconciler{Resources: resources}
 }
 
-func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, imageRepo, imageTag, clusterGatewayURL string) error {
+func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox0Infra, imageRepo, imageTag, rootFSSnapshotterImageTag, clusterGatewayURL string) error {
 	logger := log.FromContext(ctx)
 	if !infrav1alpha1.HasDataPlaneServices(infra) {
 		logger.Info("Data-plane services are disabled, skipping ctld")
@@ -124,6 +124,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 	}
 
 	image := fmt.Sprintf("%s:%s", imageRepo, imageTag)
+	if strings.TrimSpace(rootFSSnapshotterImageTag) == "" {
+		rootFSSnapshotterImageTag = imageTag
+	}
+	rootFSSnapshotterImage := fmt.Sprintf("%s:%s", imageRepo, rootFSSnapshotterImageTag)
 	pullPolicy := corev1.PullIfNotPresent
 	if r.Resources.ImagePullPolicy != nil {
 		pullPolicy = *r.Resources.ImagePullPolicy
@@ -251,7 +255,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, infra *infrav1alpha1.Sandbox
 		Namespace:            infra.Namespace,
 		Labels:               common.GetServiceLabels(infra.Name, rootFSSnapshotterComponent),
 		PodAnnotations:       configRef.PodAnnotations(),
-		Image:                image,
+		Image:                rootFSSnapshotterImage,
 		PullPolicy:           pullPolicy,
 		NodeSelector:         nodeSelector,
 		Tolerations:          tolerations,

--- a/infra-operator/internal/controller/services/ctld/ctld_test.go
+++ b/infra-operator/internal/controller/services/ctld/ctld_test.go
@@ -56,6 +56,38 @@ func TestReconcileUsesSharedSandboxNodePlacement(t *testing.T) {
 	}
 }
 
+func TestReconcileKeepsPinnedRootFSSnapshotterDuringServiceRollout(t *testing.T) {
+	ctx := context.Background()
+	infra := newCtldTestInfra()
+	_, client := reconcileCtldResources(t, infra)
+	reconciler := NewReconciler(common.NewResourceManager(client, newCtldTestScheme(t), nil, common.LocalDevConfig{}))
+	before := &appsv1.DaemonSet{}
+	require.NoError(t, client.Get(ctx, types.NamespacedName{
+		Name: infra.Name + "-rootfs-snapshotter", Namespace: infra.Namespace,
+	}, before))
+
+	require.NoError(t, reconciler.Reconcile(
+		ctx,
+		infra,
+		"ghcr.io/sandbox0-ai/sandbox0",
+		"service-next",
+		"latest",
+		"http://demo-cluster-gateway:8443",
+	))
+
+	snapshotter := &appsv1.DaemonSet{}
+	require.NoError(t, client.Get(ctx, types.NamespacedName{
+		Name: infra.Name + "-rootfs-snapshotter", Namespace: infra.Namespace,
+	}, snapshotter))
+	assert.Equal(t, "ghcr.io/sandbox0-ai/sandbox0:latest", snapshotter.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t,
+		before.Spec.Template.Annotations[rootFSSnapshotterRolloutRevisionAnnotation],
+		snapshotter.Spec.Template.Annotations[rootFSSnapshotterRolloutRevisionAnnotation],
+	)
+	standby := getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotB)
+	assert.Equal(t, "ghcr.io/sandbox0-ai/sandbox0:service-next", standby.Spec.Template.Spec.Containers[0].Image)
+}
+
 func TestReconcileConfiguresNetworkRuntimeInBothHASlots(t *testing.T) {
 	infra := newCtldTestInfra()
 	infra.Spec.Network = &infrav1alpha1.NetworkConfig{Config: &infrav1alpha1.NetdConfig{MetricsPort: 9191}}
@@ -163,7 +195,7 @@ func TestReconcileStagesHASlotRolloutBThenA(t *testing.T) {
 	require.NoError(t, client.Create(ctx, standbyPod))
 
 	reconciler := NewReconciler(common.NewResourceManager(client, newCtldTestScheme(t), nil, common.LocalDevConfig{}))
-	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "http://demo-cluster-gateway:8443"))
+	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "next", "http://demo-cluster-gateway:8443"))
 	primary = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotA)
 	standby = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotB)
 	assert.Equal(t, "ghcr.io/sandbox0-ai/sandbox0:latest", primary.Spec.Template.Spec.Containers[0].Image)
@@ -173,7 +205,7 @@ func TestReconcileStagesHASlotRolloutBThenA(t *testing.T) {
 
 	// An observed DaemonSet status is not enough while its live predecessor is
 	// still present; slot A must remain untouched.
-	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "http://demo-cluster-gateway:8443"))
+	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "next", "http://demo-cluster-gateway:8443"))
 	primary = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotA)
 	assert.Equal(t, "ghcr.io/sandbox0-ai/sandbox0:latest", primary.Spec.Template.Spec.Containers[0].Image)
 
@@ -181,7 +213,7 @@ func TestReconcileStagesHASlotRolloutBThenA(t *testing.T) {
 	standby = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotB)
 	markCtldDaemonSetReady(t, ctx, client, standby)
 	require.NoError(t, client.Create(ctx, readyCtldPodForDaemonSet(standby, "ctld-b-next", "node-a")))
-	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "http://demo-cluster-gateway:8443"))
+	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "next", "http://demo-cluster-gateway:8443"))
 	primary = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotA)
 	assert.Equal(t, "ghcr.io/sandbox0-ai/sandbox0:next", primary.Spec.Template.Spec.Containers[0].Image)
 }
@@ -202,7 +234,7 @@ func TestReadyRejectsHealthyPreviousRevisionDuringNetworkDisableRollout(t *testi
 
 	infra.Spec.Network = nil
 	reconciler := NewReconciler(common.NewResourceManager(client, newCtldTestScheme(t), nil, common.LocalDevConfig{}))
-	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "latest", "http://demo-cluster-gateway:8443"))
+	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "latest", "latest", "http://demo-cluster-gateway:8443"))
 
 	ready, err := reconciler.Ready(ctx, infra)
 	require.NoError(t, err)
@@ -219,7 +251,7 @@ func TestReconcileRepairsMissingSlotBeforeRollingPeer(t *testing.T) {
 	require.NoError(t, client.Delete(ctx, primary))
 
 	reconciler := NewReconciler(common.NewResourceManager(client, newCtldTestScheme(t), nil, common.LocalDevConfig{}))
-	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "http://demo-cluster-gateway:8443"))
+	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "next", "http://demo-cluster-gateway:8443"))
 	primary = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotA)
 	standby = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotB)
 	assert.Equal(t, "ghcr.io/sandbox0-ai/sandbox0:next", primary.Spec.Template.Spec.Containers[0].Image)
@@ -231,12 +263,12 @@ func TestReconcileRepairsMissingSlotBeforeRollingPeer(t *testing.T) {
 
 	// The surviving peer remains unchanged until the repaired slot is actually
 	// ready on its desired nodes.
-	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "http://demo-cluster-gateway:8443"))
+	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "next", "http://demo-cluster-gateway:8443"))
 	standby = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotB)
 	assert.Equal(t, "ghcr.io/sandbox0-ai/sandbox0:latest", standby.Spec.Template.Spec.Containers[0].Image)
 	markCtldDaemonSetReady(t, ctx, client, primary)
 	require.NoError(t, client.Create(ctx, readyCtldPodForDaemonSet(primary, "ctld-a-next", "node-a")))
-	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "http://demo-cluster-gateway:8443"))
+	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "next", "http://demo-cluster-gateway:8443"))
 	standby = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotB)
 	assert.Equal(t, "ghcr.io/sandbox0-ai/sandbox0:next", standby.Spec.Template.Spec.Containers[0].Image)
 }
@@ -250,7 +282,7 @@ func TestReconcileDoesNotMutateEitherDegradedPeer(t *testing.T) {
 	markCtldDaemonSetNotReady(t, ctx, client, standby)
 
 	reconciler := NewReconciler(common.NewResourceManager(client, newCtldTestScheme(t), nil, common.LocalDevConfig{}))
-	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "http://demo-cluster-gateway:8443"))
+	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "next", "http://demo-cluster-gateway:8443"))
 	primary = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotA)
 	standby = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotB)
 	assert.Equal(t, "ghcr.io/sandbox0-ai/sandbox0:latest", primary.Spec.Template.Spec.Containers[0].Image)
@@ -260,7 +292,7 @@ func TestReconcileDoesNotMutateEitherDegradedPeer(t *testing.T) {
 	// simultaneous restart.
 	markCtldDaemonSetReady(t, ctx, client, standby)
 	require.NoError(t, client.Create(ctx, readyCtldPodForDaemonSet(standby, "ctld-b-old", "node-a")))
-	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "http://demo-cluster-gateway:8443"))
+	require.NoError(t, reconciler.Reconcile(ctx, infra, "ghcr.io/sandbox0-ai/sandbox0", "next", "next", "http://demo-cluster-gateway:8443"))
 	primary = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotA)
 	standby = getCtldDaemonSet(t, ctx, client, infra, dataplane.CtldHASlotB)
 	assert.Equal(t, "ghcr.io/sandbox0-ai/sandbox0:next", primary.Spec.Template.Spec.Containers[0].Image)
@@ -428,7 +460,7 @@ func reconcileCtldResources(t *testing.T, infra *infrav1alpha1.Sandbox0Infra, ex
 		Build()
 
 	reconciler := NewReconciler(common.NewResourceManager(client, scheme, nil, common.LocalDevConfig{}))
-	if err := reconciler.Reconcile(context.Background(), infra, "ghcr.io/sandbox0-ai/sandbox0", "latest", "http://demo-cluster-gateway:8443"); err != nil {
+	if err := reconciler.Reconcile(context.Background(), infra, "ghcr.io/sandbox0-ai/sandbox0", "latest", "latest", "http://demo-cluster-gateway:8443"); err != nil {
 		t.Fatalf("reconcile returned error: %v", err)
 	}
 

--- a/manager/pkg/service/sandbox_crash_recovery_test.go
+++ b/manager/pkg/service/sandbox_crash_recovery_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -577,6 +578,50 @@ func TestSandboxPauseControllerReconstructsHealthRecoveryRegardlessOfAutoResume(
 	require.True(t, controller.processNextWorkItem(context.Background()))
 
 	assert.Equal(t, []string{"pause:sandbox-1", "resume:sandbox-1"}, calls)
+}
+
+func TestSandboxPauseControllerForgetsRecoveryForDeletedSandbox(t *testing.T) {
+	deletedAt := time.Now().UTC()
+	store := &memorySandboxStore{records: map[string]*sandboxstore.SandboxRecord{
+		"sandbox-1": {
+			ID:           "sandbox-1",
+			DesiredState: sandboxstore.SandboxDesiredStateDeleted,
+			DeletedAt:    deletedAt,
+		},
+	}}
+	controller := NewSandboxPauseController(&SandboxService{sandboxStore: store}, zap.NewNop())
+	t.Cleanup(controller.queue.ShutDown)
+	controller.complete = func(context.Context, string) error { return nil }
+	controller.resume = func(_ context.Context, sandboxID string) error {
+		return k8serrors.NewNotFound(corev1.Resource("sandbox"), sandboxID)
+	}
+	item := sandboxPauseItem{SandboxID: "sandbox-1", Resume: true}
+	controller.queue.Add(item)
+
+	require.True(t, controller.processNextWorkItem(context.Background()))
+
+	assert.Zero(t, controller.queue.NumRequeues(item))
+}
+
+func TestSandboxPauseControllerRetriesNotFoundForActiveSandbox(t *testing.T) {
+	store := &memorySandboxStore{records: map[string]*sandboxstore.SandboxRecord{
+		"sandbox-1": {
+			ID:           "sandbox-1",
+			DesiredState: sandboxstore.SandboxDesiredStateActive,
+		},
+	}}
+	controller := NewSandboxPauseController(&SandboxService{sandboxStore: store}, zap.NewNop())
+	t.Cleanup(controller.queue.ShutDown)
+	controller.complete = func(context.Context, string) error { return nil }
+	controller.resume = func(_ context.Context, sandboxID string) error {
+		return k8serrors.NewNotFound(corev1.Resource("sandbox-template"), sandboxID)
+	}
+	item := sandboxPauseItem{SandboxID: "sandbox-1", Resume: true}
+	controller.queue.Add(item)
+
+	require.True(t, controller.processNextWorkItem(context.Background()))
+
+	assert.Equal(t, 1, controller.queue.NumRequeues(item))
 }
 
 func TestSandboxPauseControllerFindsCrashRecoveryAfterManagerRestart(t *testing.T) {

--- a/manager/pkg/service/sandbox_pause_controller.go
+++ b/manager/pkg/service/sandbox_pause_controller.go
@@ -2,11 +2,13 @@ package service
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/sandboxstore"
 	"go.uber.org/zap"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/workqueue"
@@ -189,6 +191,13 @@ func (c *SandboxPauseController) processNextWorkItem(ctx context.Context) bool {
 			return true
 		}
 		if err := c.resume(ctx, item.SandboxID); err != nil {
+			if c.sandboxRecoveryTargetGone(ctx, item.SandboxID, err) {
+				c.logger.Info("Discarding sandbox runtime reconstruction for terminal sandbox",
+					zap.String("sandboxID", item.SandboxID),
+				)
+				c.queue.Forget(item)
+				return true
+			}
 			c.logger.Warn("Sandbox runtime reconstruction failed, requeueing",
 				zap.String("sandboxID", item.SandboxID),
 				zap.Error(err),
@@ -199,4 +208,26 @@ func (c *SandboxPauseController) processNextWorkItem(ctx context.Context) bool {
 	}
 	c.queue.Forget(item)
 	return true
+}
+
+// sandboxRecoveryTargetGone verifies that a not-found resume error refers to
+// the durable sandbox, rather than a missing dependency that should be retried.
+func (c *SandboxPauseController) sandboxRecoveryTargetGone(ctx context.Context, sandboxID string, resumeErr error) bool {
+	if errors.Is(resumeErr, sandboxstore.ErrSandboxRecordNotFound) {
+		return true
+	}
+	if !k8serrors.IsNotFound(resumeErr) || c == nil || c.service == nil || c.service.sandboxStore == nil {
+		return false
+	}
+	record, err := c.service.sandboxStore.GetSandbox(ctx, sandboxID)
+	if errors.Is(err, sandboxstore.ErrSandboxRecordNotFound) {
+		return true
+	}
+	if err != nil {
+		return false
+	}
+	return record == nil ||
+		record.DesiredState == sandboxstore.SandboxDesiredStateDeleted ||
+		!record.DeletedAt.IsZero() ||
+		sandboxHardExpired(record.HardExpiresAt, c.service.now())
 }

--- a/manager/pkg/service/sandbox_service_carrier.go
+++ b/manager/pkg/service/sandbox_service_carrier.go
@@ -95,11 +95,11 @@ func (s *SandboxService) claimS0FSCarrier(ctx context.Context, template *api.San
 	if err != nil {
 		return fail("carrier rootfs activation failed", err)
 	}
+	var portalMounts []BootstrapMountStatus
 	pod, err = s.waitForS0FSCarrierReady(ctx, pod, req.Template, claimType, func(readyCtx context.Context, readyPod *corev1.Pod) error {
-		phaseStarted := time.Now()
-		bindErr := s.bindSandboxRootFSSync(readyCtx, readyPod, record)
-		s.observeClaimPhase(req.Template, claimType, "bind_rootfs_sync", phaseStarted, bindErr)
-		return bindErr
+		var prepareErr error
+		portalMounts, prepareErr = s.prepareS0FSCarrierStorage(readyCtx, readyPod, template, req, record, claimType)
+		return prepareErr
 	})
 	if err != nil {
 		return fail("carrier runtime readiness failed", err)
@@ -124,8 +124,39 @@ func (s *SandboxService) claimS0FSCarrier(ctx context.Context, template *api.San
 	}
 	return &ClaimResponse{
 		SandboxID: req.SandboxID, Status: s.podToSandboxStatus(pod), ProcdAddress: procdAddress,
-		PodName: pod.Name, Template: req.Template, ClusterId: template.Spec.ClusterId,
+		PodName: pod.Name, Template: req.Template, ClusterId: template.Spec.ClusterId, BootstrapMounts: portalMounts,
 	}, true, nil
+}
+
+// prepareS0FSCarrierStorage binds durable volume portals before rootfs capture
+// starts so declared mounts are excluded from the sandbox rootfs checkpoint.
+func (s *SandboxService) prepareS0FSCarrierStorage(
+	ctx context.Context,
+	pod *corev1.Pod,
+	template *api.SandboxTemplate,
+	req *ClaimRequest,
+	record *sandboxstore.SandboxRecord,
+	claimType string,
+) ([]BootstrapMountStatus, error) {
+	phaseStarted := time.Now()
+	portalMounts, err := s.bindVolumePortals(ctx, pod, req, template)
+	s.observeClaimPhase(req.Template, claimType, "bind_volume_portals", phaseStarted, err)
+	if err != nil {
+		return nil, fmt.Errorf("bind volume portals: %w", err)
+	}
+	phaseStarted = time.Now()
+	err = s.bindWebhookStatePortal(ctx, pod, req)
+	s.observeClaimPhase(req.Template, claimType, "bind_webhook_state_portal", phaseStarted, err)
+	if err != nil {
+		return nil, fmt.Errorf("bind webhook state portal: %w", err)
+	}
+	phaseStarted = time.Now()
+	err = s.bindSandboxRootFSSync(ctx, pod, record)
+	s.observeClaimPhase(req.Template, claimType, "bind_rootfs_sync", phaseStarted, err)
+	if err != nil {
+		return nil, err
+	}
+	return portalMounts, nil
 }
 
 func (s *SandboxService) allocateS0FSCarrier(ctx context.Context, template *api.SandboxTemplate, req *ClaimRequest, allowShared bool) (*corev1.Pod, string, error) {

--- a/manager/pkg/service/sandbox_service_carrier_test.go
+++ b/manager/pkg/service/sandbox_service_carrier_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,11 +12,67 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/controller"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/sandboxstore"
 	"github.com/sandbox0-ai/sandbox0/pkg/carrier"
+	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/gateway/spec"
+	"github.com/sandbox0-ai/sandbox0/pkg/managerapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/procdapi"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestPrepareS0FSCarrierStorageBindsDeclaredVolumes(t *testing.T) {
+	var bound ctldapi.BindVolumePortalRequest
+	ctld := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/volume-portals/bind" {
+			t.Fatalf("unexpected ctld path %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&bound); err != nil {
+			t.Fatalf("decode bind request: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(ctldapi.BindVolumePortalResponse{
+			SandboxVolumeID: bound.SandboxVolumeID,
+			MountPoint:      bound.MountPath,
+			MountedAt:       "2026-08-15T00:00:00Z",
+		})
+	}))
+	defer ctld.Close()
+	ctldURL, ctldPort := parsedTestServer(t, ctld.URL)
+
+	template := newSandboxResourceTestTemplate(t)
+	template.Spec.VolumeMounts = []api.VolumeMountSpec{{
+		Name: "data", MountPath: "/tmp/sandbox0-volume",
+	}}
+	pod := newSandboxResourceTestActivePod(t, template, "sandbox-1")
+	pod.UID = "pod-uid"
+	pod.Status.HostIP = ctldURL.Hostname()
+	pod.Annotations[controller.AnnotationSandboxID] = "sandbox-1"
+	pod.Annotations[controller.AnnotationRuntimeGeneration] = "1"
+	metadata := &fakeVolumeMetadataClient{}
+	svc := &SandboxService{
+		ctldClient:     ctldapi.NewClientWithTimeout(time.Second),
+		volumeMetadata: metadata,
+		config:         SandboxServiceConfig{CtldPort: ctldPort},
+	}
+	req := &ClaimRequest{
+		SandboxID: "sandbox-1", TeamID: "team-a", UserID: "user-a", Template: template.Name,
+		Mounts: []managerapi.ClaimMount{{SandboxVolumeID: "vol-1", MountPoint: "/tmp/sandbox0-volume"}},
+	}
+	record := &sandboxstore.SandboxRecord{ID: req.SandboxID, TeamID: req.TeamID, RuntimeGeneration: 1, Mounts: req.Mounts}
+
+	mounts, err := svc.prepareS0FSCarrierStorage(context.Background(), pod, template, req, record, "shared")
+	if err != nil {
+		t.Fatalf("prepareS0FSCarrierStorage() error = %v", err)
+	}
+	if len(mounts) != 1 || mounts[0].SandboxVolumeID != "vol-1" || mounts[0].MountPoint != "/tmp/sandbox0-volume" || mounts[0].State != "mounted" {
+		t.Fatalf("prepareS0FSCarrierStorage() mounts = %+v, want mounted vol-1", mounts)
+	}
+	if bound.PodUID != "pod-uid" || bound.SandboxID != "sandbox-1" || bound.SandboxVolumeID != "vol-1" || bound.MountPath != "/tmp/sandbox0-volume" {
+		t.Fatalf("bind request = %+v, want exact carrier volume identity", bound)
+	}
+	if len(metadata.prepared) != 1 || metadata.prepared[0] != "team-a:user-a:vol-1:pod-uid" {
+		t.Fatalf("prepared calls = %v, want exact carrier volume preparation", metadata.prepared)
+	}
+}
 
 func TestPersistUpdatedCarrierPodPreservesS0FSRuntimeVersion(t *testing.T) {
 	template := newSandboxResourceTestTemplate(t)

--- a/storage-proxy/pkg/db/repository_s0fs_coordination.go
+++ b/storage-proxy/pkg/db/repository_s0fs_coordination.go
@@ -206,10 +206,16 @@ func (r *Repository) lockS0FSVolume(ctx context.Context, tx pgx.Tx, volumeID str
 
 func (r *Repository) requireS0FSHeadIdentity(ctx context.Context, tx pgx.Tx, volumeID string, expected *S0FSCommittedHead) error {
 	current, err := r.getS0FSCommittedHead(ctx, tx, volumeID, true)
-	if errors.Is(err, ErrNotFound) && expected == nil {
-		return nil
+	if errors.Is(err, ErrNotFound) {
+		if expected == nil {
+			return nil
+		}
+		return ErrConflict
 	}
-	if err != nil || !sameS0FSCommittedHeadIdentity(current, expected) {
+	if err != nil {
+		return err
+	}
+	if !sameS0FSCommittedHeadIdentity(current, expected) {
 		return ErrConflict
 	}
 	return nil

--- a/storage-proxy/pkg/db/repository_s0fs_head_test.go
+++ b/storage-proxy/pkg/db/repository_s0fs_head_test.go
@@ -259,6 +259,33 @@ func TestS0FSHeadStoreAdapterMapsConflicts(t *testing.T) {
 	}
 }
 
+func TestRequireS0FSHeadIdentityPreservesCanceledContext(t *testing.T) {
+	repo := newS0FSCommittedHeadTestRepository(t)
+	if repo == nil {
+		return
+	}
+
+	volumeID := "vol-" + uuid.NewString()
+	createTestSandboxVolume(t, repo, volumeID)
+	tx, err := repo.BeginTx(context.Background())
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = tx.Rollback(context.Background())
+	})
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = repo.requireS0FSHeadIdentity(canceledCtx, tx, volumeID, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("requireS0FSHeadIdentity() error = %v, want context.Canceled", err)
+	}
+	if errors.Is(err, ErrConflict) {
+		t.Fatalf("requireS0FSHeadIdentity() error = %v, must not be classified as ErrConflict", err)
+	}
+}
+
 func TestListSandboxVolumesBySource(t *testing.T) {
 	repo := newS0FSCommittedHeadTestRepository(t)
 	if repo == nil {


### PR DESCRIPTION
## Summary

- stop the pause/recovery controller from retrying a terminal sandbox forever, while retaining retries for active sandboxes with missing dependencies
- add an independent rootfs-snapshotter image pin so ordinary service releases do not restart live rootfs mounts
- preserve cancellation and transient database errors instead of classifying every committed-head read failure as a permanent conflict
- bind SandboxVolumes declared by shared-carrier claims before rootfs sync, and return their mounted bootstrap status
- keep the existing OnDelete snapshotter rollout as the only path for actual snapshotter upgrades

## Validation

- `go test ./manager/pkg/service ./storage-proxy/pkg/db ./storage-proxy/pkg/s0fs -count=1`
- `go test ./infra-operator/... -count=1`
- `helm lint infra-operator/chart` and rendered independent service/snapshotter tags
- remote targeted shared-pool boundary tests on persistent kind (no remote E2E): capacity 1/2/3, cold fallback, stale generation, node cordon, reserve-loss, shared-to-cold rollback, online service rollout, and SandboxVolume failure boundaries
- final reserve-loss observation: 171s, one terminal discard, zero requeues, zero visible sandboxes, pool replenished 2/2
- online rollout with pinned snapshotter: 74/74 reads succeeded; snapshotter DaemonSet revision and Pod UIDs, sandbox Pod UID, and rootfs checksum remained unchanged
- carrier SandboxVolume validation: exact mounted `bootstrap_mounts`, committed Head before pause, cross-node resume with intact data, then five PostgreSQL row-lock cancellation rounds with SandboxVolume and rootfs data intact
- negative boundaries: undeclared mount rejected with 400, concurrent RWO owner rejected with 409, paused-owner handoff and original resume preserved data, empty volume pause/resume stayed empty
- final targeted cleanup: zero terminal conflicts, dangling commit intents, committed Heads, active mounts, sandboxes, and volumes

Full E2E is intentionally left to PR CI.
