### PR TITLE
fix(manager): protect reserved carriers from pool pruning

### DIFF
--- a/manager/pkg/carrierpool/pool.go
+++ b/manager/pkg/carrierpool/pool.go
@@ -114,8 +114,7 @@ func (p *Pool) Reconcile(ctx context.Context) error {
 			continue
 		}
 		if pod.Labels[carrier.LabelGeneration] != p.config.Generation || carrierUnusable(&pod, p.config.Generation, p.config.ActivationTimeout, time.Now()) {
-			grace := int64(0)
-			if err := p.k8s.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{GracePeriodSeconds: &grace}); err != nil && !apierrors.IsNotFound(err) {
+			if err := p.deleteUnclaimed(ctx, &pod); err != nil {
 				return err
 			}
 			continue
@@ -134,13 +133,35 @@ func (p *Pool) Reconcile(ctx context.Context) error {
 			return current[i].CreationTimestamp.Time.Before(current[j].CreationTimestamp.Time)
 		})
 		for _, pod := range current[p.config.MaxIdle:] {
-			grace := int64(0)
-			if err := p.k8s.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{GracePeriodSeconds: &grace}); err != nil && !apierrors.IsNotFound(err) {
+			if err := p.deleteUnclaimed(ctx, &pod); err != nil {
 				return err
 			}
 		}
 	}
 	return nil
