### PR TITLE
fix(template): recover ImageFS import failures

### DIFF
--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -502,6 +502,7 @@ func main() {
 				templateStore,
 				sandboxStore,
 				k8sClient,
+				crdClient.Sandbox0V1alpha1(),
 				nil,
 				sandboxService.CtldAddressForPod,
 				templateimagefs.Config{

--- a/manager/pkg/templateimagefs/worker.go
+++ b/manager/pkg/templateimagefs/worker.go
@@ -12,6 +12,7 @@ import (
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	api "github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	sandboxclient "github.com/sandbox0-ai/sandbox0/manager/pkg/generated/clientset/versioned/typed/sandbox0/v1alpha1"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/sandboxstore"
 	"github.com/sandbox0-ai/sandbox0/pkg/ctldapi"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
@@ -20,6 +21,7 @@ import (
 	templstore "github.com/sandbox0-ai/sandbox0/pkg/template/store"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -29,7 +31,7 @@ const (
 	importerLabel       = "sandbox0.ai/imagefs-import"
 	defaultPollInterval = 500 * time.Millisecond
 	defaultClaimTimeout = 5 * time.Second
-	defaultLease        = 10 * time.Minute
+	defaultLease        = 2 * time.Minute
 	defaultImportTTL    = 4 * time.Hour
 	claimErrorLogPeriod = 30 * time.Second
 )
@@ -66,14 +68,15 @@ type Worker struct {
 	queue       queue
 	heads       headStore
 	k8s         kubernetes.Interface
+	templates   sandboxclient.Sandbox0V1alpha1Interface
 	ctld        *ctldapi.Client
 	ctldAddress func(context.Context, *corev1.Pod) (string, error)
 	config      Config
 	logger      *zap.Logger
 }
 
-func NewWorker(q queue, heads headStore, k8sClient kubernetes.Interface, ctldClient *ctldapi.Client, ctldAddress func(context.Context, *corev1.Pod) (string, error), cfg Config, logger *zap.Logger) (*Worker, error) {
-	if q == nil || heads == nil || k8sClient == nil || ctldAddress == nil {
+func NewWorker(q queue, heads headStore, k8sClient kubernetes.Interface, templateClient sandboxclient.Sandbox0V1alpha1Interface, ctldClient *ctldapi.Client, ctldAddress func(context.Context, *corev1.Pod) (string, error), cfg Config, logger *zap.Logger) (*Worker, error) {
+	if q == nil || heads == nil || k8sClient == nil || templateClient == nil || ctldAddress == nil {
 		return nil, fmt.Errorf("template ImageFS worker dependencies are required")
 	}
 	cfg.WorkerID = strings.TrimSpace(cfg.WorkerID)
@@ -106,7 +109,7 @@ func NewWorker(q queue, heads headStore, k8sClient kubernetes.Interface, ctldCli
 	if logger == nil {
 		logger = zap.NewNop()
 	}
-	return &Worker{queue: q, heads: heads, k8s: k8sClient, ctld: ctldClient, ctldAddress: ctldAddress, config: cfg, logger: logger}, nil
+	return &Worker{queue: q, heads: heads, k8s: k8sClient, templates: templateClient, ctld: ctldClient, ctldAddress: ctldAddress, config: cfg, logger: logger}, nil
 }
 
 func (w *Worker) Run(ctx context.Context) error {
@@ -247,6 +250,16 @@ func (w *Worker) importRevision(ctx context.Context, revision *template.Template
 	if err != nil || tpl == nil {
 		return fmt.Errorf("load template for ImageFS revision: %w", err)
 	}
+	namespace, err := templateNamespace(tpl)
+	if err != nil {
+		return err
+	}
+	// A manager can terminate after creating the importer but before its
+	// deferred cleanup runs. Once this worker owns the expired revision lease,
+	// any importer Pod for that revision is stale and safe to remove.
+	if err := w.deleteImportPods(ctx, namespace, revision.RevisionID); err != nil {
+		return err
+	}
 	desiredRevision, err := template.NewTemplateImageRevision(tpl)
 	if err != nil {
 		return fmt.Errorf("derive current template ImageFS revision: %w", err)
@@ -259,17 +272,14 @@ func (w *Worker) importRevision(ctx context.Context, revision *template.Template
 			desiredRevision.RevisionID,
 		)
 	}
-	namespace, err := templateNamespace(tpl)
-	if err != nil {
-		return err
-	}
 	pod, err := w.createImportPod(ctx, namespace, tpl, revision)
 	if err != nil {
 		return err
 	}
+	importPodNamespace, importPodName := pod.Namespace, pod.Name
 	defer func() {
 		grace := int64(0)
-		_ = w.k8s.CoreV1().Pods(pod.Namespace).Delete(context.WithoutCancel(ctx), pod.Name, metav1.DeleteOptions{GracePeriodSeconds: &grace})
+		_ = w.k8s.CoreV1().Pods(importPodNamespace).Delete(context.WithoutCancel(ctx), importPodName, metav1.DeleteOptions{GracePeriodSeconds: &grace})
 	}()
 	pod, err = w.waitForImportContainer(ctx, pod.Namespace, pod.Name)
 	if err != nil {
@@ -311,6 +321,10 @@ func (w *Worker) importRevision(ctx context.Context, revision *template.Template
 
 func (w *Worker) createImportPod(ctx context.Context, namespace string, tpl *template.Template, revision *template.TemplateImageRevision) (*corev1.Pod, error) {
 	resourceName := naming.TemplateNameForCluster(tpl.Scope, tpl.TeamID, tpl.TemplateID)
+	owner, err := w.templates.SandboxTemplates(namespace).Get(ctx, resourceName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("load ImageFS import Pod owner: %w", err)
+	}
 	resource := &api.SandboxTemplate{ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: namespace}, Spec: *tpl.Spec.DeepCopy()}
 	resource.Spec.ClusterId = stringPointer(w.config.ClusterID)
 	resource.Spec.VolumeMounts = nil
@@ -337,12 +351,35 @@ func (w *Worker) createImportPod(ctx context.Context, namespace string, tpl *tem
 		Command:         []string{"/bin/sh", "-ec", "true"},
 		VolumeMounts:    []corev1.VolumeMount{{Name: primerVolume, MountPath: "/carrier-base", ReadOnly: true}},
 	}}, spec.InitContainers...)
-	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{GenerateName: "s0fs-import-", Namespace: namespace, Labels: map[string]string{importerLabel: revision.RevisionID}}, Spec: spec}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		GenerateName: "s0fs-import-",
+		Namespace:    namespace,
+		Labels:       map[string]string{importerLabel: revision.RevisionID},
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: api.SchemeGroupVersion.String(), Kind: "SandboxTemplate", Name: owner.Name, UID: owner.UID,
+		}},
+	}, Spec: spec}
 	created, err := w.k8s.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("create ImageFS import Pod: %w", err)
 	}
 	return created, nil
+}
+
+func (w *Worker) deleteImportPods(ctx context.Context, namespace, revisionID string) error {
+	pods, err := w.k8s.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: importerLabel + "=" + revisionID,
+	})
+	if err != nil {
+		return fmt.Errorf("list stale ImageFS import Pods: %w", err)
+	}
+	grace := int64(0)
+	for i := range pods.Items {
+		if err := w.k8s.CoreV1().Pods(namespace).Delete(ctx, pods.Items[i].Name, metav1.DeleteOptions{GracePeriodSeconds: &grace}); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete stale ImageFS import Pod %s: %w", pods.Items[i].Name, err)
+		}
+	}
+	return nil
 }
 
 func (w *Worker) waitForImportContainer(ctx context.Context, namespace, name string) (*corev1.Pod, error) {
@@ -352,8 +389,14 @@ func (w *Worker) waitForImportContainer(ctx context.Context, namespace, name str
 		if err != nil {
 			return false, err
 		}
-		for _, status := range pod.Status.ContainerStatuses {
+		for _, status := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
+			if status.State.Waiting != nil && isImportStartupFailure(status.State.Waiting.Reason) {
+				return false, fmt.Errorf("ImageFS import container %s failed to start (%s): %s", status.Name, status.State.Waiting.Reason, status.State.Waiting.Message)
+			}
 			if status.Name != "procd" {
+				if status.State.Terminated != nil && status.State.Terminated.ExitCode != 0 {
+					return false, fmt.Errorf("ImageFS import init container %s terminated: %s", status.Name, status.State.Terminated.Message)
+				}
 				continue
 			}
 			if status.State.Running != nil {
@@ -363,9 +406,6 @@ func (w *Worker) waitForImportContainer(ctx context.Context, namespace, name str
 			if status.State.Terminated != nil {
 				return false, fmt.Errorf("ImageFS import container terminated: %s", status.State.Terminated.Message)
 			}
-			if status.State.Waiting != nil && (status.State.Waiting.Reason == "ErrImagePull" || status.State.Waiting.Reason == "ImagePullBackOff") {
-				return false, fmt.Errorf("ImageFS import image pull failed: %s", status.State.Waiting.Message)
-			}
 		}
 		return false, nil
 	})
@@ -373,6 +413,15 @@ func (w *Worker) waitForImportContainer(ctx context.Context, namespace, name str
 		return nil, err
 	}
 	return ready, nil
+}
+
+func isImportStartupFailure(reason string) bool {
+	switch reason {
+	case "ErrImagePull", "ImagePullBackOff", "InvalidImageName", "CreateContainerConfigError", "CreateContainerError", "RunContainerError":
+		return true
+	default:
+		return false
+	}
 }
 
 func (w *Worker) renewLease(ctx context.Context, revisionID string, stop <-chan struct{}) {

--- a/manager/pkg/templateimagefs/worker_test.go
+++ b/manager/pkg/templateimagefs/worker_test.go
@@ -264,7 +264,7 @@ func TestWaitForImportContainerObservesFailureAfterPodCreation(t *testing.T) {
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "importer", Namespace: "sandbox-team"}}
 	client := fake.NewSimpleClientset(pod)
 	getCalls := 0
-	client.Fake.PrependReactor("get", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+	client.PrependReactor("get", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
 		getCalls++
 		current := pod.DeepCopy()
 		if getCalls > 1 {
@@ -305,10 +305,10 @@ func TestProcessStartupFailureDeletesImporterAndReleasesRevision(t *testing.T) {
 		}}},
 	}
 	client := fake.NewSimpleClientset()
-	client.Fake.PrependReactor("create", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+	client.PrependReactor("create", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
 		return true, importPod.DeepCopy(), nil
 	})
-	client.Fake.PrependReactor("get", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+	client.PrependReactor("get", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
 		return true, importPod.DeepCopy(), nil
 	})
 	queue := &workerQueueStub{template: tpl}

--- a/manager/pkg/templateimagefs/worker_test.go
+++ b/manager/pkg/templateimagefs/worker_test.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	api "github.com/sandbox0-ai/sandbox0/manager/pkg/apis/sandbox0/v1alpha1"
+	fakeclientset "github.com/sandbox0-ai/sandbox0/manager/pkg/generated/clientset/versioned/fake"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/sandboxstore"
+	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/s0fsrollout"
 	"github.com/sandbox0-ai/sandbox0/pkg/template"
 	templstore "github.com/sandbox0-ai/sandbox0/pkg/template/store"
@@ -17,7 +19,11 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestNewWorkerDefaultsToLargeImageImportWindow(t *testing.T) {
@@ -25,6 +31,7 @@ func TestNewWorkerDefaultsToLargeImageImportWindow(t *testing.T) {
 		&workerQueueStub{},
 		workerHeadStoreStub{},
 		fake.NewSimpleClientset(),
+		fakeclientset.NewSimpleClientset().Sandbox0V1alpha1(),
 		nil,
 		func(context.Context, *corev1.Pod) (string, error) { return "http://ctld", nil },
 		Config{WorkerID: "manager/green", BaseImageRef: "sandbox0ai/infra:carrier-base"},
@@ -32,6 +39,7 @@ func TestNewWorkerDefaultsToLargeImageImportWindow(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, 4*time.Hour, worker.config.ImportTimeout)
+	require.Equal(t, 2*time.Minute, worker.config.LeaseDuration)
 }
 
 func TestNewWorkerPreservesExplicitImportTimeout(t *testing.T) {
@@ -39,6 +47,7 @@ func TestNewWorkerPreservesExplicitImportTimeout(t *testing.T) {
 		&workerQueueStub{},
 		workerHeadStoreStub{},
 		fake.NewSimpleClientset(),
+		fakeclientset.NewSimpleClientset().Sandbox0V1alpha1(),
 		nil,
 		func(context.Context, *corev1.Pod) (string, error) { return "http://ctld", nil },
 		Config{WorkerID: "manager/green", BaseImageRef: "sandbox0ai/infra:carrier-base", ImportTimeout: 30 * time.Minute},
@@ -162,6 +171,7 @@ func TestProcessSupersedesClaimWhoseSpecIsNoLongerCurrent(t *testing.T) {
 	queue := &workerQueueStub{template: currentTemplate}
 	worker := &Worker{
 		queue: queue,
+		k8s:   fake.NewSimpleClientset(),
 		config: Config{
 			WorkerID:      "manager/green",
 			LeaseDuration: time.Hour,
@@ -178,9 +188,165 @@ func TestProcessSupersedesClaimWhoseSpecIsNoLongerCurrent(t *testing.T) {
 	require.Contains(t, queue.failedMessage, "current template requires")
 }
 
-func TestCreateImportPodPrimesFixedCarrierBaseOnTargetNode(t *testing.T) {
+func TestProcessSupersededRevisionDeletesStaleImporterPod(t *testing.T) {
+	claimedTemplate := imageFSWorkerTestTemplate()
+	claimed, err := template.NewTemplateImageRevision(claimedTemplate)
+	require.NoError(t, err)
+	currentTemplate := imageFSWorkerTestTemplate()
+	currentTemplate.Spec.MainContainer.Image = "python:3.14"
+	namespace, err := templateNamespace(currentTemplate)
+	require.NoError(t, err)
+	client := fake.NewSimpleClientset(
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "stale-matching", Namespace: namespace, Labels: map[string]string{importerLabel: claimed.RevisionID}}},
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "different-revision", Namespace: namespace, Labels: map[string]string{importerLabel: "tir-other"}}},
+	)
+	queue := &workerQueueStub{template: currentTemplate}
 	worker := &Worker{
-		k8s: fake.NewSimpleClientset(),
+		queue: queue,
+		k8s:   client,
+		config: Config{
+			WorkerID:      "manager/green",
+			LeaseDuration: time.Hour,
+			ImportTimeout: time.Minute,
+		},
+		logger: zap.NewNop(),
+	}
+
+	worker.process(context.Background(), claimed)
+
+	pods, err := client.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, pods.Items, 1)
+	require.Equal(t, "different-revision", pods.Items[0].Name)
+	require.Equal(t, 1, queue.failCalls)
+}
+
+func TestWaitForImportContainerReturnsDeterministicStartupFailures(t *testing.T) {
+	tests := []struct {
+		name   string
+		reason string
+		init   bool
+	}{
+		{name: "image pull", reason: "ErrImagePull"},
+		{name: "pull backoff", reason: "ImagePullBackOff"},
+		{name: "invalid image", reason: "InvalidImageName"},
+		{name: "invalid config", reason: "CreateContainerConfigError"},
+		{name: "create failure", reason: "CreateContainerError"},
+		{name: "runtime failure", reason: "RunContainerError"},
+		{name: "init failure", reason: "CreateContainerError", init: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status := corev1.ContainerStatus{
+				Name:  "procd",
+				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: tt.reason, Message: "failed"}},
+			}
+			podStatus := corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{status}}
+			if tt.init {
+				status.Name = "carrier-base-primer"
+				podStatus = corev1.PodStatus{InitContainerStatuses: []corev1.ContainerStatus{status}}
+			}
+			client := fake.NewSimpleClientset(&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "importer", Namespace: "sandbox-team"},
+				Status:     podStatus,
+			})
+			worker := &Worker{k8s: client, config: Config{PollInterval: time.Millisecond}}
+
+			_, err := worker.waitForImportContainer(context.Background(), "sandbox-team", "importer")
+
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.reason)
+		})
+	}
+}
+
+func TestWaitForImportContainerObservesFailureAfterPodCreation(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "importer", Namespace: "sandbox-team"}}
+	client := fake.NewSimpleClientset(pod)
+	getCalls := 0
+	client.Fake.PrependReactor("get", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		getCalls++
+		current := pod.DeepCopy()
+		if getCalls > 1 {
+			current.Status.ContainerStatuses = []corev1.ContainerStatus{{
+				Name: "procd",
+				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+					Reason: "ErrImagePull", Message: "not found",
+				}},
+			}}
+		}
+		return true, current, nil
+	})
+	worker := &Worker{k8s: client, config: Config{PollInterval: time.Millisecond}}
+
+	_, err := worker.waitForImportContainer(context.Background(), "sandbox-team", "importer")
+
+	require.ErrorContains(t, err, "ErrImagePull")
+	require.GreaterOrEqual(t, getCalls, 2)
+}
+
+func TestProcessStartupFailureDeletesImporterAndReleasesRevision(t *testing.T) {
+	tpl := imageFSWorkerTestTemplate()
+	revision, err := template.NewTemplateImageRevision(tpl)
+	require.NoError(t, err)
+	namespace, err := templateNamespace(tpl)
+	require.NoError(t, err)
+	resourceName := naming.TemplateNameForCluster(tpl.Scope, tpl.TeamID, tpl.TemplateID)
+	owner := &api.SandboxTemplate{ObjectMeta: metav1.ObjectMeta{
+		Name: resourceName, Namespace: namespace, UID: types.UID("template-uid"),
+	}}
+	importPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "importer", Namespace: namespace, UID: types.UID("importer-uid")},
+		Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{
+			Name: "procd",
+			State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+				Reason: "ErrImagePull", Message: "not found",
+			}},
+		}}},
+	}
+	client := fake.NewSimpleClientset()
+	client.Fake.PrependReactor("create", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, importPod.DeepCopy(), nil
+	})
+	client.Fake.PrependReactor("get", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, importPod.DeepCopy(), nil
+	})
+	queue := &workerQueueStub{template: tpl}
+	worker := &Worker{
+		queue:     queue,
+		heads:     workerHeadStoreStub{},
+		k8s:       client,
+		templates: fakeclientset.NewSimpleClientset(owner).Sandbox0V1alpha1(),
+		config: Config{
+			WorkerID: "manager/green", ClusterID: "green",
+			BaseImageRef: "sandbox0ai/infra:carrier-base", PrimerImageRef: "sandbox0ai/infra:manager",
+			LeaseDuration: time.Hour, ImportTimeout: time.Minute, PollInterval: time.Millisecond,
+		},
+		logger: zap.NewNop(),
+	}
+
+	require.NotPanics(t, func() { worker.process(context.Background(), revision) })
+	require.Equal(t, 1, queue.releaseCalls)
+	require.Equal(t, revision.RevisionID, queue.releasedRevisionID)
+	deleteActions := 0
+	for _, action := range client.Actions() {
+		if action.GetVerb() == "delete" && action.GetResource().Resource == "pods" {
+			deleteActions++
+			assert.Equal(t, "importer", action.(k8stesting.DeleteAction).GetName())
+		}
+	}
+	require.Equal(t, 1, deleteActions)
+}
+
+func TestCreateImportPodPrimesFixedCarrierBaseOnTargetNode(t *testing.T) {
+	namespace := "sandbox-team"
+	resourceName := naming.TemplateNameForCluster("team", "team-1", "python")
+	owner := &api.SandboxTemplate{ObjectMeta: metav1.ObjectMeta{
+		Name: resourceName, Namespace: namespace, UID: types.UID("template-uid"),
+	}}
+	worker := &Worker{
+		k8s:       fake.NewSimpleClientset(),
+		templates: fakeclientset.NewSimpleClientset(owner).Sandbox0V1alpha1(),
 		config: Config{
 			ClusterID: "cluster-a", BaseImageRef: "sandbox0ai/infra:carrier-base-v1", PrimerImageRef: "alpine:3.20",
 		},
@@ -193,8 +359,11 @@ func TestCreateImportPodPrimesFixedCarrierBaseOnTargetNode(t *testing.T) {
 	}
 	revision, err := template.NewTemplateImageRevision(tpl)
 	require.NoError(t, err)
-	pod, err := worker.createImportPod(context.Background(), "sandbox-team", tpl, revision)
+	pod, err := worker.createImportPod(context.Background(), namespace, tpl, revision)
 	require.NoError(t, err)
+	require.Len(t, pod.OwnerReferences, 1)
+	assert.Equal(t, owner.Name, pod.OwnerReferences[0].Name)
+	assert.Equal(t, owner.UID, pod.OwnerReferences[0].UID)
 	require.NotEmpty(t, pod.Spec.InitContainers)
 	assert.Equal(t, "carrier-base-primer", pod.Spec.InitContainers[0].Name)
 	assert.Equal(t, "alpine:3.20", pod.Spec.InitContainers[0].Image)
@@ -222,17 +391,19 @@ func TestTemplateNamespaceKeepsPublicAndTeamImportsIsolated(t *testing.T) {
 type workerQueueStub struct {
 	templstore.TemplateStore
 	templstore.TemplateImageRevisionStore
-	ensureCalls      int
-	selectCalls      int
-	clearCalls       int
-	claimCalls       int
-	claimErr         error
-	blockClaim       bool
-	template         *template.Template
-	failCalls        int
-	failedRevisionID string
-	failedReason     string
-	failedMessage    string
+	ensureCalls        int
+	selectCalls        int
+	clearCalls         int
+	claimCalls         int
+	claimErr           error
+	blockClaim         bool
+	template           *template.Template
+	failCalls          int
+	failedRevisionID   string
+	failedReason       string
+	failedMessage      string
+	releaseCalls       int
+	releasedRevisionID string
 }
 
 type workerHeadStoreStub struct{}
@@ -279,6 +450,12 @@ func (s *workerQueueStub) FailTemplateImageRevision(_ context.Context, revisionI
 	s.failedRevisionID = revisionID
 	s.failedReason = reason
 	s.failedMessage = message
+	return nil
+}
+
+func (s *workerQueueStub) ReleaseTemplateImageRevision(_ context.Context, revisionID, _ string, _ time.Time, _ string) error {
+	s.releaseCalls++
+	s.releasedRevisionID = revisionID
 	return nil
 }
 

--- a/pkg/template/http/handlers.go
+++ b/pkg/template/http/handlers.go
@@ -761,7 +761,8 @@ func (h *Handler) UpdateTemplate(c *gin.Context) {
 		spec.JSONError(c, http.StatusNotFound, spec.CodeNotFound, "template not found")
 		return
 	}
-	if !existing.ReadyForClaim() {
+	if existing.Status != nil && existing.Status.Creation != nil &&
+		existing.Status.Creation.State != v1alpha1.TemplateCreationStateReady {
 		message := "template is not ready"
 		if existing.Status != nil && existing.Status.Creation != nil {
 			creation := existing.Status.Creation

--- a/pkg/template/http/handlers_test.go
+++ b/pkg/template/http/handlers_test.go
@@ -856,6 +856,109 @@ func TestUpdateTemplate_DerivesCPUWhenOmitted(t *testing.T) {
 	assertTemplateResponseOmitsCPU(t, rec.Body.Bytes())
 }
 
+func TestUpdateTemplate_AllowsReplacingUnreadyImageRevision(t *testing.T) {
+	t.Parallel()
+
+	store := &testTemplateStore{
+		getTemplateFn: func(context.Context, string, string, string) (*template.Template, error) {
+			return &template.Template{
+				TemplateID: "demo",
+				Scope:      "team",
+				TeamID:     "team-1",
+				Spec:       validTemplateSpec(),
+				Status: &v1alpha1.SandboxTemplateStatus{
+					ImageRevision: &v1alpha1.TemplateImageRevisionStatus{
+						State:   v1alpha1.TemplateImageRevisionStateFailed,
+						Reason:  "ImagePullFailed",
+						Message: "source image does not exist",
+					},
+				},
+			}, nil
+		},
+	}
+	h := &Handler{Store: store, Logger: zap.NewNop()}
+	router := gin.New()
+	router.Use(withClaims(&internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+	router.PUT("/api/v1/templates/:id", h.UpdateTemplate)
+
+	body := []byte(`{
+		"spec":{
+			"mainContainer":{"image":"alpine:3.22","resources":{"memory":"4Gi"}},
+			"pool":{"minIdle":0,"maxIdle":1}
+		}
+	}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/templates/demo", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	if !store.updateCalled {
+		t.Fatal("expected update to replace the failed image revision")
+	}
+	if got := store.createdOrUpdatedSpec.MainContainer.Image; got != "alpine:3.22" {
+		t.Fatalf("updated image = %q, want alpine:3.22", got)
+	}
+}
+
+func TestUpdateTemplate_RejectsIncompleteFromSandboxCreation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		state       v1alpha1.TemplateCreationState
+		wantMessage string
+	}{
+		{name: "creating", state: v1alpha1.TemplateCreationStateCreating, wantMessage: "template creation is still in progress"},
+		{name: "failed", state: v1alpha1.TemplateCreationStateFailed, wantMessage: "template creation failed; delete and recreate the template"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			store := &testTemplateStore{
+				getTemplateFn: func(context.Context, string, string, string) (*template.Template, error) {
+					return &template.Template{
+						TemplateID: "demo",
+						Scope:      "team",
+						TeamID:     "team-1",
+						Spec:       validTemplateSpec(),
+						Status: &v1alpha1.SandboxTemplateStatus{
+							Creation: &v1alpha1.TemplateCreationStatus{State: tt.state},
+						},
+					}, nil
+				},
+			}
+			h := &Handler{Store: store, Logger: zap.NewNop()}
+			router := gin.New()
+			router.Use(withClaims(&internalauth.Claims{TeamID: "team-1", UserID: "user-1"}))
+			router.PUT("/api/v1/templates/:id", h.UpdateTemplate)
+
+			body := []byte(`{
+				"spec":{
+					"mainContainer":{"image":"alpine:3.22","resources":{"memory":"4Gi"}},
+					"pool":{"minIdle":0,"maxIdle":1}
+				}
+			}`)
+			req := httptest.NewRequest(http.MethodPut, "/api/v1/templates/demo", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusConflict {
+				t.Fatalf("expected status %d, got %d: %s", http.StatusConflict, rec.Code, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), tt.wantMessage) {
+				t.Fatalf("response = %s, want %q", rec.Body.String(), tt.wantMessage)
+			}
+			if store.updateCalled {
+				t.Fatal("expected update not called while from-sandbox creation is incomplete")
+			}
+		})
+	}
+}
+
 func TestUpdateTemplate_RejectsMemoryAbovePlatformMaximum(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- allow users to replace an unresolved or failed ImageFS revision while preserving the incomplete from-sandbox creation guard
- shorten the default ImageFS lease to two minutes and clean stale importer Pods after lease takeover
- bind importer Pods to their SandboxTemplate projection for Kubernetes owner GC
- classify deterministic container startup failures, release them promptly, and avoid the deferred-cleanup nil-pointer panic

## Local verification

- go test ./manager/pkg/templateimagefs ./pkg/template/http ./manager/cmd/manager
- git diff --check

## Targeted remote verification

No E2E was run on the persistent remote environment; PR CI owns E2E.

- invalid image claim failed closed with 409 and the template was updated in place to a ready alpine:3.22 revision
- two legacy orphan importers were replaced, then a forced manager crash recovered naturally in 114 seconds without database mutation
- forced manager crash plus template deletion owner-GC deleted the importer in 1 second; same-ID recreation became ready
- real ErrImagePull retries released in 9.65 seconds and 5.18 seconds on consecutive attempts, with no manager panic
- unrelated existing sandbox Pod UID remained unchanged throughout

## Rollout

Deploy the immutable service image to green while retaining the independent rootfs-snapshotter pin. Keep production admission cold/shared-off until the exact-cohort protected canary passes.