### PR TITLE
docs: announce Sandbox Volume retirement

### DIFF
--- a/docs/volume/backends/page.mdx
+++ b/docs/volume/backends/page.mdx
@@ -2,6 +2,10 @@
 
 Volume backend selection controls where Volume data lives and which storage operations are available.
 
+<Callout variant="warning">
+Sandbox Volumes will be retired soon and replaced by persistent Sandbox rootfs. Use Sandbox rootfs for new workloads and plan to migrate existing Volume data. See [Snapshot And Restore](/docs/sandbox/snapshot-restore) for rootfs snapshots, restore, and forks.
+</Callout>
+
 The default backend is `s0fs`. It stores Sandbox0-managed filesystem state in S3-compatible object storage and keeps filesystem metadata under Sandbox0 control. Use `s0fs` for agent workspaces that need direct file APIs, snapshots, restore, forks, and small-file write-heavy behavior.
 
 The `s3` backend mounts an existing S3-compatible bucket prefix through the same ctld volume portal used by normal Sandbox mounts. Use `s3` when the bucket prefix is the source of truth and a Sandbox should read or write objects through a mounted filesystem path.

--- a/docs/volume/fork/page.mdx
+++ b/docs/volume/fork/page.mdx
@@ -2,6 +2,10 @@
 
 Volume Fork creates a new Volume from an existing Volume using s0fs Copy-on-Write (COW) clone.
 
+<Callout variant="warning">
+Sandbox Volumes will be retired soon and replaced by persistent Sandbox rootfs. Use Sandbox rootfs for new workloads and plan to migrate existing Volume data. See [Snapshot And Restore](/docs/sandbox/snapshot-restore) for rootfs snapshots, restore, and forks.
+</Callout>
+
 <Callout variant="info">
 Volume fork is supported only for the `s0fs` backend. Forking an `s3` backend Volume returns a bad request because the external bucket prefix remains the source of truth. See [Volume Backends](/docs/sandbox/volume/backends) for the compatibility matrix.
 </Callout>

--- a/docs/volume/http/page.mdx
+++ b/docs/volume/http/page.mdx
@@ -2,6 +2,10 @@
 
 Use direct Volume file operations to operate on files in a Volume by volume ID, without mounting the Volume into a Sandbox first.
 
+<Callout variant="warning">
+Sandbox Volumes will be retired soon and replaced by persistent Sandbox rootfs. Use Sandbox rootfs for new workloads and plan to migrate existing Volume data. See [Snapshot And Restore](/docs/sandbox/snapshot-restore) for rootfs snapshots, restore, and forks.
+</Callout>
+
 Start with the Go, Python, TypeScript SDKs, or the `s0` CLI. The endpoint reference below is for advanced integrations and custom clients that need to call the HTTP and WebSocket API directly.
 
 <Callout variant="info">

--- a/docs/volume/mounts/page.mdx
+++ b/docs/volume/mounts/page.mdx
@@ -2,6 +2,10 @@
 
 Volumes are mounted through template-declared mount points and bound when a Sandbox is claimed.
 
+<Callout variant="warning">
+Sandbox Volumes will be retired soon and replaced by persistent Sandbox rootfs. Use Sandbox rootfs for new workloads and plan to migrate existing Volume data. See [Snapshot And Restore](/docs/sandbox/snapshot-restore) for rootfs snapshots, restore, and forks.
+</Callout>
+
 Dynamic mount and unmount APIs are no longer part of the Sandbox API. Define the allowed mount paths in the template, then provide the Volume IDs for those paths in the claim request.
 
 ## Mount Flow

--- a/docs/volume/page.mdx
+++ b/docs/volume/page.mdx
@@ -2,6 +2,10 @@
 
 Volume provides persistent storage for Sandbox0. It is a storage unit independent of the Sandbox lifecycle, allowing data sharing and reuse across multiple Sandboxes.
 
+<Callout variant="warning">
+Sandbox Volumes will be retired soon and replaced by persistent Sandbox rootfs. Use Sandbox rootfs for new workloads and plan to migrate existing Volume data. See [Snapshot And Restore](/docs/sandbox/snapshot-restore) for rootfs snapshots, restore, and forks.
+</Callout>
+
 ## Why Volumes?
 
 The default Sandbox writable filesystem is checkpointed across pause/resume for the same Sandbox identity. Sandbox rootfs snapshots and forks can preserve or branch that rootfs state, but they still operate at the sandbox rootfs boundary. Volumes solve the cases where data must be mounted by multiple Sandboxes or accessed directly through storage APIs:

--- a/docs/volume/snapshots/page.mdx
+++ b/docs/volume/snapshots/page.mdx
@@ -2,6 +2,10 @@
 
 A Snapshot is a point-in-time, read-only copy of a Volume. Snapshots are designed for backup, rollback, and reproducible environments.
 
+<Callout variant="warning">
+Sandbox Volumes will be retired soon and replaced by persistent Sandbox rootfs. Use Sandbox rootfs for new workloads and plan to migrate existing Volume data. See [Snapshot And Restore](/docs/sandbox/snapshot-restore) for rootfs snapshots, restore, and forks.
+</Callout>
+
 <Callout variant="info">
 Volume snapshots, restore, and creating a Volume from `snapshot_id` are supported only for the `s0fs` backend. `s3` backend Volumes return a bad request because they expose an external object prefix rather than Sandbox0-managed snapshot state. See [Volume Backends](/docs/sandbox/volume/backends) for the compatibility matrix.
 </Callout>


### PR DESCRIPTION
## Summary

- add a retirement warning to every Sandbox Volume documentation page
- direct new workloads and existing-data migration planning toward persistent Sandbox rootfs
- link readers to the rootfs snapshot, restore, and fork guide

## Why

Sandbox Volumes will be retired soon. Users need an explicit notice at every Volume documentation entry point and a clear replacement path before the feature is removed.

## Impact

This is a documentation-only change. It does not change Volume APIs or runtime behavior.

## Validation

- confirmed all six Volume documentation pages contain the warning
- ran the sandbox0-cloud production website build against these local docs
- verified rendered docs HTML, llms.txt, semantic 404 data, and agent markdown outputs