+}
+
+// deleteUnclaimed removes only the exact Pod version observed by Reconcile.
+// Reserving a carrier updates its resource version, so a concurrent prune then
+// fails its precondition instead of deleting a Pod that a claim already owns.
+func (p *Pool) deleteUnclaimed(ctx context.Context, pod *corev1.Pod) error {
+	if pod == nil || pod.UID == "" || pod.ResourceVersion == "" {
+		return fmt.Errorf("carrier Pod UID and resource version are required for safe deletion")
+	}
+	grace := int64(0)
+	uid := pod.UID
+	resourceVersion := pod.ResourceVersion
+	err := p.k8s.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{
+		GracePeriodSeconds: &grace,
+		Preconditions: &metav1.Preconditions{
+			UID:             &uid,
+			ResourceVersion: &resourceVersion,
+		},
+	})
+	if apierrors.IsConflict(err) || apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
 }
 
 func carrierUnusable(pod *corev1.Pod, generation string, activationTimeout time.Duration, now time.Time) bool {

--- a/manager/pkg/carrierpool/pool_test.go
+++ b/manager/pkg/carrierpool/pool_test.go
@@ -1,6 +1,8 @@
 package carrierpool
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -9,9 +11,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestNewCarrierPodUsesUniquePullNeverMarkerAndInitGate(t *testing.T) {
@@ -81,6 +88,77 @@ func TestCarrierUnusableRejectsExpiredGateAndStartedMain(t *testing.T) {
 	pod.CreationTimestamp = metav1.Now()
 	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{Name: "procd", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}}}
 	assert.True(t, carrierUnusable(pod, "g", 15*time.Second, time.Now()))
+}
+
+func TestReconcileDoesNotDeleteConcurrentlyReservedCarrier(t *testing.T) {
+	oldest := readyCarrierPod("carrier-oldest", "uid-oldest", "rv-oldest", time.Now().Add(-time.Minute))
+	pruned := readyCarrierPod("carrier-pruned", "uid-pruned", "rv-pruned", time.Now())
+	client := fake.NewSimpleClientset(oldest, pruned)
+	pool, err := New(client, Config{
+		Namespace: "sandbox0", ClusterID: "default", MinIdle: 0, MaxIdle: 1,
+		CarrierImageRef: "sandbox0ai/infra:carrier-base-v1", Generation: "generation-a",
+	}, nil)
+	require.NoError(t, err)
+
+	client.Fake.PrependReactor("delete", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		deleteAction, ok := action.(k8stesting.DeleteAction)
+		require.True(t, ok)
+		require.Equal(t, "carrier-pruned", deleteAction.GetName())
+		preconditions := deleteAction.GetDeleteOptions().Preconditions
+		require.NotNil(t, preconditions)
+		require.NotNil(t, preconditions.UID)
+		require.NotNil(t, preconditions.ResourceVersion)
+		assert.Equal(t, types.UID("uid-pruned"), *preconditions.UID)
+		assert.Equal(t, "rv-pruned", *preconditions.ResourceVersion)
+
+		resource := corev1.SchemeGroupVersion.WithResource("pods")
+		object, getErr := client.Tracker().Get(resource, "sandbox0", "carrier-pruned")
+		require.NoError(t, getErr)
+		reserved := object.(*corev1.Pod).DeepCopy()
+		reserved.Annotations[carrier.AnnotationState] = carrier.StateReserved
+		reserved.ResourceVersion = "rv-after-reserve"
+		require.NoError(t, client.Tracker().Update(resource, reserved, "sandbox0"))
+		return true, nil, apierrors.NewConflict(
+			schema.GroupResource{Resource: "pods"}, reserved.Name, errors.New("resource version changed"),
+		)
+	})
+
+	require.NoError(t, pool.Reconcile(context.Background()))
+	current, err := client.CoreV1().Pods("sandbox0").Get(context.Background(), "carrier-pruned", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, carrier.StateReserved, current.Annotations[carrier.AnnotationState])
+}
+
+func TestReconcilePrunesUnchangedExcessCarrier(t *testing.T) {
+	oldest := readyCarrierPod("carrier-oldest", "uid-oldest", "rv-oldest", time.Now().Add(-time.Minute))
+	pruned := readyCarrierPod("carrier-pruned", "uid-pruned", "rv-pruned", time.Now())
+	client := fake.NewSimpleClientset(oldest, pruned)
+	pool, err := New(client, Config{
+		Namespace: "sandbox0", ClusterID: "default", MinIdle: 0, MaxIdle: 1,
+		CarrierImageRef: "sandbox0ai/infra:carrier-base-v1", Generation: "generation-a",
+	}, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, pool.Reconcile(context.Background()))
+	_, err = client.CoreV1().Pods("sandbox0").Get(context.Background(), "carrier-pruned", metav1.GetOptions{})
+	assert.True(t, apierrors.IsNotFound(err), "unchanged excess carrier should be pruned: %v", err)
+}
+
+func readyCarrierPod(name, uid, resourceVersion string, createdAt time.Time) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: "sandbox0", UID: types.UID(uid), ResourceVersion: resourceVersion,
+			CreationTimestamp: metav1.NewTime(createdAt),
+			Labels:            map[string]string{carrier.LabelPool: "shared", carrier.LabelGeneration: "generation-a"},
+			Annotations:       map[string]string{carrier.AnnotationState: carrier.StateReady},
+		},
+		Spec: corev1.PodSpec{NodeName: "node-a"},
+		Status: corev1.PodStatus{
+			Conditions:            []corev1.PodCondition{{Type: corev1.PodReadyToStartContainers, Status: corev1.ConditionTrue}},
+			InitContainerStatuses: []corev1.ContainerStatus{{Name: "carrier-wait", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}}},
+			ContainerStatuses:     []corev1.ContainerStatus{{Name: "procd"}},
+		},
+	}
 }
 
 func TestCompatibleRoutesDynamicShapeToColdCarrier(t *testing.T) {

--- a/manager/pkg/carrierpool/pool_test.go
+++ b/manager/pkg/carrierpool/pool_test.go
@@ -100,7 +100,7 @@ func TestReconcileDoesNotDeleteConcurrentlyReservedCarrier(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	client.Fake.PrependReactor("delete", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+	client.PrependReactor("delete", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		deleteAction, ok := action.(k8stesting.DeleteAction)
 		require.True(t, ok)
 		require.Equal(t, "carrier-pruned", deleteAction.GetName())


### PR DESCRIPTION
## Summary
- delete idle or unusable shared carriers only when both UID and resourceVersion still match the reconciler snapshot
- treat resource-version conflicts as a concurrent reservation and leave the claimed carrier intact
- preserve normal pruning of unchanged excess carriers

## Root cause
`Reserve` atomically updates a ready carrier to `reserved`, but a concurrent pool reconcile could issue an unconditional delete from an older list snapshot. The claimed Pod then terminated while resume waited for procd startup.

## Validation
- `go test ./manager/pkg/carrierpool ./manager/pkg/service`
- remote real-kind stale-resourceVersion delete rejection
- remote `go test -race ./manager/pkg/carrierpool -run TestReconcileDoesNotDeleteConcurrentlyReservedCarrier -count=100`
- `go test ./manager/...` passed for all packages except the expected local generated-proto setup failure in `manager/cmd/manager` (`storage-proxy/proto/fs` absent)

Production full-function rollout remains stopped at the private acceptance cohort until this fix passes CI, is squash-merged, deployed, and the protected suite passes.