### PR TITLE
feat(nomad): select warm slots by security class

### DIFF
--- a/deploy/nomad/README.md
+++ b/deploy/nomad/README.md
@@ -26,9 +26,10 @@ Pin one build of every service, `nomad-driver-sandbox0`, `procd`, and stock
 - RootFS artifact OS and architecture.
 
 Runtime-class catalog version `3` contains immutable carrier compatibility only.
-CPU, memory, PIDs, quota/weight, and cpuset do not belong in the catalog. Until
-an explicit class selector is public, configure exactly one class per requested
-cluster; zero or multiple matches fail closed.
+CPU, memory, PIDs, quota/weight, and cpuset do not belong in the catalog. Each
+cluster may publish one `standard` and one `privileged` class; template
+`mainContainer.securityClass` selects between them. Zero or multiple matches
+for the same cluster and security class fail closed.
 
 Nomad schedules dedicated Sandbox0 nodes and resource-neutral warm carriers.
 Manager atomically leases exact CPU and memory from ctld-reported node capacity;

--- a/deploy/nomad/assets_test.go
+++ b/deploy/nomad/assets_test.go
@@ -32,13 +32,21 @@ const minimumAcceptanceWidth = 8
 
 func TestAcceptanceExamplesUseDedicatedResourceNeutralWarmCarriers(t *testing.T) {
 	warmJob := readAsset(t, "../../nomad-driver-sandbox0/example/warm-slot.nomad")
-	countMatch := regexp.MustCompile(`(?m)^\s*count\s*=\s*([0-9]+)\s*$`).FindStringSubmatch(warmJob)
-	if len(countMatch) != 2 {
-		t.Fatal("warm-slot example does not contain one literal group count")
+	countMatches := regexp.MustCompile(`(?m)^\s*count\s*=\s*([0-9]+)\s*$`).FindAllStringSubmatch(warmJob, -1)
+	if len(countMatches) != 2 {
+		t.Fatalf("warm-slot example group count records = %d, want standard and privileged", len(countMatches))
 	}
-	warmCount, err := strconv.Atoi(countMatch[1])
+	warmCount, err := strconv.Atoi(countMatches[0][1])
 	if err != nil || warmCount < minimumAcceptanceWidth {
-		t.Fatalf("warm-slot count = %q, want at least %d", countMatch[1], minimumAcceptanceWidth)
+		t.Fatalf("standard warm-slot count = %q, want at least %d", countMatches[0][1], minimumAcceptanceWidth)
+	}
+	privilegedCount, err := strconv.Atoi(countMatches[1][1])
+	if err != nil || privilegedCount < 1 {
+		t.Fatalf("privileged warm-slot count = %q, want at least 1", countMatches[1][1])
+	}
+	if !strings.Contains(warmJob, `security_class = "standard"`) ||
+		!strings.Contains(warmJob, `security_class = "privileged"`) {
+		t.Fatal("warm carriers must publish both explicit security classes")
 	}
 	if regexp.MustCompile(`(?m)^\s*cores\s*=`).MatchString(warmJob) {
 		t.Fatal("warm carriers must not encode sandbox CPU as Nomad dedicated cores")
@@ -70,6 +78,9 @@ func TestAcceptanceExamplesUseDedicatedResourceNeutralWarmCarriers(t *testing.T)
 	}
 	if len(devices) < minimumAcceptanceWidth {
 		t.Fatalf("ctld example configures %d NBD devices, want at least %d", len(devices), minimumAcceptanceWidth)
+	}
+	if len(devices) < warmCount+privilegedCount {
+		t.Fatalf("ctld configures %d NBD devices for %d total warm slots", len(devices), warmCount+privilegedCount)
 	}
 	seen := make(map[string]struct{}, len(devices))
 	devicePattern := regexp.MustCompile(`^/dev/nbd[0-9]+$`)

--- a/docs/template/configuration/page.mdx
+++ b/docs/template/configuration/page.mdx
@@ -1,9 +1,10 @@
 # Template Configuration
 
 A template describes reusable sandbox inputs. The public spec is
-runtime-neutral: it contains an image, default memory and ephemeral storage,
-environment variables, metadata, and a default network policy. Scheduling and
-warm-pool topology are platform concerns and are not embedded in a template.
+runtime-neutral: it contains an image, default memory and RootFS storage,
+guest security class, claim-lifetime ephemeral mounts, environment variables,
+metadata, and a default network policy. Scheduling and warm-pool topology are
+platform concerns and are not embedded in a template.
 
 ## Example
 
@@ -17,12 +18,17 @@ spec:
 
     mainContainer:
         image: registry.example.com/t-<team-key>/my-ds-env@sha256:<64-hex-digest>
+        securityClass: privileged
         resources:
             memory: 8Gi
             ephemeralStorage: 8Gi
         env:
             - name: PYTHONPATH
               value: /workspace
+
+    ephemeralMounts:
+        - mountPath: /var/lib/docker
+          sizeLimit: 16Gi
 
     envVars:
         LOG_LEVEL: info
@@ -48,6 +54,7 @@ spec:
 | `image` | Yes | Normalized public or team-scoped private OCI reference pinned as `@sha256:<64 lowercase hex>`. Mutable tags and shorthand names are rejected. |
 | `resources.memory` | Yes | Default sandbox memory, such as `2Gi` or `512Mi`. It must be within the platform limits. |
 | `resources.ephemeralStorage` | No | Immutable RootFS block-device size. The default is `8Gi`; values must be exact bytes, between `300Mi` and `1Ti`, and 4096-byte aligned. |
+| `securityClass` | No | `standard` by default. `privileged` grants guest-kernel capabilities inside gVisor but never bypasses runsc or exposes host devices. The value is immutable for a sandbox. |
 | `env` | No | Base environment entries with `name` and `value`. |
 
 CPU is platform-derived from memory and is intentionally absent from the
@@ -58,6 +65,18 @@ lease. Every value remains subject to the platform maximum.
 Carrier allocation resources do not define these limits. Manager leases exact
 CPU and memory from ctld-reported dedicated-node capacity and the task driver
 writes the committed lease into the OCI spec.
+
+## `ephemeralMounts`
+
+Each entry creates a size-bounded tmpfs for one runtime generation. Its files
+are intentionally discarded on pause, runtime replacement, fork, snapshot,
+or deletion and never enter the block-COW RootFS ledger. Mount paths must be
+canonical absolute paths, cannot overlap, and cannot shadow runtime-owned
+paths such as `/proc`, `/sys`, `/config`, or `/procd`. Size limits range from
+`1Mi` to `1Ti` and remain subject to the sandbox memory cgroup.
+
+Use this for throwaway Docker state such as `/var/lib/docker`. Keep source and
+durable outputs outside ephemeral mounts.
 
 ## `envVars`
 
@@ -110,13 +129,15 @@ Metadata does not change runtime compatibility.
 
 ## Scheduling And Resources
 
-Template specs define the image, environment, memory, ephemeral storage,
-network policy, and metadata. CPU is derived from memory by platform policy.
-The API uses strict decoding and rejects unknown fields.
+Template specs define the image, environment, memory, RootFS storage, security
+class, ephemeral mounts, network policy, and metadata. CPU is derived from
+memory by platform policy. The API uses strict decoding and rejects unknown
+fields.
 
-Platform administrators configure immutable runtime classes, dedicated node
-capacity, and the unified resource-neutral carrier pool outside template
-specs. See
+Platform administrators configure the concrete runtime classes, dedicated
+node capacity, and the unified resource-neutral carrier pool. A template
+selects only its public `securityClass`; manager resolves that selector to one
+exact compatible carrier class. See
 [Unified Warm Pool](/docs/sandbox/template/pool).
 
 ## Next Steps

--- a/manager/pkg/nomadclaim/catalog.go
+++ b/manager/pkg/nomadclaim/catalog.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/manager/pkg/sandboxstore"
 	"github.com/sandbox0-ai/sandbox0/pkg/naming"
 	protocol "github.com/sandbox0-ai/sandbox0/pkg/runtimeslot"
+	"github.com/sandbox0-ai/sandbox0/pkg/sandboxspec"
 )
 
 const (
@@ -164,27 +165,37 @@ func normalizeRuntimeClass(record runtimeClassCatalogRecord) (RuntimeClass, erro
 	}, nil
 }
 
-// Resolve returns the only immutable class for a requested cluster. Until the
-// public API has an explicit class selector, multiple candidates fail closed.
-func (c *RuntimeClassCatalog) Resolve(clusterID string) (RuntimeClass, error) {
+// Resolve returns the only immutable class matching a cluster and canonical
+// template security class. Other compatibility dimensions remain fail-closed
+// until they gain explicit selectors.
+func (c *RuntimeClassCatalog) Resolve(clusterID, requestedSecurityClass string) (RuntimeClass, error) {
 	if c == nil {
 		return RuntimeClass{}, ErrRuntimeClassUnavailable
 	}
 	clusterID = strings.TrimSpace(clusterID)
+	securityClass, ok := sandboxspec.EffectiveSandboxSecurityClass(sandboxspec.SandboxSecurityClass(requestedSecurityClass))
+	if !ok || string(securityClass) != requestedSecurityClass {
+		return RuntimeClass{}, fmt.Errorf("%w for invalid security class %q", ErrRuntimeClassUnavailable, requestedSecurityClass)
+	}
 	var selected RuntimeClass
 	found := false
 	for _, class := range c.classes {
 		if clusterID != "" && class.ClusterID != clusterID {
 			continue
 		}
+		if class.Compatibility.SecurityClass != requestedSecurityClass {
+			continue
+		}
 		if found {
-			return RuntimeClass{}, fmt.Errorf("%w for cluster %q", ErrRuntimeClassAmbiguous, clusterID)
+			return RuntimeClass{}, fmt.Errorf("%w for cluster %q and security class %q",
+				ErrRuntimeClassAmbiguous, clusterID, requestedSecurityClass)
 		}
 		selected = class
 		found = true
 	}
 	if !found {
-		return RuntimeClass{}, fmt.Errorf("%w for cluster %q", ErrRuntimeClassUnavailable, clusterID)
+		return RuntimeClass{}, fmt.Errorf("%w for cluster %q and security class %q",
+			ErrRuntimeClassUnavailable, clusterID, requestedSecurityClass)
 	}
 	return selected, nil
 }

--- a/manager/pkg/nomadclaim/catalog_test.go
+++ b/manager/pkg/nomadclaim/catalog_test.go
@@ -41,7 +41,7 @@ func TestLoadRuntimeClassCatalogResolvesWithoutResourceShape(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	class, err := catalog.Resolve("cluster-1")
+	class, err := catalog.Resolve("cluster-1", "standard")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestLoadRuntimeClassCatalogResolvesWithoutResourceShape(t *testing.T) {
 		class.Compatibility.SecurityClass != "standard" || class.CompatibilityDigest == "" {
 		t.Fatalf("runtime class = %+v", class)
 	}
-	if _, err := catalog.Resolve("cluster-2"); !errors.Is(err, ErrRuntimeClassUnavailable) {
+	if _, err := catalog.Resolve("cluster-2", "standard"); !errors.Is(err, ErrRuntimeClassUnavailable) {
 		t.Fatalf("missing cluster error = %v", err)
 	}
 }
@@ -97,10 +97,28 @@ func TestRuntimeClassCatalogRejectsAmbiguousOrLooseInput(t *testing.T) {
 
 func TestRuntimeClassCatalogRejectsImplicitAmbiguousSelection(t *testing.T) {
 	catalog := &RuntimeClassCatalog{classes: []RuntimeClass{
-		{Name: "standard", ClusterID: "cluster-1"},
-		{Name: "gpu", ClusterID: "cluster-1"},
+		{Name: "standard-a", ClusterID: "cluster-1", Compatibility: protocol.RuntimeCompatibility{SecurityClass: "standard"}},
+		{Name: "standard-b", ClusterID: "cluster-1", Compatibility: protocol.RuntimeCompatibility{SecurityClass: "standard"}},
 	}}
-	if _, err := catalog.Resolve("cluster-1"); !errors.Is(err, ErrRuntimeClassAmbiguous) {
+	if _, err := catalog.Resolve("cluster-1", "standard"); !errors.Is(err, ErrRuntimeClassAmbiguous) {
 		t.Fatalf("ambiguous class error = %v", err)
+	}
+}
+
+func TestRuntimeClassCatalogResolvesSecurityClassesIndependently(t *testing.T) {
+	catalog := &RuntimeClassCatalog{classes: []RuntimeClass{
+		{Name: "standard", ClusterID: "cluster-1", Compatibility: protocol.RuntimeCompatibility{SecurityClass: "standard"}},
+		{Name: "privileged", ClusterID: "cluster-1", Compatibility: protocol.RuntimeCompatibility{SecurityClass: "privileged"}},
+	}}
+	standard, err := catalog.Resolve("cluster-1", "standard")
+	if err != nil || standard.Name != "standard" {
+		t.Fatalf("standard = %+v, %v", standard, err)
+	}
+	privileged, err := catalog.Resolve("cluster-1", "privileged")
+	if err != nil || privileged.Name != "privileged" {
+		t.Fatalf("privileged = %+v, %v", privileged, err)
+	}
+	if _, err := catalog.Resolve("cluster-1", "host"); !errors.Is(err, ErrRuntimeClassUnavailable) {
+		t.Fatalf("invalid security class error = %v", err)
 	}
 }

--- a/manager/pkg/nomadclaim/service.go
+++ b/manager/pkg/nomadclaim/service.go
@@ -423,7 +423,11 @@ func (s *Service) resumeNomadSandbox(
 	}
 
 	plan.request.RuntimeGeneration = candidate.RuntimeGeneration
-	plan.assignment = runtimeAssignment(candidate.Record.TemplateSpec, &plan.request)
+	plan.assignment, err = runtimeAssignment(candidate.Record.TemplateSpec, &plan.request)
+	if err != nil {
+		return nil, nil, apierror.NewConflict("sandbox", sandboxID,
+			fmt.Errorf("stored runtime assignment changed during resume: %w", err))
+	}
 	if err := plan.assignment.Validate(); err != nil {
 		return nil, nil, apierror.NewConflict("sandbox", sandboxID,
 			fmt.Errorf("stored runtime assignment changed during resume: %w", err))
@@ -490,7 +494,12 @@ func (s *Service) prepareNomadResumePlan(ctx context.Context, record *sandboxsto
 		return nomadResumePlan{}, fmt.Errorf("%w: stored Nomad resources are invalid: %v",
 			service.ErrSandboxLifecycleUnavailable, err)
 	}
-	runtimeClass, err := s.runtimeClasses.Resolve(record.ClusterID)
+	securityClass, ok := v1alpha1.EffectiveSandboxSecurityClass(record.TemplateSpec.MainContainer.SecurityClass)
+	if !ok {
+		return nomadResumePlan{}, fmt.Errorf("%w: stored Nomad security class is invalid",
+			service.ErrSandboxLifecycleUnavailable)
+	}
+	runtimeClass, err := s.runtimeClasses.Resolve(record.ClusterID, string(securityClass))
 	if err != nil {
 		return nomadResumePlan{}, fmt.Errorf("%w: no compatible Nomad warm-slot class for the stored sandbox",
 			service.ErrSandboxLifecycleUnavailable)
@@ -531,7 +540,11 @@ func (s *Service) prepareNomadResumePlan(ctx context.Context, record *sandboxsto
 		return nomadResumePlan{}, fmt.Errorf("%w: stored Nomad credential binding semantics changed",
 			service.ErrSandboxLifecycleUnavailable)
 	}
-	assignment := runtimeAssignment(record.TemplateSpec, &req)
+	assignment, err := runtimeAssignment(record.TemplateSpec, &req)
+	if err != nil {
+		return nomadResumePlan{}, fmt.Errorf("%w: stored runtime assignment is invalid: %v",
+			service.ErrSandboxLifecycleUnavailable, err)
+	}
 	if err := assignment.Validate(); err != nil {
 		return nomadResumePlan{}, fmt.Errorf("%w: stored runtime assignment is invalid: %v",
 			service.ErrSandboxLifecycleUnavailable, err)
@@ -786,7 +799,11 @@ func (s *Service) ClaimSandbox(ctx context.Context, request *service.ClaimReques
 	if err != nil {
 		return nil, err
 	}
-	runtimeClass, err := s.runtimeClasses.Resolve("")
+	securityClass, ok := v1alpha1.EffectiveSandboxSecurityClass(tpl.Spec.MainContainer.SecurityClass)
+	if !ok {
+		return nil, fmt.Errorf("%w: template security class is invalid", service.ErrInvalidClaimRequest)
+	}
+	runtimeClass, err := s.runtimeClasses.Resolve("", string(securityClass))
 	if err != nil {
 		return nil, fmt.Errorf("%w: resolve Nomad runtime class: %v", service.ErrDataPlaneNotReady, err)
 	}
@@ -815,7 +832,10 @@ func (s *Service) ClaimSandbox(ctx context.Context, request *service.ClaimReques
 	}
 	storeBindings := credentialbinding.ToStore(credentials)
 	sanitizeNomadCredentialBindings(req.Config)
-	assignment := runtimeAssignment(tpl.Spec, &req)
+	assignment, err := runtimeAssignment(tpl.Spec, &req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: runtime assignment: %v", service.ErrInvalidClaimRequest, err)
+	}
 	if err := assignment.Validate(); err != nil {
 		return nil, fmt.Errorf("%w: runtime assignment: %v", service.ErrInvalidClaimRequest, err)
 	}
@@ -1243,7 +1263,7 @@ func bytesToMiBRoundUp(value int64) int64 {
 	return 1 + (value-1)/mib
 }
 
-func runtimeAssignment(spec v1alpha1.SandboxTemplateSpec, req *service.ClaimRequest) runtimecontrol.Assignment {
+func runtimeAssignment(spec v1alpha1.SandboxTemplateSpec, req *service.ClaimRequest) (runtimecontrol.Assignment, error) {
 	environment := make(map[string]string, len(spec.EnvVars)+len(spec.MainContainer.Env)+2)
 	for _, item := range spec.MainContainer.Env {
 		environment[item.Name] = item.Value
@@ -1257,15 +1277,30 @@ func runtimeAssignment(spec v1alpha1.SandboxTemplateSpec, req *service.ClaimRequ
 		}
 	}
 	environment[runtimecontrol.EnvSandboxID] = req.SandboxID
+	securityClass, ok := v1alpha1.EffectiveSandboxSecurityClass(spec.MainContainer.SecurityClass)
+	if !ok {
+		return runtimecontrol.Assignment{}, fmt.Errorf("template security class is invalid")
+	}
+	resolvedMounts, err := templatepkg.ResolveEphemeralMounts(spec)
+	if err != nil {
+		return runtimecontrol.Assignment{}, err
+	}
+	ephemeralMounts := make([]runtimecontrol.EphemeralMount, 0, len(resolvedMounts))
+	for _, mount := range resolvedMounts {
+		ephemeralMounts = append(ephemeralMounts, runtimecontrol.EphemeralMount{
+			MountPath: mount.MountPath, SizeBytes: mount.SizeBytes,
+		})
+	}
 	assignment := runtimecontrol.Assignment{
 		SandboxID: req.SandboxID, TeamID: req.TeamID,
-		RuntimeGeneration: req.RuntimeGeneration, EnvVars: environment,
+		RuntimeGeneration: req.RuntimeGeneration, SecurityClass: string(securityClass),
+		EphemeralMounts: ephemeralMounts, EnvVars: environment,
 	}
 	if req.Config != nil && req.Config.Webhook != nil {
 		webhook := *req.Config.Webhook
 		assignment.Webhook = &webhook
 	}
-	return assignment
+	return assignment, nil
 }
 
 func digestPinnedImage(image string) (string, error) {

--- a/manager/pkg/nomadclaim/service_test.go
+++ b/manager/pkg/nomadclaim/service_test.go
@@ -41,6 +41,29 @@ type fakeTemplateStore struct {
 	template *templatepkg.Template
 }
 
+func TestRuntimeAssignmentCarriesSecurityClassAndEphemeralMounts(t *testing.T) {
+	spec := v1alpha1.TemplateSpec{
+		MainContainer: v1alpha1.ContainerSpec{SecurityClass: v1alpha1.SandboxSecurityClassPrivileged},
+		EphemeralMounts: []v1alpha1.EphemeralMountSpec{
+			{MountPath: "/var/lib/docker", SizeLimit: "16Gi"},
+		},
+	}
+	assignment, err := runtimeAssignment(spec, &service.ClaimRequest{
+		SandboxID: "sandbox-1", TeamID: "team-1", RuntimeGeneration: 2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if assignment.SecurityClass != "privileged" || len(assignment.EphemeralMounts) != 1 ||
+		assignment.EphemeralMounts[0].MountPath != "/var/lib/docker" ||
+		assignment.EphemeralMounts[0].SizeBytes != 16<<30 {
+		t.Fatalf("assignment = %#v", assignment)
+	}
+	if err := assignment.Validate(); err != nil {
+		t.Fatalf("assignment validation = %v", err)
+	}
+}
+
 func (f *fakeTemplateStore) GetTemplateForTeam(_ context.Context, teamID, templateID string) (*templatepkg.Template, error) {
 	if f.template == nil || f.template.TemplateID != templateID ||
 		(f.template.Scope == naming.ScopeTeam && f.template.TeamID != teamID) {

--- a/manager/pkg/nomadclaim/template_capture.go
+++ b/manager/pkg/nomadclaim/template_capture.go
@@ -220,7 +220,12 @@ func (s *Service) nomadTemplateCaptureMetadata(
 	if _, err := s.effectiveResources(desiredSpec, nil); err != nil {
 		return nil, err
 	}
-	runtimeClass, err := s.runtimeClasses.Resolve("")
+	securityClass, ok := v1alpha1.EffectiveSandboxSecurityClass(desiredSpec.MainContainer.SecurityClass)
+	if !ok {
+		return nil, fmt.Errorf("%w: captured template security class is invalid",
+			templatepkg.ErrTemplateSourceUnavailable)
+	}
+	runtimeClass, err := s.runtimeClasses.Resolve("", string(securityClass))
 	if err != nil {
 		return nil, fmt.Errorf("%w: no unambiguous Nomad runtime class for captured template",
 			templatepkg.ErrTemplateSourceUnavailable)

--- a/manager/pkg/runtimeslotclaim/planner_test.go
+++ b/manager/pkg/runtimeslotclaim/planner_test.go
@@ -401,7 +401,7 @@ func newPlannerFixture(t *testing.T) *plannerFixture {
 		CompatibilityDigest: store.slot.CompatibilityDigest, ClusterID: store.slot.ClusterID,
 		NetworkPolicy: `{"version":"v1","sandboxId":"sandbox-1","teamId":"team-1","mode":"allow-all"}`,
 		Runtime: runtimecontrol.Assignment{
-			SandboxID: "sandbox-1", TeamID: "team-1", RuntimeGeneration: 19,
+			SandboxID: "sandbox-1", TeamID: "team-1", RuntimeGeneration: 19, SecurityClass: "standard",
 			EnvVars: map[string]string{runtimecontrol.EnvSandboxID: "sandbox-1", "MODE": "test"},
 		},
 		Resources: protocol.RuntimeResourceRequest{

--- a/manager/pkg/runtimeslotnode/channel_test.go
+++ b/manager/pkg/runtimeslotnode/channel_test.go
@@ -718,7 +718,7 @@ func testChannelClaimRequest() protocol.NodeClaimControlRequest {
 	networkPolicy := `{"mode":"block-all"}`
 	token := strings.Repeat("writer-token-", 4)
 	assignment := &runtimecontrol.Assignment{
-		SandboxID: "sandbox-1", TeamID: "team-1", RuntimeGeneration: 1,
+		SandboxID: "sandbox-1", TeamID: "team-1", RuntimeGeneration: 1, SecurityClass: "standard",
 		EnvVars: map[string]string{runtimecontrol.EnvSandboxID: "sandbox-1"},
 	}
 	revision, _ := assignment.Revision()

--- a/manager/procd/pkg/runtimecontroller/controller_test.go
+++ b/manager/procd/pkg/runtimecontroller/controller_test.go
@@ -23,6 +23,7 @@ func TestControllerActivatesImmutableAssignment(t *testing.T) {
 	assignment := runtimecontrol.Assignment{
 		SandboxID:         "sandbox-1",
 		RuntimeGeneration: 2,
+		SecurityClass:     "standard",
 		EnvVars:           map[string]string{runtimecontrol.EnvSandboxID: "sandbox-1", "MODE": "test"},
 	}
 	if err := controller.Activate(context.Background(), assignment); err != nil {
@@ -70,6 +71,7 @@ func TestControllerFailsClosedOnCopiedSessionStateWithoutExplicitReset(t *testin
 	assignment := runtimecontrol.Assignment{
 		SandboxID:         "target-sandbox",
 		RuntimeGeneration: 1,
+		SecurityClass:     "standard",
 	}
 	if err := controller.Activate(context.Background(), assignment); err == nil {
 		t.Fatal("Activate() accepted copied state without an explicit reset")
@@ -90,6 +92,7 @@ func TestFreshProcdRecoversImmutableAssignmentWithoutExternalRequest(t *testing.
 	assignment := runtimecontrol.Assignment{
 		SandboxID:         "sandbox-1",
 		RuntimeGeneration: 4,
+		SecurityClass:     "standard",
 	}
 
 	activate := func() {

--- a/manager/procd/pkg/runtimecontroller/static_test.go
+++ b/manager/procd/pkg/runtimecontroller/static_test.go
@@ -65,7 +65,7 @@ func TestAssignmentFromEnvRejectsMalformedInput(t *testing.T) {
 
 func testStaticAssignment() runtimecontrol.Assignment {
 	return runtimecontrol.Assignment{
-		SandboxID: "sandbox-1", TeamID: "team-1", RuntimeGeneration: 3,
+		SandboxID: "sandbox-1", TeamID: "team-1", RuntimeGeneration: 3, SecurityClass: "standard",
 		EnvVars: map[string]string{runtimecontrol.EnvSandboxID: "sandbox-1", "MODE": "test"},
 	}
 }

--- a/nomad-driver-sandbox0/README.md
+++ b/nomad-driver-sandbox0/README.md
@@ -56,8 +56,15 @@ contains immutable execution inputs only:
 - security class.
 
 CPU and memory do not belong in the digest. The checked-in outer class catalog
-format is version `3`; each compatibility entry is version `2`. Until a public
-selector exists, configure one class per requested cluster.
+format is version `3`; each compatibility entry is version `2`. A cluster may
+publish both `standard` and `privileged` classes. The template
+`mainContainer.securityClass` selects one exact class; omitting it selects
+`standard`.
+
+`privileged` grants Linux capabilities only inside the gVisor guest kernel; it
+does not bypass runsc or expose host devices. Template `ephemeralMounts` become
+size-bounded guest tmpfs mounts and are intentionally absent from every
+durable RootFS generation.
 
 ## RootFS And Failure Safety
 

--- a/nomad-driver-sandbox0/example/runtime-classes.example.json
+++ b/nomad-driver-sandbox0/example/runtime-classes.example.json
@@ -22,6 +22,28 @@
         "runtime_mode": "static",
         "security_class": "standard"
       }
+    },
+    {
+      "name": "linux-amd64-systrap-privileged",
+      "cluster_id": "cluster-1",
+      "artifact_platform": {
+        "os": "linux",
+        "architecture": "amd64"
+      },
+      "compatibility": {
+        "version": 2,
+        "architecture": "amd64",
+        "driver_version": "0.1.0",
+        "runsc_version": "runsc release-20260820.0",
+        "platform": "systrap",
+        "overlay2": "none",
+        "file_access": "shared",
+        "directfs": true,
+        "command": "/procd",
+        "procd_port": 49983,
+        "runtime_mode": "static",
+        "security_class": "privileged"
+      }
     }
   ]
 }

--- a/nomad-driver-sandbox0/example/warm-slot.nomad
+++ b/nomad-driver-sandbox0/example/warm-slot.nomad
@@ -10,7 +10,7 @@ job "sandbox0-warm-slots" {
     value     = "true"
   }
 
-  group "warm" {
+  group "standard" {
     # Eight is the minimum pool width used by the production acceptance gate.
     # Keep replacement capacity and the matching ctld NBD pool at least this
     # wide when changing this value.
@@ -39,12 +39,45 @@ job "sandbox0-warm-slots" {
       config {
         command        = "/procd"
         args           = []
+        security_class = "standard"
       }
 
       resources {
         # These values reserve only the carrier/driver overhead. They are not
         # the sandbox limit and must not be copied into OCI. Manager leases
         # sandbox CPU and memory from ctld-reported dedicated-node capacity.
+        cpu    = 50
+        memory = 64
+      }
+    }
+  }
+
+  group "privileged" {
+    count = 2
+
+    restart {
+      attempts = 0
+      mode     = "fail"
+    }
+
+    network {
+      mode = "bridge"
+
+      port "procd" {
+        to = 49983
+      }
+    }
+
+    task "slot" {
+      driver = "sandbox0-gvisor"
+
+      config {
+        command        = "/procd"
+        args           = []
+        security_class = "privileged"
+      }
+
+      resources {
         cpu    = 50
         memory = 64
       }

--- a/nomad-driver-sandbox0/internal/driver/handle.go
+++ b/nomad-driver-sandbox0/internal/driver/handle.go
@@ -350,6 +350,7 @@ func (h *taskHandle) writeClaimBundle(
 	procdPort := h.procdPort
 	h.mu.Unlock()
 	var runtimeEnv []string
+	var ephemeralMounts []runtimecontrol.EphemeralMount
 	if assignment != nil {
 		if procdPort != protocol.NomadProcdPort {
 			return fmt.Errorf("static procd port must be %d", protocol.NomadProcdPort)
@@ -364,6 +365,7 @@ func (h *taskHandle) writeClaimBundle(
 			runtimecontrol.EnvControlMode + "=" + runtimecontrol.ControlModeStatic,
 			runtimecontrol.EnvStaticAssignment + "=" + string(payload),
 		}
+		ephemeralMounts = append([]runtimecontrol.EphemeralMount(nil), assignment.EphemeralMounts...)
 	}
 	spec := buildSpec(specOptions{
 		Command:                       command,
@@ -374,6 +376,8 @@ func (h *taskHandle) writeClaimBundle(
 		NetNSPath:                     netnsPath,
 		ProcdInternalJWTPublicKeyFile: h.procdInternalJWTPublicKeyFile,
 		Resources:                     resources,
+		SecurityClass:                 h.driverConfig.SecurityClass,
+		EphemeralMounts:               ephemeralMounts,
 	})
 	if err := writeBundle(h.bundleDir, spec); err != nil {
 		return err
@@ -458,6 +462,10 @@ func (h *taskHandle) Claim(request ClaimRequest) (resultErr error) {
 	if err != nil {
 		h.setPhase(phaseWarm)
 		return fmt.Errorf("derive static runtime assignment revision: %w: %w", err, errdefs.ErrInvalidArgument)
+	}
+	if request.Runtime.SecurityClass != h.driverConfig.SecurityClass {
+		h.setPhase(phaseWarm)
+		return fmt.Errorf("runtime assignment security class does not match the warm slot: %w", errdefs.ErrInvalidArgument)
 	}
 	rootfsSource := ""
 	allowedRoot := h.rootfsAllowedRoot

--- a/nomad-driver-sandbox0/internal/driver/oci.go
+++ b/nomad-driver-sandbox0/internal/driver/oci.go
@@ -166,7 +166,9 @@ func buildSpec(options specOptions) specs.Spec {
 }
 
 var standardCapabilities = []string{
-	"CAP_AUDIT_WRITE", "CAP_KILL", "CAP_NET_BIND_SERVICE",
+	"CAP_AUDIT_WRITE", "CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FOWNER", "CAP_FSETID",
+	"CAP_KILL", "CAP_MKNOD", "CAP_NET_BIND_SERVICE", "CAP_NET_RAW", "CAP_SETFCAP",
+	"CAP_SETGID", "CAP_SETPCAP", "CAP_SETUID", "CAP_SYS_CHROOT",
 }
 
 // privilegedCapabilities are guest-kernel capabilities. runsc still keeps

--- a/nomad-driver-sandbox0/internal/driver/oci.go
+++ b/nomad-driver-sandbox0/internal/driver/oci.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sandbox0-ai/sandbox0/pkg/runtimecontrol"
+	"github.com/sandbox0-ai/sandbox0/pkg/sandboxspec"
 )
 
 type specOptions struct {
@@ -32,6 +34,8 @@ type specOptions struct {
 	NetNSPath                     string
 	ProcdInternalJWTPublicKeyFile string
 	Resources                     *driversResources
+	SecurityClass                 string
+	EphemeralMounts               []runtimecontrol.EphemeralMount
 }
 
 const procdInternalJWTPublicKeyDestination = "/config/internal_jwt_public.key"
@@ -48,6 +52,10 @@ type driversResources struct {
 }
 
 func buildSpec(options specOptions) specs.Spec {
+	capabilities := standardCapabilities
+	if options.SecurityClass == string(sandboxspec.SandboxSecurityClassPrivileged) {
+		capabilities = privilegedCapabilities
+	}
 	process := specs.Process{
 		User: specs.User{UID: 0, GID: 0},
 		Args: append([]string{options.Command}, options.Args...),
@@ -57,10 +65,10 @@ func buildSpec(options specOptions) specs.Spec {
 		},
 		Cwd: "/",
 		Capabilities: &specs.LinuxCapabilities{
-			Bounding:    []string{"CAP_AUDIT_WRITE", "CAP_KILL", "CAP_NET_BIND_SERVICE"},
-			Effective:   []string{"CAP_AUDIT_WRITE", "CAP_KILL", "CAP_NET_BIND_SERVICE"},
+			Bounding:    append([]string(nil), capabilities...),
+			Effective:   append([]string(nil), capabilities...),
 			Inheritable: []string{},
-			Permitted:   []string{"CAP_AUDIT_WRITE", "CAP_KILL", "CAP_NET_BIND_SERVICE"},
+			Permitted:   append([]string(nil), capabilities...),
 			Ambient:     []string{},
 		},
 		Rlimits: []specs.POSIXRlimit{{Type: "RLIMIT_NOFILE", Hard: 1024, Soft: 1024}},
@@ -110,8 +118,28 @@ func buildSpec(options specOptions) specs.Spec {
 
 	mounts := []specs.Mount{
 		{Destination: "/proc", Type: "proc", Source: "proc"},
-		{Destination: "/dev", Type: "tmpfs", Source: "tmpfs"},
+		{Destination: "/dev", Type: "tmpfs", Source: "tmpfs", Options: []string{"nosuid", "strictatime", "mode=755", "size=65536k"}},
+		{Destination: "/dev/pts", Type: "devpts", Source: "devpts", Options: []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620"}},
+		{Destination: "/dev/shm", Type: "tmpfs", Source: "shm", Options: []string{"nosuid", "noexec", "nodev", "mode=1777", "size=67108864"}},
+		{Destination: "/dev/mqueue", Type: "mqueue", Source: "mqueue", Options: []string{"nosuid", "noexec", "nodev"}},
 		{Destination: "/sys", Type: "sysfs", Source: "sysfs", Options: []string{"nosuid", "noexec", "nodev", "ro"}},
+	}
+	for _, mount := range options.EphemeralMounts {
+		ephemeral := specs.Mount{
+			Destination: mount.MountPath, Type: "tmpfs", Source: "tmpfs",
+			Options: []string{"nosuid", "nodev", "mode=1777", fmt.Sprintf("size=%d", mount.SizeBytes)},
+		}
+		if mount.MountPath == "/dev/shm" {
+			ephemeral.Source = "shm"
+			ephemeral.Options = append(ephemeral.Options, "noexec")
+			for index := range mounts {
+				if mounts[index].Destination == mount.MountPath {
+					mounts[index] = ephemeral
+				}
+			}
+			continue
+		}
+		mounts = append(mounts, ephemeral)
 	}
 	if options.ProcdInternalJWTPublicKeyFile != "" {
 		mounts = append(mounts, specs.Mount{
@@ -135,6 +163,24 @@ func buildSpec(options specOptions) specs.Spec {
 			"com.sandbox0.slot-state": "created",
 		},
 	}
+}
+
+var standardCapabilities = []string{
+	"CAP_AUDIT_WRITE", "CAP_KILL", "CAP_NET_BIND_SERVICE",
+}
+
+// privilegedCapabilities are guest-kernel capabilities. runsc still keeps
+// the process inside the gVisor sandbox and never grants host-kernel access.
+var privilegedCapabilities = []string{
+	"CAP_AUDIT_CONTROL", "CAP_AUDIT_READ", "CAP_AUDIT_WRITE", "CAP_BLOCK_SUSPEND",
+	"CAP_BPF", "CAP_CHECKPOINT_RESTORE", "CAP_CHOWN", "CAP_DAC_OVERRIDE",
+	"CAP_DAC_READ_SEARCH", "CAP_FOWNER", "CAP_FSETID", "CAP_IPC_LOCK", "CAP_IPC_OWNER",
+	"CAP_KILL", "CAP_LEASE", "CAP_LINUX_IMMUTABLE", "CAP_MAC_ADMIN", "CAP_MAC_OVERRIDE",
+	"CAP_MKNOD", "CAP_NET_ADMIN", "CAP_NET_BIND_SERVICE", "CAP_NET_BROADCAST", "CAP_NET_RAW",
+	"CAP_PERFMON", "CAP_SETFCAP", "CAP_SETGID", "CAP_SETPCAP", "CAP_SETUID", "CAP_SYS_ADMIN",
+	"CAP_SYS_BOOT", "CAP_SYS_CHROOT", "CAP_SYS_MODULE", "CAP_SYS_NICE", "CAP_SYS_PACCT",
+	"CAP_SYS_PTRACE", "CAP_SYS_RAWIO", "CAP_SYS_RESOURCE", "CAP_SYS_TIME", "CAP_SYS_TTY_CONFIG",
+	"CAP_SYSLOG", "CAP_WAKE_ALARM",
 }
 
 func writeBundle(bundleDir string, spec specs.Spec) error {

--- a/nomad-driver-sandbox0/internal/driver/oci_test.go
+++ b/nomad-driver-sandbox0/internal/driver/oci_test.go
@@ -74,6 +74,10 @@ func TestBuildSpecAppliesSecurityClassAndEphemeralMounts(t *testing.T) {
 	if containsCapability(standard.Process.Capabilities.Effective, "CAP_SYS_ADMIN") {
 		t.Fatal("standard class received CAP_SYS_ADMIN")
 	}
+	if !containsCapability(standard.Process.Capabilities.Effective, "CAP_CHOWN") ||
+		!containsCapability(standard.Process.Capabilities.Effective, "CAP_SETUID") {
+		t.Fatalf("standard OCI capabilities = %#v", standard.Process.Capabilities)
+	}
 	privileged := buildSpec(specOptions{
 		Command: "/procd", SecurityClass: "privileged",
 		EphemeralMounts: []runtimecontrol.EphemeralMount{

--- a/nomad-driver-sandbox0/internal/driver/oci_test.go
+++ b/nomad-driver-sandbox0/internal/driver/oci_test.go
@@ -17,6 +17,9 @@ package driver
 import (
 	"strings"
 	"testing"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sandbox0-ai/sandbox0/pkg/runtimecontrol"
 )
 
 func TestRuntimeLeaseCgroupsPathIsRelativeToUnifiedMount(t *testing.T) {
@@ -59,9 +62,63 @@ func TestBuildSpecAppliesExactRuntimeResourceLease(t *testing.T) {
 		spec.Linux.CgroupsPath != "/sandbox0/s0-lease" {
 		t.Fatalf("OCI PIDs/cgroup resources = %+v", spec.Linux)
 	}
-	if len(spec.Mounts) != 4 || spec.Mounts[3].Source != "/etc/sandbox0/internal-auth/data-public.pem" ||
-		spec.Mounts[3].Destination != procdInternalJWTPublicKeyDestination ||
-		!strings.Contains(strings.Join(spec.Mounts[3].Options, ","), "ro") {
+	keyMount := findOCIMount(spec.Mounts, procdInternalJWTPublicKeyDestination)
+	if keyMount == nil || keyMount.Source != "/etc/sandbox0/internal-auth/data-public.pem" ||
+		!strings.Contains(strings.Join(keyMount.Options, ","), "ro") {
 		t.Fatalf("OCI procd internal JWT public-key mount = %+v", spec.Mounts)
 	}
+}
+
+func TestBuildSpecAppliesSecurityClassAndEphemeralMounts(t *testing.T) {
+	standard := buildSpec(specOptions{Command: "/procd", SecurityClass: "standard"})
+	if containsCapability(standard.Process.Capabilities.Effective, "CAP_SYS_ADMIN") {
+		t.Fatal("standard class received CAP_SYS_ADMIN")
+	}
+	privileged := buildSpec(specOptions{
+		Command: "/procd", SecurityClass: "privileged",
+		EphemeralMounts: []runtimecontrol.EphemeralMount{
+			{MountPath: "/var/lib/docker", SizeBytes: 16 << 30},
+			{MountPath: "/dev/shm", SizeBytes: 2 << 30},
+		},
+	})
+	if !containsCapability(privileged.Process.Capabilities.Effective, "CAP_SYS_ADMIN") ||
+		!containsCapability(privileged.Process.Capabilities.Bounding, "CAP_NET_ADMIN") {
+		t.Fatalf("privileged capabilities = %#v", privileged.Process.Capabilities)
+	}
+	dockerMount := findOCIMount(privileged.Mounts, "/var/lib/docker")
+	if dockerMount == nil || !containsString(dockerMount.Options, "size=17179869184") {
+		t.Fatalf("Docker ephemeral mount = %#v", dockerMount)
+	}
+	shmCount := 0
+	for _, mount := range privileged.Mounts {
+		if mount.Destination == "/dev/shm" {
+			shmCount++
+			if !containsString(mount.Options, "size=2147483648") {
+				t.Fatalf("shm mount = %#v", mount)
+			}
+		}
+	}
+	if shmCount != 1 {
+		t.Fatalf("shm mount count = %d", shmCount)
+	}
+}
+
+func findOCIMount(mounts []specs.Mount, destination string) *specs.Mount {
+	for index := range mounts {
+		if mounts[index].Destination == destination {
+			return &mounts[index]
+		}
+	}
+	return nil
+}
+
+func containsCapability(values []string, target string) bool { return containsString(values, target) }
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }

--- a/nomad-driver-sandbox0/internal/driver/plugin.go
+++ b/nomad-driver-sandbox0/internal/driver/plugin.go
@@ -34,6 +34,7 @@ import (
 	"github.com/hashicorp/nomad/plugins/shared/structs"
 	"github.com/sandbox0-ai/sandbox0/pkg/internalauth"
 	protocol "github.com/sandbox0-ai/sandbox0/pkg/runtimeslot"
+	"github.com/sandbox0-ai/sandbox0/pkg/sandboxspec"
 )
 
 const (
@@ -86,10 +87,6 @@ var (
 			hclspec.NewAttr("directfs", "bool", false),
 			hclspec.NewLiteral(`true`),
 		),
-		"security_class": hclspec.NewDefault(
-			hclspec.NewAttr("security_class", "string", false),
-			hclspec.NewLiteral(`"standard"`),
-		),
 		"resource_cgroup_root": hclspec.NewDefault(
 			hclspec.NewAttr("resource_cgroup_root", "string", false),
 			hclspec.NewLiteral(`"/sys/fs/cgroup/sandbox0"`),
@@ -117,6 +114,10 @@ var (
 			hclspec.NewLiteral(`"/procd"`),
 		),
 		"args": hclspec.NewAttr("args", "list(string)", false),
+		"security_class": hclspec.NewDefault(
+			hclspec.NewAttr("security_class", "string", false),
+			hclspec.NewLiteral(`"standard"`),
+		),
 	})
 
 	capabilities = &drivers.Capabilities{
@@ -138,7 +139,6 @@ type PluginConfig struct {
 	Overlay2                      string `codec:"overlay2"`
 	FileAccess                    string `codec:"file_access"`
 	DirectFS                      bool   `codec:"directfs"`
-	SecurityClass                 string `codec:"security_class"`
 	ResourceCgroupRoot            string `codec:"resource_cgroup_root"`
 	RootFSNodeSocket              string `codec:"rootfs_node_socket"`
 	RootFSAuthorityURL            string `codec:"rootfs_authority_url"`
@@ -154,8 +154,9 @@ type PluginConfig struct {
 
 // TaskConfig is the per-allocation driver configuration.
 type TaskConfig struct {
-	Command string   `codec:"command"`
-	Args    []string `codec:"args"`
+	Command       string   `codec:"command"`
+	Args          []string `codec:"args"`
+	SecurityClass string   `codec:"security_class"`
 }
 
 // Plugin implements a Nomad task driver for generic gVisor warm slots.
@@ -210,7 +211,6 @@ func defaultPluginConfig() *PluginConfig {
 		Overlay2:                     "none",
 		FileAccess:                   "shared",
 		DirectFS:                     true,
-		SecurityClass:                "standard",
 		ResourceCgroupRoot:           protocol.RuntimeResourceCgroupRoot,
 		RootFSNodeSocket:             "/run/sandbox0/ctld-nomad-runtime.sock",
 		RuntimeSlotNodeBootIDFile:    "/proc/sys/kernel/random/boot_id",
@@ -244,7 +244,6 @@ func (p *Plugin) SetConfig(config *base.Config) error {
 	decoded.Platform = strings.TrimSpace(decoded.Platform)
 	decoded.Overlay2 = strings.TrimSpace(decoded.Overlay2)
 	decoded.FileAccess = strings.TrimSpace(decoded.FileAccess)
-	decoded.SecurityClass = strings.TrimSpace(decoded.SecurityClass)
 	decoded.ResourceCgroupRoot = strings.TrimSpace(decoded.ResourceCgroupRoot)
 	if decoded.RunscPath == "" || decoded.RunscRoot == "" || decoded.ControlDir == "" {
 		return errors.New("runsc, control, and rootfs paths must be non-empty")
@@ -265,8 +264,8 @@ func (p *Plugin) SetConfig(config *base.Config) error {
 	if !filepath.IsAbs(decoded.RunscPath) || !filepath.IsAbs(decoded.RunscRoot) || !filepath.IsAbs(decoded.ControlDir) {
 		return errors.New("runsc and control paths must be absolute")
 	}
-	if decoded.Platform == "" || decoded.Overlay2 == "" || decoded.FileAccess == "" || decoded.SecurityClass == "" {
-		return errors.New("platform, overlay2, file_access, and security_class cannot be empty")
+	if decoded.Platform == "" || decoded.Overlay2 == "" || decoded.FileAccess == "" {
+		return errors.New("platform, overlay2, and file_access cannot be empty")
 	}
 	if decoded.Overlay2 != "none" {
 		return errors.New("sandbox0 gVisor driver requires overlay2=none for persistent upper writes")
@@ -408,14 +407,7 @@ func (p *Plugin) StartTask(config *drivers.TaskConfig) (*drivers.TaskHandle, *dr
 	if err := config.DecodeDriverConfig(&taskConfig); err != nil {
 		return nil, nil, fmt.Errorf("decode task config: %w", err)
 	}
-	taskConfig.Command = strings.TrimSpace(taskConfig.Command)
-	if taskConfig.Command == "" {
-		taskConfig.Command = "/procd"
-	}
-	if !filepath.IsAbs(taskConfig.Command) {
-		return nil, nil, errors.New("task command must be absolute")
-	}
-	if err := validateRuntimeSlotTaskConfig(p.config, taskConfig); err != nil {
+	if err := normalizeRuntimeSlotTaskConfig(p.config, &taskConfig); err != nil {
 		return nil, nil, err
 	}
 
@@ -502,14 +494,7 @@ func (p *Plugin) RecoverTask(handle *drivers.TaskHandle) error {
 	if err := handle.Config.DecodeDriverConfig(&taskConfig); err != nil {
 		return fmt.Errorf("decode recovered task config: %w", err)
 	}
-	taskConfig.Command = strings.TrimSpace(taskConfig.Command)
-	if taskConfig.Command == "" {
-		taskConfig.Command = "/procd"
-	}
-	if !filepath.IsAbs(taskConfig.Command) {
-		return errors.New("recovered task command must be absolute")
-	}
-	if err := validateRuntimeSlotTaskConfig(p.config, taskConfig); err != nil {
+	if err := normalizeRuntimeSlotTaskConfig(p.config, &taskConfig); err != nil {
 		return err
 	}
 	if state.TaskConfig.ID != handle.Config.ID || state.TaskConfig.AllocID != handle.Config.AllocID {
@@ -575,6 +560,23 @@ func (p *Plugin) WaitTask(ctx context.Context, taskID string) (<-chan *drivers.E
 		return nil, drivers.ErrTaskNotFound
 	}
 	return handle.WaitChannel(ctx), nil
+}
+func normalizeRuntimeSlotTaskConfig(config *PluginConfig, task *TaskConfig) error {
+	if task == nil {
+		return errors.New("task driver config is required")
+	}
+	task.Command = strings.TrimSpace(task.Command)
+	task.SecurityClass = strings.TrimSpace(task.SecurityClass)
+	if task.Command == "" {
+		task.Command = "/procd"
+	}
+	if task.SecurityClass == "" {
+		task.SecurityClass = string(sandboxspec.SandboxSecurityClassStandard)
+	}
+	if !filepath.IsAbs(task.Command) {
+		return errors.New("task command must be absolute")
+	}
+	return validateRuntimeSlotTaskConfig(config, *task)
 }
 
 // StopTask stops a warm or active one-shot gVisor container.

--- a/nomad-driver-sandbox0/internal/driver/runtime_slot.go
+++ b/nomad-driver-sandbox0/internal/driver/runtime_slot.go
@@ -36,6 +36,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/rootfshandoff"
 	"github.com/sandbox0-ai/sandbox0/pkg/runtimecontrol"
 	protocol "github.com/sandbox0-ai/sandbox0/pkg/runtimeslot"
+	"github.com/sandbox0-ai/sandbox0/pkg/sandboxspec"
 	"golang.org/x/sys/unix"
 )
 
@@ -163,6 +164,10 @@ func validateRuntimeSlotTaskConfig(config *PluginConfig, task TaskConfig) error 
 	if task.Command != "/procd" || len(task.Args) != 0 {
 		return fmt.Errorf("regional runtime slots require command=/procd without arguments")
 	}
+	securityClass, ok := sandboxspec.EffectiveSandboxSecurityClass(sandboxspec.SandboxSecurityClass(task.SecurityClass))
+	if !ok || string(securityClass) != task.SecurityClass {
+		return fmt.Errorf("regional runtime slot security class is unsupported")
+	}
 	return nil
 }
 
@@ -285,7 +290,7 @@ func newRuntimeSlotLifecycle(
 	if err != nil {
 		return nil, fmt.Errorf("read runtime slot mount namespace: %w", err)
 	}
-	compatibility, err := runtimeCompatibilityDigest(config, task, runscVersion)
+	compatibility, err := runtimeCompatibilityDigest(config, task, handle.driverConfig.SecurityClass, runscVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -710,7 +715,7 @@ func runtimeSlotHeartbeatDelay(leaseWindow time.Duration) time.Duration {
 	return delay
 }
 
-func runtimeCompatibilityDigest(config *PluginConfig, task *drivers.TaskConfig, runscVersion string) (string, error) {
+func runtimeCompatibilityDigest(config *PluginConfig, task *drivers.TaskConfig, securityClass, runscVersion string) (string, error) {
 	if task == nil {
 		return "", fmt.Errorf("runtime slot task is required: %w", errdefs.ErrInvalidArgument)
 	}
@@ -719,7 +724,7 @@ func runtimeCompatibilityDigest(config *PluginConfig, task *drivers.TaskConfig, 
 		DriverVersion: PluginVersion, RunscVersion: strings.TrimSpace(runscVersion),
 		Platform: config.Platform, Overlay2: config.Overlay2, FileAccess: config.FileAccess,
 		DirectFS: config.DirectFS, Command: "/procd", ProcdPort: protocol.NomadProcdPort,
-		RuntimeMode: runtimecontrol.ControlModeStatic, SecurityClass: config.SecurityClass,
+		RuntimeMode: runtimecontrol.ControlModeStatic, SecurityClass: securityClass,
 	}).Digest()
 }
 

--- a/nomad-driver-sandbox0/internal/driver/runtime_slot_test.go
+++ b/nomad-driver-sandbox0/internal/driver/runtime_slot_test.go
@@ -303,7 +303,7 @@ func newRuntimeSlotPluginFixture(t *testing.T) *runtimeSlotPluginFixture {
 		Name: protocol.NomadTaskName, AllocDir: filepath.Join(tempDir, "allocation"),
 		Env: map[string]string{
 			"NOMAD_ALLOC_ADDR_" + protocol.NomadProcdPortLabel: "172.26.64.2:49983",
-			"UNTRUSTED_TASK_ENV":                               "must-not-enter-procd",
+			"UNTRUSTED_TASK_ENV": "must-not-enter-procd",
 		},
 		Resources: &drivers.Resources{
 			NomadResources: &structs.AllocatedTaskResources{

--- a/nomad-driver-sandbox0/internal/driver/runtime_slot_test.go
+++ b/nomad-driver-sandbox0/internal/driver/runtime_slot_test.go
@@ -303,7 +303,7 @@ func newRuntimeSlotPluginFixture(t *testing.T) *runtimeSlotPluginFixture {
 		Name: protocol.NomadTaskName, AllocDir: filepath.Join(tempDir, "allocation"),
 		Env: map[string]string{
 			"NOMAD_ALLOC_ADDR_" + protocol.NomadProcdPortLabel: "172.26.64.2:49983",
-			"UNTRUSTED_TASK_ENV": "must-not-enter-procd",
+			"UNTRUSTED_TASK_ENV":                               "must-not-enter-procd",
 		},
 		Resources: &drivers.Resources{
 			NomadResources: &structs.AllocatedTaskResources{
@@ -624,7 +624,7 @@ func runtimeSlotResourceLease(
 
 func runtimeSlotAssignment() *runtimecontrol.Assignment {
 	return &runtimecontrol.Assignment{
-		SandboxID: "sandbox-1", TeamID: "team-1", RuntimeGeneration: 1,
+		SandboxID: "sandbox-1", TeamID: "team-1", RuntimeGeneration: 1, SecurityClass: "standard",
 		EnvVars: map[string]string{runtimecontrol.EnvSandboxID: "sandbox-1"},
 	}
 }
@@ -918,6 +918,33 @@ func TestRuntimeSlotClaimRequiresRegionalIdentityBeforeConsumingWriter(t *testin
 	}
 	if phase := handle.TaskStatus().DriverAttributes["phase"]; phase != string(phaseWarm) {
 		t.Fatalf("phase = %s, want reusable warm slot before writer consumption", phase)
+	}
+	if err := fixture.plugin.DestroyTask(fixture.task.ID, true); err != nil {
+		t.Fatalf("DestroyTask() error = %v", err)
+	}
+}
+
+func TestRuntimeSlotClaimRejectsAnotherSecurityClassBeforeConsumingWriter(t *testing.T) {
+	fixture := newRuntimeSlotPluginFixture(t)
+	handle, stage, token, networkPolicy, _ := prepareRuntimeSlotClaim(t, fixture)
+	assignment := runtimeSlotAssignment()
+	assignment.SecurityClass = "privileged"
+	revision, err := assignment.Revision()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stage.Labels[protocol.RuntimeAssignmentRevisionLabel] = revision
+	err = handle.Claim(ClaimRequest{
+		OperationID: "operation-1", ClaimID: "claim-1", PolicyToken: token, WriterEpoch: "1",
+		Stage: &stage, NetworkPolicy: networkPolicy, Runtime: assignment,
+		Resources: runtimeSlotResourceLease(t, fixture, stage),
+	})
+	if err == nil || !strings.Contains(err.Error(), "security class does not match") {
+		t.Fatalf("Claim() error = %v", err)
+	}
+	ensureCalls, retireCalls, _, _ := fixture.rootfs.snapshot()
+	if ensureCalls != 0 || retireCalls != 0 {
+		t.Fatalf("RootFS calls = ensure %d retire %d, mismatched class consumed writer", ensureCalls, retireCalls)
 	}
 	if err := fixture.plugin.DestroyTask(fixture.task.ID, true); err != nil {
 		t.Fatalf("DestroyTask() error = %v", err)
@@ -1315,7 +1342,8 @@ func TestRuntimeSlotNetNSReplacementChangesReadinessIdentity(t *testing.T) {
 	fixture := newRuntimeSlotPluginFixture(t)
 	handle := newTaskHandle(taskHandleOptions{
 		taskConfig: fixture.task, bundleDir: filepath.Join(t.TempDir(), "bundle"),
-		containerID: safeContainerID(fixture.task.ID), rootMount: filepath.Join(t.TempDir(), "root"),
+		driverConfig: TaskConfig{Command: "/procd", SecurityClass: "standard"},
+		containerID:  safeContainerID(fixture.task.ID), rootMount: filepath.Join(t.TempDir(), "root"),
 		socketPath: controlSocketPath(fixture.config.ControlDir, fixture.task.ID), runner: fixture.runner,
 		mounter: &fakeMounter{}, rootfs: fixture.rootfs, logger: hclog.NewNullLogger(),
 	})
@@ -1351,8 +1379,9 @@ func TestValidateRuntimeSlotTaskConfigRequiresGenericProcdSlot(t *testing.T) {
 		name string
 		task TaskConfig
 	}{
-		{name: "different command", task: TaskConfig{Command: "/bin/sh"}},
-		{name: "arguments", task: TaskConfig{Command: "/procd", Args: []string{"--unsafe"}}},
+		{name: "different command", task: TaskConfig{Command: "/bin/sh", SecurityClass: "standard"}},
+		{name: "arguments", task: TaskConfig{Command: "/procd", Args: []string{"--unsafe"}, SecurityClass: "standard"}},
+		{name: "unknown security class", task: TaskConfig{Command: "/procd", SecurityClass: "host"}},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -1361,7 +1390,7 @@ func TestValidateRuntimeSlotTaskConfigRequiresGenericProcdSlot(t *testing.T) {
 			}
 		})
 	}
-	if err := validateRuntimeSlotTaskConfig(config, TaskConfig{Command: "/procd"}); err != nil {
+	if err := validateRuntimeSlotTaskConfig(config, TaskConfig{Command: "/procd", SecurityClass: "standard"}); err != nil {
 		t.Fatalf("valid regional runtime slot task was rejected: %v", err)
 	}
 }
@@ -1385,16 +1414,23 @@ func TestRuntimeCompatibilityDigestIgnoresCarrierResources(t *testing.T) {
 			CPUShares: 2, CpusetCpus: "0-7", MemoryLimitBytes: 64 * 1024 * 1024,
 		},
 	}}
-	digest, err := runtimeCompatibilityDigest(defaultPluginConfig(), first, "runsc version test")
+	digest, err := runtimeCompatibilityDigest(defaultPluginConfig(), first, "standard", "runsc version test")
 	if err != nil {
 		t.Fatalf("runtimeCompatibilityDigest() error = %v", err)
 	}
-	secondDigest, err := runtimeCompatibilityDigest(defaultPluginConfig(), second, "runsc version test")
+	secondDigest, err := runtimeCompatibilityDigest(defaultPluginConfig(), second, "standard", "runsc version test")
 	if err != nil {
 		t.Fatalf("runtimeCompatibilityDigest(second) error = %v", err)
 	}
 	if digest != secondDigest {
 		t.Fatalf("carrier resources changed compatibility: %q != %q", digest, secondDigest)
+	}
+	privilegedDigest, err := runtimeCompatibilityDigest(defaultPluginConfig(), first, "privileged", "runsc version test")
+	if err != nil {
+		t.Fatalf("privileged runtimeCompatibilityDigest() error = %v", err)
+	}
+	if privilegedDigest == digest {
+		t.Fatal("security class did not change runtime compatibility")
 	}
 	wantDigest, err := (protocol.RuntimeCompatibility{
 		Version: protocol.RuntimeCompatibilityVersion, Architecture: runtime.GOARCH,

--- a/pkg/apispec/openapi.yaml
+++ b/pkg/apispec/openapi.yaml
@@ -6934,6 +6934,11 @@ components:
             type: string
         mainContainer:
           $ref: "#/components/schemas/ContainerSpec"
+        ephemeralMounts:
+          type: array
+          description: Claim-lifetime tmpfs mounts excluded from pause, resume, fork, and snapshot RootFS generations.
+          items:
+            $ref: "#/components/schemas/EphemeralMountSpec"
         network:
           $ref: "#/components/schemas/SandboxNetworkPolicy"
         envVars:
@@ -6954,7 +6959,23 @@ components:
             $ref: "#/components/schemas/EnvVar"
         resources:
           $ref: "#/components/schemas/ResourceQuota"
+        securityClass:
+          type: string
+          enum: [standard, privileged]
+          default: standard
+          description: Immutable gVisor guest privilege class. Privileged capabilities remain confined by runsc and do not expose host devices.
       required: [image, resources]
+
+    EphemeralMountSpec:
+      type: object
+      properties:
+        mountPath:
+          type: string
+          pattern: '^/.*'
+        sizeLimit:
+          type: string
+          description: Exact byte quantity between 1Mi and 1Ti. The tmpfs remains subject to the sandbox memory cgroup.
+      required: [mountPath, sizeLimit]
 
     EnvVar:
       type: object

--- a/pkg/apispec/types.gen.go
+++ b/pkg/apispec/types.gen.go
@@ -23,6 +23,12 @@ const (
 	AddTeamMemberRequestRoleViewer    AddTeamMemberRequestRole = "viewer"
 )
 
+// Defines values for ContainerSpecSecurityClass.
+const (
+	Privileged ContainerSpecSecurityClass = "privileged"
+	Standard   ContainerSpecSecurityClass = "standard"
+)
+
 // Defines values for CredentialProjectionType.
 const (
 	HttpHeaders             CredentialProjectionType = "http_headers"
@@ -842,7 +848,13 @@ type ContainerSpec struct {
 	// Image Canonical normalized OCI reference pinned by a lowercase SHA-256 digest. Mutable tags are rejected.
 	Image     string        `json:"image"`
 	Resources ResourceQuota `json:"resources"`
+
+	// SecurityClass Immutable gVisor guest privilege class. Privileged capabilities remain confined by runsc and do not expose host devices.
+	SecurityClass *ContainerSpecSecurityClass `json:"securityClass,omitempty"`
 }
+
+// ContainerSpecSecurityClass Immutable gVisor guest privilege class. Privileged capabilities remain confined by runsc and do not expose host devices.
+type ContainerSpecSecurityClass string
 
 // ContextExecResponse defines model for ContextExecResponse.
 type ContextExecResponse struct {
@@ -1134,6 +1146,14 @@ type EgressTLSMode string
 type EnvVar struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
+}
+
+// EphemeralMountSpec defines model for EphemeralMountSpec.
+type EphemeralMountSpec struct {
+	MountPath string `json:"mountPath"`
+
+	// SizeLimit Exact byte quantity between 1Mi and 1Ti. The tmpfs remains subject to the sandbox memory cgroup.
+	SizeLimit string `json:"sizeLimit"`
 }
 
 // Error defines model for Error.
@@ -2421,12 +2441,15 @@ type SandboxSummary struct {
 
 // SandboxTemplateSpec defines model for SandboxTemplateSpec.
 type SandboxTemplateSpec struct {
-	Description   *string               `json:"description,omitempty"`
-	DisplayName   *string               `json:"displayName,omitempty"`
-	EnvVars       *map[string]string    `json:"envVars,omitempty"`
-	MainContainer ContainerSpec         `json:"mainContainer"`
-	Network       *SandboxNetworkPolicy `json:"network,omitempty"`
-	Tags          *[]string             `json:"tags,omitempty"`
+	Description *string            `json:"description,omitempty"`
+	DisplayName *string            `json:"displayName,omitempty"`
+	EnvVars     *map[string]string `json:"envVars,omitempty"`
+
+	// EphemeralMounts Claim-lifetime tmpfs mounts excluded from pause, resume, fork, and snapshot RootFS generations.
+	EphemeralMounts *[]EphemeralMountSpec `json:"ephemeralMounts,omitempty"`
+	MainContainer   ContainerSpec         `json:"mainContainer"`
+	Network         *SandboxNetworkPolicy `json:"network,omitempty"`
+	Tags            *[]string             `json:"tags,omitempty"`
 }
 
 // SandboxTemplateStatus defines model for SandboxTemplateStatus.

--- a/pkg/nomadruntime/channel_test.go
+++ b/pkg/nomadruntime/channel_test.go
@@ -345,7 +345,7 @@ func testNomadNodeClaimControlRequest(t *testing.T) protocol.NodeClaimControlReq
 		},
 	}
 	runtime := &runtimecontrol.Assignment{
-		SandboxID: "sandbox-1", TeamID: "team-1", RuntimeGeneration: 1,
+		SandboxID: "sandbox-1", TeamID: "team-1", RuntimeGeneration: 1, SecurityClass: "standard",
 		EnvVars: map[string]string{runtimecontrol.EnvSandboxID: "sandbox-1"},
 	}
 	revision, err := runtime.Revision()

--- a/pkg/runtimecontrol/types.go
+++ b/pkg/runtimecontrol/types.go
@@ -8,7 +8,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path"
 	"strings"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/sandboxspec"
 )
 
 const (
@@ -26,12 +29,20 @@ type WebhookConfig struct {
 	WatchDir string `json:"watch_dir,omitempty"`
 }
 
+// EphemeralMount is a claim-lifetime tmpfs excluded from durable RootFS state.
+type EphemeralMount struct {
+	MountPath string `json:"mount_path"`
+	SizeBytes int64  `json:"size_bytes"`
+}
+
 // Assignment is the complete input that the Nomad driver passes to a fresh
 // procd process. The assignment cannot change during the process lifetime.
 type Assignment struct {
 	SandboxID               string            `json:"sandbox_id"`
 	TeamID                  string            `json:"team_id,omitempty"`
 	RuntimeGeneration       int64             `json:"runtime_generation"`
+	SecurityClass           string            `json:"security_class"`
+	EphemeralMounts         []EphemeralMount  `json:"ephemeral_mounts,omitempty"`
 	EnvVars                 map[string]string `json:"env_vars,omitempty"`
 	Webhook                 *WebhookConfig    `json:"webhook,omitempty"`
 	ResetCopiedSessionState bool              `json:"reset_copied_session_state,omitempty"`
@@ -58,5 +69,34 @@ func (a Assignment) Validate() error {
 	if a.RuntimeGeneration <= 0 {
 		return errors.New("runtime generation must be positive")
 	}
+	securityClass, ok := sandboxspec.EffectiveSandboxSecurityClass(sandboxspec.SandboxSecurityClass(a.SecurityClass))
+	if !ok || string(securityClass) != a.SecurityClass {
+		return errors.New("security class must be canonical")
+	}
+	for index, mount := range a.EphemeralMounts {
+		if mount.MountPath == "" || strings.TrimSpace(mount.MountPath) != mount.MountPath ||
+			!strings.HasPrefix(mount.MountPath, "/") || path.Clean(mount.MountPath) != mount.MountPath ||
+			mount.SizeBytes < 1<<20 || mount.SizeBytes > 1<<40 || reservedEphemeralPath(mount.MountPath) {
+			return fmt.Errorf("ephemeral mount %d is invalid", index)
+		}
+		for previous := 0; previous < index; previous++ {
+			other := a.EphemeralMounts[previous].MountPath
+			if mount.MountPath == other || strings.HasPrefix(mount.MountPath, other+"/") ||
+				strings.HasPrefix(other, mount.MountPath+"/") {
+				return fmt.Errorf("ephemeral mount %d overlaps another mount", index)
+			}
+		}
+	}
 	return nil
+}
+
+func reservedEphemeralPath(value string) bool {
+	if value == "/" || value == "/dev" || value == "/proc" || value == "/sys" || value == "/config" || value == "/procd" {
+		return true
+	}
+	if strings.HasPrefix(value, "/proc/") || strings.HasPrefix(value, "/sys/") ||
+		strings.HasPrefix(value, "/config/") || strings.HasPrefix(value, "/procd/") {
+		return true
+	}
+	return strings.HasPrefix(value, "/dev/") && value != "/dev/shm"
 }

--- a/pkg/runtimecontrol/types_test.go
+++ b/pkg/runtimecontrol/types_test.go
@@ -6,6 +6,7 @@ func TestAssignmentRevisionIsStable(t *testing.T) {
 	first := Assignment{
 		SandboxID:         "sandbox-a",
 		RuntimeGeneration: 2,
+		SecurityClass:     "standard",
 		EnvVars: map[string]string{
 			"B": "2",
 			"A": "1",
@@ -14,6 +15,7 @@ func TestAssignmentRevisionIsStable(t *testing.T) {
 	second := Assignment{
 		SandboxID:         "sandbox-a",
 		RuntimeGeneration: 2,
+		SecurityClass:     "standard",
 		EnvVars: map[string]string{
 			"A": "1",
 			"B": "2",
@@ -36,5 +38,22 @@ func TestAssignmentRevisionIsStable(t *testing.T) {
 func TestAssignmentRevisionRejectsInvalidGeneration(t *testing.T) {
 	if _, err := (Assignment{SandboxID: "sandbox-a"}).Revision(); err == nil {
 		t.Fatal("Revision() error = nil, want invalid generation")
+	}
+}
+
+func TestAssignmentRejectsInvalidSecurityAndEphemeralMounts(t *testing.T) {
+	base := Assignment{SandboxID: "sandbox-a", RuntimeGeneration: 1, SecurityClass: "standard"}
+	tests := []Assignment{
+		{SandboxID: "sandbox-a", RuntimeGeneration: 1, SecurityClass: "host"},
+		{SandboxID: "sandbox-a", RuntimeGeneration: 1, SecurityClass: "standard", EphemeralMounts: []EphemeralMount{{MountPath: "/proc/cache", SizeBytes: 1 << 20}}},
+		{SandboxID: "sandbox-a", RuntimeGeneration: 1, SecurityClass: "standard", EphemeralMounts: []EphemeralMount{{MountPath: "/workspace", SizeBytes: 1 << 20}, {MountPath: "/workspace/cache", SizeBytes: 1 << 20}}},
+	}
+	if err := base.Validate(); err != nil {
+		t.Fatalf("valid assignment error = %v", err)
+	}
+	for _, assignment := range tests {
+		if err := assignment.Validate(); err == nil {
+			t.Fatalf("invalid assignment accepted: %#v", assignment)
+		}
 	}
 }

--- a/pkg/runtimeslot/compatibility.go
+++ b/pkg/runtimeslot/compatibility.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	"github.com/sandbox0-ai/sandbox0/pkg/runtimecontrol"
+	"github.com/sandbox0-ai/sandbox0/pkg/sandboxspec"
 )
 
 const RuntimeCompatibilityVersion = 2
@@ -53,6 +54,10 @@ func (c RuntimeCompatibility) Validate() error {
 	}
 	if c.RuntimeMode != runtimecontrol.ControlModeStatic {
 		return fmt.Errorf("runtime compatibility mode must be %s", runtimecontrol.ControlModeStatic)
+	}
+	securityClass, ok := sandboxspec.EffectiveSandboxSecurityClass(sandboxspec.SandboxSecurityClass(c.SecurityClass))
+	if !ok || string(securityClass) != c.SecurityClass {
+		return fmt.Errorf("runtime compatibility security class is unsupported")
 	}
 	return nil
 }

--- a/pkg/runtimeslot/compatibility_test.go
+++ b/pkg/runtimeslot/compatibility_test.go
@@ -46,6 +46,7 @@ func TestRuntimeCompatibilityRejectsAmbiguousClasses(t *testing.T) {
 		"spaced architecture":    func(runtimeClass *RuntimeCompatibility) { runtimeClass.Architecture = " amd64" },
 		"missing runsc version":  func(runtimeClass *RuntimeCompatibility) { runtimeClass.RunscVersion = "" },
 		"missing security class": func(runtimeClass *RuntimeCompatibility) { runtimeClass.SecurityClass = "" },
+		"unknown security class": func(runtimeClass *RuntimeCompatibility) { runtimeClass.SecurityClass = "host" },
 		"wrong command":          func(runtimeClass *RuntimeCompatibility) { runtimeClass.Command = "/bin/sh" },
 		"wrong port":             func(runtimeClass *RuntimeCompatibility) { runtimeClass.ProcdPort++ },
 		"wrong mode":             func(runtimeClass *RuntimeCompatibility) { runtimeClass.RuntimeMode = "watch" },

--- a/pkg/runtimeslot/types_test.go
+++ b/pkg/runtimeslot/types_test.go
@@ -164,7 +164,7 @@ func TestNodeClaimControlRequestValidatesRegionalBinding(t *testing.T) {
 	require.ErrorContains(t, changed.ValidateRegional(), "runtime assignment")
 	changed = request
 	changed.Runtime = &runtimecontrol.Assignment{
-		SandboxID: "sandbox-1", RuntimeGeneration: 1,
+		SandboxID: "sandbox-1", RuntimeGeneration: 1, SecurityClass: "standard",
 		EnvVars: map[string]string{runtimecontrol.EnvSandboxID: "another-sandbox"},
 	}
 	require.ErrorContains(t, changed.ValidateRegional(), "sandbox environment")
@@ -309,7 +309,7 @@ func testNodeClaimControlRequest() NodeClaimControlRequest {
 		},
 	}
 	runtime := &runtimecontrol.Assignment{
-		SandboxID: "sandbox-1", TeamID: "team-1", RuntimeGeneration: 1,
+		SandboxID: "sandbox-1", TeamID: "team-1", RuntimeGeneration: 1, SecurityClass: "standard",
 		EnvVars: map[string]string{runtimecontrol.EnvSandboxID: "sandbox-1"},
 	}
 	revision, err := runtime.Revision()

--- a/pkg/sandboxspec/types.go
+++ b/pkg/sandboxspec/types.go
@@ -5,14 +5,24 @@ import "time"
 
 const DefaultSandboxEphemeralStorage = "8Gi"
 
+// SandboxSecurityClass selects the immutable guest privilege boundary. It is
+// part of warm-slot compatibility and never changes after a sandbox claim.
+type SandboxSecurityClass string
+
+const (
+	SandboxSecurityClassStandard   SandboxSecurityClass = "standard"
+	SandboxSecurityClassPrivileged SandboxSecurityClass = "privileged"
+)
+
 // TemplateSpec defines the reusable runtime inputs for sandbox claims.
 type TemplateSpec struct {
-	Description   string                `json:"description,omitempty"`
-	DisplayName   string                `json:"displayName,omitempty"`
-	Tags          []string              `json:"tags,omitempty"`
-	MainContainer ContainerSpec         `json:"mainContainer"`
-	Network       *SandboxNetworkPolicy `json:"network,omitempty"`
-	EnvVars       map[string]string     `json:"envVars,omitempty"`
+	Description     string                `json:"description,omitempty"`
+	DisplayName     string                `json:"displayName,omitempty"`
+	Tags            []string              `json:"tags,omitempty"`
+	MainContainer   ContainerSpec         `json:"mainContainer"`
+	EphemeralMounts []EphemeralMountSpec  `json:"ephemeralMounts,omitempty"`
+	Network         *SandboxNetworkPolicy `json:"network,omitempty"`
+	EnvVars         map[string]string     `json:"envVars,omitempty"`
 }
 
 // SandboxTemplateSpec is retained as the public product-domain name.
@@ -20,9 +30,30 @@ type SandboxTemplateSpec = TemplateSpec
 
 // ContainerSpec defines the sandbox image, environment, and default resources.
 type ContainerSpec struct {
-	Image     string        `json:"image"`
-	Env       []EnvVar      `json:"env,omitempty"`
-	Resources ResourceQuota `json:"resources"`
+	Image         string               `json:"image"`
+	Env           []EnvVar             `json:"env,omitempty"`
+	Resources     ResourceQuota        `json:"resources"`
+	SecurityClass SandboxSecurityClass `json:"securityClass,omitempty"`
+}
+
+// EphemeralMountSpec declares claim-lifetime storage that is intentionally
+// excluded from pause, resume, fork, and snapshot RootFS generations.
+type EphemeralMountSpec struct {
+	MountPath string `json:"mountPath"`
+	SizeLimit string `json:"sizeLimit"`
+}
+
+// EffectiveSandboxSecurityClass returns the canonical class and treats the
+// omitted legacy value as standard.
+func EffectiveSandboxSecurityClass(value SandboxSecurityClass) (SandboxSecurityClass, bool) {
+	switch value {
+	case "", SandboxSecurityClassStandard:
+		return SandboxSecurityClassStandard, true
+	case SandboxSecurityClassPrivileged:
+		return SandboxSecurityClassPrivileged, true
+	default:
+		return "", false
+	}
 }
 
 // EnvVar represents an environment variable.

--- a/pkg/template/ephemeral_mounts.go
+++ b/pkg/template/ephemeral_mounts.go
@@ -1,0 +1,68 @@
+package template
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/quantity"
+	"github.com/sandbox0-ai/sandbox0/pkg/sandboxspec"
+)
+
+const (
+	minEphemeralMountBytes int64 = 1 << 20
+	maxEphemeralMountBytes int64 = 1 << 40
+)
+
+// ResolveEphemeralMounts validates runtime-neutral ephemeral mounts and
+// returns exact byte limits for the claim assignment.
+func ResolveEphemeralMounts(spec sandboxspec.TemplateSpec) ([]ResolvedEphemeralMount, error) {
+	result := make([]ResolvedEphemeralMount, 0, len(spec.EphemeralMounts))
+	for index, mount := range spec.EphemeralMounts {
+		mountPath := strings.TrimSpace(mount.MountPath)
+		if mountPath != mount.MountPath || !strings.HasPrefix(mountPath, "/") || path.Clean(mountPath) != mountPath {
+			return nil, fmt.Errorf("spec.ephemeralMounts[%d].mountPath must be a canonical absolute path", index)
+		}
+		if reservedEphemeralMountPath(mountPath) {
+			return nil, fmt.Errorf("spec.ephemeralMounts[%d].mountPath overlaps a reserved runtime path", index)
+		}
+		limit, err := quantity.Parse(strings.TrimSpace(mount.SizeLimit))
+		if err != nil {
+			return nil, fmt.Errorf("spec.ephemeralMounts[%d].sizeLimit is invalid: %w", index, err)
+		}
+		bytes := limit.Value()
+		if bytes < minEphemeralMountBytes || bytes > maxEphemeralMountBytes || quantity.New(bytes).Cmp(limit) != 0 {
+			return nil, fmt.Errorf(
+				"spec.ephemeralMounts[%d].sizeLimit must be an exact byte quantity between 1Mi and 1Ti", index,
+			)
+		}
+		for _, existing := range result {
+			if pathOverlaps(existing.MountPath, mountPath) {
+				return nil, fmt.Errorf("spec.ephemeralMounts[%d].mountPath overlaps %s", index, existing.MountPath)
+			}
+		}
+		result = append(result, ResolvedEphemeralMount{MountPath: mountPath, SizeBytes: bytes})
+	}
+	return result, nil
+}
+
+// ResolvedEphemeralMount is the exact claim-time mount shape.
+type ResolvedEphemeralMount struct {
+	MountPath string
+	SizeBytes int64
+}
+
+func reservedEphemeralMountPath(value string) bool {
+	if value == "/" || value == "/dev" || value == "/proc" || value == "/sys" || value == "/config" || value == "/procd" {
+		return true
+	}
+	if strings.HasPrefix(value, "/proc/") || strings.HasPrefix(value, "/sys/") ||
+		strings.HasPrefix(value, "/config/") || strings.HasPrefix(value, "/procd/") {
+		return true
+	}
+	return strings.HasPrefix(value, "/dev/") && value != "/dev/shm"
+}
+
+func pathOverlaps(left, right string) bool {
+	return left == right || strings.HasPrefix(left, right+"/") || strings.HasPrefix(right, left+"/")
+}

--- a/pkg/template/ephemeral_mounts_test.go
+++ b/pkg/template/ephemeral_mounts_test.go
@@ -1,0 +1,44 @@
+package template
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sandbox0-ai/sandbox0/pkg/sandboxspec"
+)
+
+func TestResolveEphemeralMountsReturnsExactLimits(t *testing.T) {
+	mounts, err := ResolveEphemeralMounts(sandboxspec.TemplateSpec{EphemeralMounts: []sandboxspec.EphemeralMountSpec{
+		{MountPath: "/var/lib/docker", SizeLimit: "16Gi"},
+		{MountPath: "/dev/shm", SizeLimit: "2Gi"},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mounts) != 2 || mounts[0].SizeBytes != 16<<30 || mounts[1].SizeBytes != 2<<30 {
+		t.Fatalf("mounts = %#v", mounts)
+	}
+}
+
+func TestResolveEphemeralMountsRejectsUnsafeShapes(t *testing.T) {
+	tests := []struct {
+		name   string
+		mounts []sandboxspec.EphemeralMountSpec
+		want   string
+	}{
+		{name: "relative", mounts: []sandboxspec.EphemeralMountSpec{{MountPath: "workspace", SizeLimit: "1Gi"}}, want: "canonical absolute"},
+		{name: "reserved", mounts: []sandboxspec.EphemeralMountSpec{{MountPath: "/proc/memory", SizeLimit: "1Gi"}}, want: "reserved runtime path"},
+		{name: "unsupported dev", mounts: []sandboxspec.EphemeralMountSpec{{MountPath: "/dev/custom", SizeLimit: "1Gi"}}, want: "reserved runtime path"},
+		{name: "overlap", mounts: []sandboxspec.EphemeralMountSpec{{MountPath: "/workspace", SizeLimit: "1Gi"}, {MountPath: "/workspace/cache", SizeLimit: "1Gi"}}, want: "overlaps"},
+		{name: "too small", mounts: []sandboxspec.EphemeralMountSpec{{MountPath: "/workspace", SizeLimit: "4Ki"}}, want: "between 1Mi and 1Ti"},
+		{name: "fractional byte", mounts: []sandboxspec.EphemeralMountSpec{{MountPath: "/workspace", SizeLimit: "1.1Mi"}}, want: "exact byte quantity"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := ResolveEphemeralMounts(sandboxspec.TemplateSpec{EphemeralMounts: test.mounts})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("ResolveEphemeralMounts() error = %v, want containing %q", err, test.want)
+			}
+		})
+	}
+}

--- a/pkg/template/http/handlers.go
+++ b/pkg/template/http/handlers.go
@@ -204,6 +204,9 @@ func decodeTemplateRequestSpec(raw json.RawMessage) (v1alpha1.SandboxTemplateSpe
 	if err := rejectExplicitTemplateCPU(raw); err != nil {
 		return out, err
 	}
+	if securityClass, ok := v1alpha1.EffectiveSandboxSecurityClass(out.MainContainer.SecurityClass); ok {
+		out.MainContainer.SecurityClass = securityClass
+	}
 	return out, nil
 }
 

--- a/pkg/template/http/handlers_test.go
+++ b/pkg/template/http/handlers_test.go
@@ -100,8 +100,34 @@ func TestCreateTemplatePersistsRuntimeNeutralSpec(t *testing.T) {
 	if got := store.createdOrUpdatedSpec.MainContainer.Resources.EphemeralStorage; got != "768Mi" {
 		t.Fatalf("ephemeral storage = %q, want 768Mi", got)
 	}
+	if got := store.createdOrUpdatedSpec.MainContainer.SecurityClass; got != v1alpha1.SandboxSecurityClassStandard {
+		t.Fatalf("default security class = %q", got)
+	}
 	if strings.Contains(response.Body.String(), `"cpu"`) {
 		t.Fatalf("public response leaked platform-derived CPU: %s", response.Body.String())
+	}
+}
+
+func TestCreateTemplateAcceptsPrivilegedClassAndEphemeralMounts(t *testing.T) {
+	store := &testTemplateStore{}
+	handler := &Handler{Store: store, Logger: zap.NewNop()}
+	router := templateTestRouter(http.MethodPost, "/api/v1/templates", handler.CreateTemplate,
+		&internalauth.Claims{TeamID: "team-1", UserID: "user-1"})
+	body := `{
+		"template_id":"docker",
+		"spec":{
+			"mainContainer":{"image":"registry.example/runtime@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","securityClass":"privileged","resources":{"memory":"4Gi"}},
+			"ephemeralMounts":[{"mountPath":"/var/lib/docker","sizeLimit":"16Gi"}]
+		}
+	}`
+	response := performTemplateRequest(router, http.MethodPost, "/api/v1/templates", body)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("status = %d; body=%s", response.Code, response.Body.String())
+	}
+	got := store.createdOrUpdatedSpec
+	if got.MainContainer.SecurityClass != v1alpha1.SandboxSecurityClassPrivileged ||
+		len(got.EphemeralMounts) != 1 || got.EphemeralMounts[0].MountPath != "/var/lib/docker" {
+		t.Fatalf("persisted spec = %#v", got)
 	}
 }
 

--- a/pkg/template/http/template_validation.go
+++ b/pkg/template/http/template_validation.go
@@ -67,6 +67,12 @@ func validateTemplateSpec(spec v1alpha1.SandboxTemplateSpec) error {
 	if _, err := s0template.ResolveRootFSLogicalSize(spec); err != nil {
 		return err
 	}
+	if _, ok := v1alpha1.EffectiveSandboxSecurityClass(spec.MainContainer.SecurityClass); !ok {
+		return fmt.Errorf("spec.mainContainer.securityClass must be one of: standard, privileged")
+	}
+	if _, err := s0template.ResolveEphemeralMounts(spec); err != nil {
+		return err
+	}
 
 	if spec.Network != nil {
 		if spec.Network.Mode != v1alpha1.NetworkModeAllowAll && spec.Network.Mode != v1alpha1.NetworkModeBlockAll {


### PR DESCRIPTION
## Summary
- make `security_class` a per-warm-allocation task input and schedule standard/privileged classes independently inside one Nomad data-plane cluster
- carry the canonical class through templates, claim assignments, resume, template capture, compatibility digests, and the OCI spec
- add runtime-neutral, size-bounded `ephemeralMounts` for data intentionally excluded from block-COW generations
- generate a guest-confined privileged OCI capability set while retaining stock runsc as the isolation boundary
- update the public OpenAPI contract, generated types, deployment examples, tests, and docs

## Why
The ACK migration preflight found 7 retained sandboxes whose templates explicitly require privileged guest semantics and 9 retained sandboxes with Kubernetes `emptyDir` mounts. The Nomad-only implementation already included `security_class` in the compatibility digest, but plugin configuration fixed it node-wide and manager rejected more than one class per cluster. Migrating as-is would silently break Docker-in-sandbox and discard intended ephemeral mount behavior.

## Validation
- `go test ./...`
- `go vet ./...`
- `cd nomad-driver-sandbox0 && go test -buildvcs=false ./...`
- `cd nomad-driver-sandbox0 && go vet ./...`
- `make apispec`
- `git diff --check`
