### PR TITLE
feat(rollout): add explicit all-template admission

### DIFF
--- a/infra-operator/api/config/manager.go
+++ b/infra-operator/api/config/manager.go
@@ -306,6 +306,7 @@ type S0FSAdmissionConfig struct {
 	Mode               string   `yaml:"mode" json:"mode"`
 	TeamIDs            []string `yaml:"team_ids" json:"teamIds"`
 	TemplateIDs        []string `yaml:"template_ids" json:"templateIds"`
+	AdmitAll           bool     `yaml:"admit_all" json:"admitAll"`
 	RejectLegacyClaims bool     `yaml:"reject_legacy_claims" json:"rejectLegacyClaims"`
 }
 
@@ -329,12 +330,13 @@ func (c *ManagerConfig) S0FSRuntimeEnabled() bool {
 // S0FSAdmission returns the validated rollout policy for this manager.
 func (c *ManagerConfig) S0FSAdmission() (s0fsrollout.Admission, error) {
 	if c == nil {
-		return s0fsrollout.NewAdmission("off", nil, nil, false, false)
+		return s0fsrollout.NewAdmission("off", nil, nil, false, false, false)
 	}
 	return s0fsrollout.NewAdmission(
 		c.S0FSRuntime.Admission.Mode,
 		c.S0FSRuntime.Admission.TeamIDs,
 		c.S0FSRuntime.Admission.TemplateIDs,
+		c.S0FSRuntime.Admission.AdmitAll,
 		c.S0FSRuntime.Admission.RejectLegacyClaims,
 		c.SharedCarrierPool.Enabled,
 	)

--- a/infra-operator/api/config/manager_test.go
+++ b/infra-operator/api/config/manager_test.go
@@ -49,6 +49,22 @@ func TestS0FSRolloutControlsAllowShadowImportWithAdmissionOff(t *testing.T) {
 	}
 }
 
+func TestS0FSRolloutControlsAllowExplicitAdmissionForAllTemplates(t *testing.T) {
+	cfg := &ManagerConfig{
+		S0FSRuntime: S0FSRuntimeConfig{Enabled: true, Admission: S0FSAdmissionConfig{
+			Mode: "shared", AdmitAll: true, RejectLegacyClaims: true,
+		}},
+	}
+	admission, err := cfg.S0FSAdmission()
+	if err != nil {
+		t.Fatalf("S0FSAdmission() error = %v", err)
+	}
+	if !admission.Admits(naming.ScopePublic, "", "public-template") ||
+		!admission.Admits(naming.ScopeTeam, "team-a", "private-template") {
+		t.Fatal("explicit admit-all configuration did not admit every template scope")
+	}
+}
+
 func TestEffectiveRuntimeReadyTimeout(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/infra-operator/api/v1alpha1/service_api_config_types.go
+++ b/infra-operator/api/v1alpha1/service_api_config_types.go
@@ -1077,6 +1077,10 @@ type S0FSAdmissionConfig struct {
 	// +kubebuilder:validation:MaxItems=100
 	// +listType=set
 	TemplateIDs []string `json:"templateIds,omitempty"`
+	// AdmitAll explicitly admits every public and private template. It cannot
+	// be combined with teamIds or templateIds.
+	// +optional
+	AdmitAll bool `json:"admitAll,omitempty"`
 	// RejectLegacyClaims makes unmatched new claims fail closed on a green
 	// data-plane cluster instead of falling back to legacy rootfs creation.
 	// +optional

--- a/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
+++ b/infra-operator/chart/crds/infra.sandbox0.ai_sandbox0infras.yaml
@@ -3951,6 +3951,11 @@ spec:
                                 description: S0FSAdmissionConfig defines one explicit
                                   S0FS rollout cohort.
                                 properties:
+                                  admitAll:
+                                    description: |-
+                                      AdmitAll explicitly admits every public and private template. It cannot
+                                      be combined with teamIds or templateIds.
+                                    type: boolean
                                   mode:
                                     description: |-
                                       Mode is empty only for compatibility with the original shared carrier

--- a/infra-operator/internal/runtimeconfig/dataplane.go
+++ b/infra-operator/internal/runtimeconfig/dataplane.go
@@ -63,6 +63,7 @@ func ToManager(spec *infrav1alpha1.ManagerConfig) *apiconfig.ManagerConfig {
 			Mode:               spec.S0FSRuntime.Admission.Mode,
 			TeamIDs:            cloneStrings(spec.S0FSRuntime.Admission.TeamIDs),
 			TemplateIDs:        cloneStrings(spec.S0FSRuntime.Admission.TemplateIDs),
+			AdmitAll:           spec.S0FSRuntime.Admission.AdmitAll,
 			RejectLegacyClaims: spec.S0FSRuntime.Admission.RejectLegacyClaims,
 		},
 	}

--- a/infra-operator/internal/runtimeconfig/dataplane_test.go
+++ b/infra-operator/internal/runtimeconfig/dataplane_test.go
@@ -45,6 +45,17 @@ func TestToManagerPreservesS0FSRolloutControls(t *testing.T) {
 	}
 }
 
+func TestToManagerPreservesS0FSAdmitAll(t *testing.T) {
+	cfg := ToManager(&infrav1alpha1.ManagerConfig{
+		S0FSRuntime: infrav1alpha1.S0FSRuntimeConfig{
+			Admission: infrav1alpha1.S0FSAdmissionConfig{Mode: "shared", AdmitAll: true},
+		},
+	})
+	if !cfg.S0FSRuntime.Admission.AdmitAll {
+		t.Fatal("admission admit-all flag was not preserved")
+	}
+}
+
 func TestToManagerLeavesProcdWebhookOutboxDirUnsetWhenOmitted(t *testing.T) {
 	cfg := ToManager(&infrav1alpha1.ManagerConfig{})
 	if cfg.ProcdConfig.WebhookOutboxDir != "" {

--- a/manager/pkg/service/sandbox_service_claim_test.go
+++ b/manager/pkg/service/sandbox_service_claim_test.go
@@ -101,7 +101,7 @@ func TestClaimSandboxRejectsUnmatchedLegacyClaimOnGreenDataPlane(t *testing.T) {
 		"sandbox0.ai/template-scope":      naming.ScopeTeam,
 		"sandbox0.ai/template-logical-id": "default",
 	}
-	admission, err := s0fsrollout.NewAdmission("cold", []string{"team-b"}, nil, true, false)
+	admission, err := s0fsrollout.NewAdmission("cold", []string{"team-b"}, nil, false, true, false)
 	if err != nil {
 		t.Fatalf("NewAdmission() error = %v", err)
 	}
@@ -124,7 +124,7 @@ func TestClaimSandboxDoesNotFallbackWhenAdmittedRevisionIsNotReady(t *testing.T)
 		"sandbox0.ai/template-scope":      naming.ScopeTeam,
 		"sandbox0.ai/template-logical-id": "default",
 	}
-	admission, err := s0fsrollout.NewAdmission("cold", []string{"team-a"}, nil, true, false)
+	admission, err := s0fsrollout.NewAdmission("cold", []string{"team-a"}, nil, false, true, false)
 	if err != nil {
 		t.Fatalf("NewAdmission() error = %v", err)
 	}

--- a/manager/pkg/templateimagefs/worker_test.go
+++ b/manager/pkg/templateimagefs/worker_test.go
@@ -533,7 +533,7 @@ func imageFSWorkerTestTemplate() *template.Template {
 
 func mustAdmission(t *testing.T, mode string, teamIDs, templateIDs []string) s0fsrollout.Admission {
 	t.Helper()
-	admission, err := s0fsrollout.NewAdmission(mode, teamIDs, templateIDs, false, false)
+	admission, err := s0fsrollout.NewAdmission(mode, teamIDs, templateIDs, false, false, false)
 	require.NoError(t, err)
 	return admission
 }

--- a/pkg/s0fsrollout/admission.go
+++ b/pkg/s0fsrollout/admission.go
@@ -23,6 +23,7 @@ const (
 type Admission struct {
 	mode               AdmissionMode
 	cohort             Cohort
+	admitAll           bool
 	rejectLegacyClaims bool
 	legacyAdmitAll     bool
 }
@@ -79,10 +80,11 @@ func (c Cohort) Matches(scope, teamID, templateID string) bool {
 // NewAdmission validates and normalizes one rollout policy. An empty mode
 // preserves the original sharedCarrierPool.enabled behavior for existing
 // configurations; explicit rollout configurations must use off, cold, or
-// shared and an allowlist.
-func NewAdmission(mode string, teamIDs, templateIDs []string, rejectLegacyClaims, legacySharedEnabled bool) (Admission, error) {
+// shared and either an allowlist or admitAll.
+func NewAdmission(mode string, teamIDs, templateIDs []string, admitAll, rejectLegacyClaims, legacySharedEnabled bool) (Admission, error) {
 	mode = strings.TrimSpace(strings.ToLower(mode))
 	legacyAdmitAll := false
+	explicitMode := mode != ""
 	if mode == "" {
 		if legacySharedEnabled {
 			mode = string(AdmissionModeShared)
@@ -97,10 +99,18 @@ func NewAdmission(mode string, teamIDs, templateIDs []string, rejectLegacyClaims
 	default:
 		return Admission{}, fmt.Errorf("unsupported S0FS admission mode %q", mode)
 	}
+	cohort := NewCohort(teamIDs, templateIDs)
+	if admitAll && !explicitMode {
+		return Admission{}, fmt.Errorf("S0FS admitAll requires an explicit admission mode")
+	}
+	if admitAll && !cohort.Empty() {
+		return Admission{}, fmt.Errorf("S0FS admitAll cannot be combined with team or template selectors")
+	}
 
 	return Admission{
 		mode:               admissionMode,
-		cohort:             NewCohort(teamIDs, templateIDs),
+		cohort:             cohort,
+		admitAll:           admitAll,
 		rejectLegacyClaims: rejectLegacyClaims,
 		legacyAdmitAll:     legacyAdmitAll,
 	}, nil
@@ -124,7 +134,7 @@ func (a Admission) Admits(scope, teamID, templateID string) bool {
 	if a.mode == AdmissionModeOff {
 		return false
 	}
-	if a.legacyAdmitAll {
+	if a.admitAll || a.legacyAdmitAll {
 		return true
 	}
 	return a.cohort.Matches(scope, teamID, templateID)

--- a/pkg/s0fsrollout/admission_test.go
+++ b/pkg/s0fsrollout/admission_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestAdmissionCohortScope(t *testing.T) {
-	admission, err := NewAdmission("cold", []string{" team-a "}, []string{"public-canary"}, true, false)
+	admission, err := NewAdmission("cold", []string{" team-a "}, []string{"public-canary"}, false, true, false)
 	if err != nil {
 		t.Fatalf("NewAdmission() error = %v", err)
 	}
@@ -39,7 +39,7 @@ func TestAdmissionCohortScope(t *testing.T) {
 }
 
 func TestAdmissionOffOverridesAllowlist(t *testing.T) {
-	admission, err := NewAdmission("off", []string{"team-a"}, []string{"template-a"}, true, true)
+	admission, err := NewAdmission("off", []string{"team-a"}, []string{"template-a"}, false, true, true)
 	if err != nil {
 		t.Fatalf("NewAdmission() error = %v", err)
 	}
@@ -49,7 +49,7 @@ func TestAdmissionOffOverridesAllowlist(t *testing.T) {
 }
 
 func TestAdmissionPreservesLegacySharedCarrierConfiguration(t *testing.T) {
-	admission, err := NewAdmission("", nil, nil, false, true)
+	admission, err := NewAdmission("", nil, nil, false, false, true)
 	if err != nil {
 		t.Fatalf("NewAdmission() error = %v", err)
 	}
@@ -59,8 +59,39 @@ func TestAdmissionPreservesLegacySharedCarrierConfiguration(t *testing.T) {
 }
 
 func TestAdmissionRejectsUnknownMode(t *testing.T) {
-	if _, err := NewAdmission("gradual", nil, nil, false, false); err == nil {
+	if _, err := NewAdmission("gradual", nil, nil, false, false, false); err == nil {
 		t.Fatal("NewAdmission() error = nil, want unsupported mode error")
+	}
+}
+
+func TestAdmissionExplicitAdmitAll(t *testing.T) {
+	admission, err := NewAdmission("shared", nil, nil, true, true, false)
+	if err != nil {
+		t.Fatalf("NewAdmission() error = %v", err)
+	}
+	if !admission.Admits(naming.ScopePublic, "", "public-template") ||
+		!admission.Admits(naming.ScopeTeam, "team-a", "private-template") ||
+		!admission.UsesSharedCarrier() || !admission.RejectLegacyClaims() {
+		t.Fatal("explicit admit-all policy did not admit every template in shared mode")
+	}
+}
+
+func TestAdmissionOffOverridesExplicitAdmitAll(t *testing.T) {
+	admission, err := NewAdmission("off", nil, nil, true, true, false)
+	if err != nil {
+		t.Fatalf("NewAdmission() error = %v", err)
+	}
+	if admission.Admits(naming.ScopePublic, "", "public-template") || admission.Admits(naming.ScopeTeam, "team-a", "private-template") {
+		t.Fatal("off admission admitted a template with admitAll configured")
+	}
+}
+
+func TestAdmissionRejectsAmbiguousAdmitAll(t *testing.T) {
+	if _, err := NewAdmission("shared", []string{"team-a"}, nil, true, true, false); err == nil {
+		t.Fatal("NewAdmission() error = nil, want admit-all selector conflict")
+	}
+	if _, err := NewAdmission("", nil, nil, true, true, true); err == nil {
+		t.Fatal("NewAdmission() error = nil, want explicit-mode requirement")
 	}
 }
 


### PR DESCRIPTION
## Summary

- add an explicit `admitAll` S0FS admission switch instead of overloading empty selectors
- reject ambiguous admit-all plus team/template selector configurations
- preserve legacy empty-mode compatibility and allow `mode=off` to override admit-all for rollback
- propagate the field through operator CRD and manager runtime config

## Safety

The default is false and this PR does not change production configuration. Full admission remains a later independent infra wave after all shadow revisions are ready and the carrier fix is deployed and accepted.

## Validation

- `go test -race ./pkg/s0fsrollout ./infra-operator/api/config ./infra-operator/internal/runtimeconfig ./manager/pkg/service ./manager/pkg/templateimagefs`
- `go test ./infra-operator/... ./pkg/s0fsrollout`
- `make manifests` and generated CRD diff review