### PR TITLE
fix(runtime): source authority from Nomad plugin

### DIFF
--- a/pkg/nodebootstrap/files.go
+++ b/pkg/nodebootstrap/files.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -224,14 +225,64 @@ func runtimeAuthorityHost(staged *stagedRuntimeConfig) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	authority, err := url.Parse(strings.TrimSpace(values["SANDBOX0_AUTHORITY_URL"]))
-	if err != nil || authority.Scheme != "https" || authority.Hostname() == "" ||
-		authority.Port() != "8421" || authority.User != nil ||
-		authority.RawQuery != "" || authority.Fragment != "" ||
-		(authority.Path != "" && authority.Path != "/") {
-		return "", errors.New("rendered ctld environment has an invalid manager authority URL")
+	candidates := make([]string, 0, 2)
+	if configured := strings.TrimSpace(values["SANDBOX0_AUTHORITY_URL"]); configured != "" {
+		candidates = append(candidates, configured)
 	}
-	return authority.Hostname(), nil
+	pluginURL, err := runtimeAuthorityURLFromPlugin(
+		staged.path("etc/nomad.d/30-sandbox0-gvisor.hcl"),
+	)
+	if err != nil {
+		return "", err
+	}
+	candidates = append(candidates, pluginURL)
+
+	var authorityHost string
+	for _, candidate := range candidates {
+		authority, err := url.Parse(candidate)
+		if err != nil || authority.Scheme != "https" || authority.Hostname() == "" ||
+			authority.Port() != "8421" || authority.User != nil ||
+			authority.RawQuery != "" || authority.Fragment != "" ||
+			(authority.Path != "" && authority.Path != "/") {
+			return "", errors.New("rendered runtime config has an invalid manager authority URL")
+		}
+		if authorityHost != "" && !strings.EqualFold(authorityHost, authority.Hostname()) {
+			return "", errors.New("rendered runtime config has inconsistent manager authority hosts")
+		}
+		authorityHost = authority.Hostname()
+	}
+	return authorityHost, nil
+}
+
+func runtimeAuthorityURLFromPlugin(file string) (string, error) {
+	handle, err := os.Open(file)
+	if err != nil {
+		return "", err
+	}
+	defer handle.Close()
+	var authorityURL string
+	scanner := bufio.NewScanner(io.LimitReader(handle, 1<<20))
+	for scanner.Scan() {
+		line, _, _ := strings.Cut(scanner.Text(), "#")
+		key, value, found := strings.Cut(line, "=")
+		if !found || strings.TrimSpace(key) != "rootfs_authority_url" {
+			continue
+		}
+		if authorityURL != "" {
+			return "", errors.New("rendered Nomad plugin repeats the manager authority URL")
+		}
+		authorityURL, err = strconv.Unquote(strings.TrimSpace(value))
+		if err != nil {
+			return "", errors.New("rendered Nomad plugin has an invalid manager authority URL")
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	if authorityURL == "" {
+		return "", errors.New("rendered Nomad plugin is missing the manager authority URL")
+	}
+	return authorityURL, nil
 }
 
 // removeRuntimeAuthorityHostAliases prevents a replaced private load

--- a/pkg/nodebootstrap/nodebootstrap_test.go
+++ b/pkg/nodebootstrap/nodebootstrap_test.go
@@ -67,6 +67,11 @@ func TestRuntimeConfigArchiveBindsExactNodeIdentity(t *testing.T) {
 		"SANDBOX0_AUTHORITY_URL=https://authority.ali-ue1.internal:8421",
 	}, "\n") + "\n"
 	files["opt/cni/config/10-sandbox0.conflist"] = `{"subnet":"172.27.0.0/26"}`
+	files["etc/nomad.d/30-sandbox0-gvisor.hcl"] = `plugin "sandbox0-gvisor" {
+  config {
+    rootfs_authority_url = "https://authority.ali-ue1.internal:8421"
+  }
+}`
 	staged, err := stageRuntimeConfigAt(runtimeConfigArchive(t, files), t.TempDir())
 	require.NoError(t, err)
 	defer staged.close()
@@ -98,8 +103,11 @@ func TestRemoveRuntimeAuthorityHostAliasesKeepsDNSAuthoritative(t *testing.T) {
 func TestRuntimeAuthorityHostRejectsNoncanonicalEndpoint(t *testing.T) {
 	directory := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(directory, "etc/sandbox0"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(directory, "etc/nomad.d"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(directory, "etc/sandbox0/ctld.env"), []byte(
 		"SANDBOX0_AUTHORITY_URL=http://authority.internal:8421\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(directory, "etc/nomad.d/30-sandbox0-gvisor.hcl"), []byte(
+		"rootfs_authority_url = \"https://authority.internal:8421\"\n"), 0o600))
 	staged := &stagedRuntimeConfig{root: directory}
 	_, err := runtimeAuthorityHost(staged)
 	require.ErrorContains(t, err, "invalid manager authority URL")


### PR DESCRIPTION
## Summary
- derive the authoritative manager endpoint from the rendered Nomad driver plugin used by production nodes
- optionally cross-check ctld environment configuration when it also declares an authority URL
- keep retired `/etc/hosts` aliases removable for both captured fixed-node templates and elastic enrollment

## Tests
- `go test ./pkg/nodebootstrap ./manager/pkg/nodeenrollment ./tools/node-runtime-config`
- `git diff --check`