### PR TITLE
fix(manager): preserve S0FS image and resume correctness

### DIFF
--- a/manager/pkg/controller/helpers.go
+++ b/manager/pkg/controller/helpers.go
@@ -49,8 +49,13 @@ func EnsureProcdConfigSecret(
 	labels := map[string]string{
 		LabelTemplateID: template.Name,
 	}
-	ownerRefs := []metav1.OwnerReference{
-		*metav1.NewControllerRef(template, v1alpha1.SchemeGroupVersion.WithKind("SandboxTemplate")),
+	var ownerRefs []metav1.OwnerReference
+	// Resume can reconstruct a template after its CR has been deleted. Such a
+	// synthetic object has no UID and cannot be a Kubernetes owner.
+	if template.UID != "" {
+		ownerRefs = []metav1.OwnerReference{
+			*metav1.NewControllerRef(template, v1alpha1.SchemeGroupVersion.WithKind("SandboxTemplate")),
+		}
 	}
 	desired := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/manager/pkg/controller/helpers_test.go
+++ b/manager/pkg/controller/helpers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -232,6 +233,7 @@ func TestEnsureProcdConfigSecretHandlesAlreadyExistsWhenListerIsStale(t *testing
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "template-a",
 			Namespace: "tpl-a",
+			UID:       types.UID("template-uid"),
 		},
 	}
 
@@ -261,6 +263,30 @@ func TestEnsureProcdConfigSecretHandlesAlreadyExistsWhenListerIsStale(t *testing
 	require.Len(t, updated.OwnerReferences, 1)
 	require.Equal(t, "SandboxTemplate", updated.OwnerReferences[0].Kind)
 	require.Equal(t, "template-a", updated.OwnerReferences[0].Name)
+}
+
+func TestEnsureProcdConfigSecretOmitsOwnerForReconstructedTemplate(t *testing.T) {
+	keyPath := filepath.Join(t.TempDir(), "internal_jwt_public.key")
+	require.NoError(t, os.WriteFile(keyPath, []byte("test-public-key"), 0o600))
+	previousPath := internalauth.DefaultInternalJWTPublicKeyPath
+	internalauth.DefaultInternalJWTPublicKeyPath = keyPath
+	t.Cleanup(func() {
+		internalauth.DefaultInternalJWTPublicKeyPath = previousPath
+	})
+
+	template := &v1alpha1.SandboxTemplate{ObjectMeta: metav1.ObjectMeta{
+		Name: "template-a", Namespace: "tpl-a",
+	}}
+	client := fake.NewSimpleClientset()
+
+	require.NoError(t, EnsureProcdConfigSecret(
+		context.Background(), client, newHelpersSecretLister(t), template,
+	))
+	created, err := client.CoreV1().Secrets("tpl-a").Get(
+		context.Background(), "procd-secret-mrswmylvnr2a-template-a", metav1.GetOptions{},
+	)
+	require.NoError(t, err)
+	require.Empty(t, created.OwnerReferences)
 }
 
 func newHelpersSecretLister(t *testing.T, secrets ...*corev1.Secret) corelisters.SecretLister {

--- a/manager/pkg/templateimagefs/worker.go
+++ b/manager/pkg/templateimagefs/worker.go
@@ -45,6 +45,7 @@ type queue interface {
 
 type headStore interface {
 	StageRootFSHead(context.Context, *sandboxstore.SandboxRootFSHead) error
+	GetRootFSHeadByID(context.Context, string, string) (*sandboxstore.SandboxRootFSHead, error)
 }
 
 type Config struct {
@@ -272,6 +273,16 @@ func (w *Worker) importRevision(ctx context.Context, revision *template.Template
 			desiredRevision.RevisionID,
 		)
 	}
+	headID := templateImageFSHeadID(revision)
+	if revision.State == template.TemplateImageRevisionStateImporting {
+		recovered, err := w.recoverPublishedHead(ctx, revision, headID)
+		if err != nil {
+			return err
+		}
+		if recovered {
+			return nil
+		}
+	}
 	pod, err := w.createImportPod(ctx, namespace, tpl, revision)
 	if err != nil {
 		return err
@@ -291,7 +302,7 @@ func (w *Worker) importRevision(ctx context.Context, revision *template.Template
 	}
 	response, err := w.ctld.ImportRootFSImage(ctx, address, ctldapi.ImportRootFSImageRequest{
 		Target:     ctldapi.RootFSContainerRef{Namespace: pod.Namespace, PodName: pod.Name, PodUID: string(pod.UID), ContainerName: "procd"},
-		RevisionID: revision.RevisionID, TeamID: revision.ImageFSStorageScope(), HeadID: "imagefs-" + revision.RevisionID,
+		RevisionID: revision.RevisionID, TeamID: revision.ImageFSStorageScope(), HeadID: headID,
 		BaseImageRef: w.config.BaseImageRef,
 	}, w.config.ImportTimeout)
 	if err != nil {
@@ -317,6 +328,41 @@ func (w *Worker) importRevision(ctx context.Context, revision *template.Template
 	}
 	w.logger.Info("Template ImageFS revision ready", zap.String("revisionID", revision.RevisionID), zap.String("headID", response.Reference.HeadID), zap.Int64("createdBytes", response.CreatedBytes), zap.Duration("duration", response.Duration))
 	return nil
+}
+
+func templateImageFSHeadID(revision *template.TemplateImageRevision) string {
+	if revision == nil {
+		return ""
+	}
+	incarnationID := strings.ReplaceAll(strings.TrimSpace(revision.IncarnationID), "-", "")
+	if incarnationID == "" {
+		return "imagefs-" + revision.RevisionID
+	}
+	return "imagefs-" + revision.RevisionID + "-" + incarnationID
+}
+
+func (w *Worker) recoverPublishedHead(ctx context.Context, revision *template.TemplateImageRevision, headID string) (bool, error) {
+	if strings.TrimSpace(revision.ResolvedDigest) == "" || len(revision.OCIConfig) == 0 {
+		return false, nil
+	}
+	head, err := w.heads.GetRootFSHeadByID(ctx, headID, revision.ImageFSStorageScope())
+	if err != nil {
+		return false, fmt.Errorf("load staged ImageFS Head: %w", err)
+	}
+	if head == nil {
+		return false, nil
+	}
+	sourceID := "imagefs:" + revision.RevisionID
+	if head.SandboxID != sourceID || head.SourceSandboxID != sourceID ||
+		head.TeamID != revision.ImageFSStorageScope() || head.RuntimeGeneration != 1 ||
+		head.Reference.HeadID != headID {
+		return false, fmt.Errorf("staged ImageFS Head %s does not match revision incarnation", headID)
+	}
+	if err := w.queue.MarkTemplateImageRevisionReady(ctx, revision.RevisionID, w.config.WorkerID, headID, time.Now().UTC()); err != nil {
+		return false, err
+	}
+	w.logger.Info("Template ImageFS revision recovered from staged Head", zap.String("revisionID", revision.RevisionID), zap.String("headID", headID))
+	return true, nil
 }
 
 func (w *Worker) createImportPod(ctx context.Context, namespace string, tpl *template.Template, revision *template.TemplateImageRevision) (*corev1.Pod, error) {

--- a/manager/pkg/templateimagefs/worker_test.go
+++ b/manager/pkg/templateimagefs/worker_test.go
@@ -10,6 +10,7 @@ import (
 	fakeclientset "github.com/sandbox0-ai/sandbox0/manager/pkg/generated/clientset/versioned/fake"
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/sandboxstore"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
+	"github.com/sandbox0-ai/sandbox0/pkg/rootfshead"
 	"github.com/sandbox0-ai/sandbox0/pkg/s0fsrollout"
 	"github.com/sandbox0-ai/sandbox0/pkg/template"
 	templstore "github.com/sandbox0-ai/sandbox0/pkg/template/store"
@@ -221,6 +222,51 @@ func TestProcessSupersededRevisionDeletesStaleImporterPod(t *testing.T) {
 	require.Equal(t, 1, queue.failCalls)
 }
 
+func TestImportRevisionRecoversHeadStagedBeforeReadyCommit(t *testing.T) {
+	tpl := imageFSWorkerTestTemplate()
+	revision, err := template.NewTemplateImageRevision(tpl)
+	require.NoError(t, err)
+	revision.IncarnationID = "11111111-2222-3333-4444-555555555555"
+	revision.State = template.TemplateImageRevisionStateImporting
+	revision.ResolvedDigest = "sha256:resolved"
+	revision.OCIConfig = []byte(`{"architecture":"amd64","os":"linux"}`)
+	headID := templateImageFSHeadID(revision)
+	sourceID := "imagefs:" + revision.RevisionID
+	queue := &workerQueueStub{template: tpl}
+	client := fake.NewSimpleClientset()
+	worker := &Worker{
+		queue: queue,
+		heads: workerHeadStoreStub{head: &sandboxstore.SandboxRootFSHead{
+			SandboxID: sourceID, SourceSandboxID: sourceID, TeamID: revision.ImageFSStorageScope(),
+			RuntimeGeneration: 1, Reference: rootfshead.HeadReference{HeadID: headID},
+		}},
+		k8s:    client,
+		config: Config{WorkerID: "manager/green"},
+		logger: zap.NewNop(),
+	}
+
+	require.NoError(t, worker.importRevision(context.Background(), revision))
+	require.Equal(t, 1, queue.readyCalls)
+	assert.Equal(t, revision.RevisionID, queue.readyRevisionID)
+	assert.Equal(t, headID, queue.readyHeadID)
+	for _, action := range client.Actions() {
+		assert.NotEqual(t, "create", action.GetVerb(), "recovery must not create another importer Pod")
+	}
+}
+
+func TestTemplateImageFSHeadIDSeparatesRevisionIncarnations(t *testing.T) {
+	first := &template.TemplateImageRevision{
+		RevisionID: "tir-stable", IncarnationID: "11111111-2222-3333-4444-555555555555",
+	}
+	second := &template.TemplateImageRevision{
+		RevisionID: "tir-stable", IncarnationID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+	}
+
+	assert.Equal(t, templateImageFSHeadID(first), templateImageFSHeadID(first))
+	assert.NotEqual(t, templateImageFSHeadID(first), templateImageFSHeadID(second))
+	assert.Equal(t, "imagefs-tir-stable-11111111222233334444555555555555", templateImageFSHeadID(first))
+}
+
 func TestWaitForImportContainerReturnsDeterministicStartupFailures(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -404,12 +450,22 @@ type workerQueueStub struct {
 	failedMessage      string
 	releaseCalls       int
 	releasedRevisionID string
+	readyCalls         int
+	readyRevisionID    string
+	readyHeadID        string
 }
 
-type workerHeadStoreStub struct{}
+type workerHeadStoreStub struct {
+	head   *sandboxstore.SandboxRootFSHead
+	getErr error
+}
 
 func (workerHeadStoreStub) StageRootFSHead(context.Context, *sandboxstore.SandboxRootFSHead) error {
 	return nil
+}
+
+func (s workerHeadStoreStub) GetRootFSHeadByID(context.Context, string, string) (*sandboxstore.SandboxRootFSHead, error) {
+	return s.head, s.getErr
 }
 
 func (s *workerQueueStub) ListTemplates(context.Context) ([]*template.Template, error) {
@@ -456,6 +512,13 @@ func (s *workerQueueStub) FailTemplateImageRevision(_ context.Context, revisionI
 func (s *workerQueueStub) ReleaseTemplateImageRevision(_ context.Context, revisionID, _ string, _ time.Time, _ string) error {
 	s.releaseCalls++
 	s.releasedRevisionID = revisionID
+	return nil
+}
+
+func (s *workerQueueStub) MarkTemplateImageRevisionReady(_ context.Context, revisionID, _ string, headID string, _ time.Time) error {
+	s.readyCalls++
+	s.readyRevisionID = revisionID
+	s.readyHeadID = headID
 	return nil
 }
 

--- a/pkg/template/image_revision.go
+++ b/pkg/template/image_revision.go
@@ -25,6 +25,7 @@ const (
 // TemplateImageRevision is one immutable OCI resolution and S0FS ImageFS import.
 type TemplateImageRevision struct {
 	RevisionID           string
+	IncarnationID        string
 	TemplateID           string
 	Scope                string
 	TeamID               string

--- a/pkg/template/migrations/00004_add_template_image_revision_incarnations.sql
+++ b/pkg/template/migrations/00004_add_template_image_revision_incarnations.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+
+-- A deterministic revision ID identifies template content, while an
+-- incarnation identifies one durable queue row. Deleting and recreating the
+-- same template may resolve a moving tag again, so it must publish a distinct
+-- immutable ImageFS Head.
+ALTER TABLE scheduler_template_image_revisions
+    ADD COLUMN incarnation_id UUID NOT NULL DEFAULT gen_random_uuid();
+
+-- +goose Down
+
+ALTER TABLE scheduler_template_image_revisions
+    DROP COLUMN IF EXISTS incarnation_id;

--- a/pkg/template/store/pg/image_revision.go
+++ b/pkg/template/store/pg/image_revision.go
@@ -13,7 +13,7 @@ import (
 )
 
 const templateImageRevisionSelectColumns = `
-	revision_id, template_id, scope, team_id, source_image, spec_hash,
+	revision_id, incarnation_id::text, template_id, scope, team_id, source_image, spec_hash,
 	resolved_digest, platform_os, platform_architecture, platform_variant,
 	image_fs_head_id, oci_config, state, attempt_count, next_attempt_at,
 	lease_owner, lease_expires_at, reason, message, started_at, completed_at,
@@ -321,7 +321,7 @@ func scanTemplateImageRevision(row rowScanner) (*template.TemplateImageRevision,
 	var imageFSHeadID *string
 	var leaseExpiresAt, startedAt, completedAt *time.Time
 	if err := row.Scan(
-		&revision.RevisionID, &revision.TemplateID, &revision.Scope, &revision.TeamID,
+		&revision.RevisionID, &revision.IncarnationID, &revision.TemplateID, &revision.Scope, &revision.TeamID,
 		&revision.SourceImage, &revision.SpecHash, &revision.ResolvedDigest,
 		&revision.PlatformOS, &revision.PlatformArchitecture, &revision.PlatformVariant,
 		&imageFSHeadID, &ociConfig, &revision.State, &revision.AttemptCount,

--- a/pkg/template/store/pg/store_integration_test.go
+++ b/pkg/template/store/pg/store_integration_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	"github.com/sandbox0-ai/sandbox0/pkg/template"
 	"github.com/sandbox0-ai/sandbox0/pkg/template/migrations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -69,6 +71,34 @@ func TestEnsureTemplateImageRevisionStaysShadowUntilSelected(t *testing.T) {
 	if loaded.Status != nil && loaded.Status.ImageRevision != nil {
 		t.Fatalf("cleared template still selected revision %#v", loaded.Status.ImageRevision)
 	}
+}
+
+func TestRecreatedTemplateGetsNewImageRevisionIncarnation(t *testing.T) {
+	store, _ := newTemplateStoreIntegrationTest(t)
+	ctx := context.Background()
+	tpl := &template.Template{
+		TemplateID: "recreated-imagefs",
+		Scope:      naming.ScopeTeam,
+		TeamID:     "team-1",
+		UserID:     "user-1",
+		Spec:       integrationTemplateSpec("alpine:3.20"),
+	}
+	recreate := func() *template.TemplateImageRevision {
+		t.Helper()
+		require.NoError(t, store.CreateTemplate(ctx, tpl))
+		revision, created, err := store.EnsureTemplateImageRevision(ctx, tpl)
+		require.NoError(t, err)
+		require.True(t, created)
+		require.NotEmpty(t, revision.IncarnationID)
+		return revision
+	}
+
+	first := recreate()
+	require.NoError(t, store.DeleteTemplate(ctx, tpl.Scope, tpl.TeamID, tpl.TemplateID))
+	second := recreate()
+
+	assert.Equal(t, first.RevisionID, second.RevisionID)
+	assert.NotEqual(t, first.IncarnationID, second.IncarnationID)
 }
 
 func TestEnsureTemplateImageRevisionRevivesOnlySupersededSpec(t *testing.T) {


### PR DESCRIPTION
## Summary
- assign a unique incarnation to each persisted template image revision row so delete/recreate cannot reuse an immutable ImageFS Head ID
- recover a revision whose Head was staged before the ready-state commit
- allow paused S0FS sandboxes to resume after their template CR is deleted by omitting an invalid synthetic owner reference

## Validation
- go test ./manager/pkg/... ./pkg/template/...
- targeted persistent remote kind acceptance: template create/list/update/delete/recreate, Alpine and BusyBox custom images, shared claim, pause, resume after update/delete, from-sandbox, idempotency, rootfs metadata/content, cleanup, non-target isolation
- verified migration 4 applies and delete/recreate produces the same deterministic revision ID with distinct incarnation Head IDs

Merge method: squash.