### PR TITLE
fix(manager): recognize terminal Nomad allocations

### DIFF
--- a/manager/pkg/runtimeslotnomad/controller.go
+++ b/manager/pkg/runtimeslotnomad/controller.go
@@ -23,6 +23,7 @@ type Allocation struct {
 	Namespace     string `json:"Namespace"`
 	NodeID        string `json:"NodeID"`
 	DesiredStatus string `json:"DesiredStatus"`
+	ClientStatus  string `json:"ClientStatus"`
 }
 
 // API separates Nomad protocol details from reconciliation ordering. The
@@ -70,7 +71,8 @@ func (c *Controller) Observe(
 		if err := validateAllocation(*allocation, target); err != nil {
 			return runtimeslotreconciler.AllocationObservation{}, err
 		}
-		serverOwnsAllocation = allocation.DesiredStatus == "run"
+		serverOwnsAllocation = allocation.DesiredStatus == "run" &&
+			!allocationClientTerminal(allocation.ClientStatus)
 	}
 	clientPresent, err := c.api.ClientAllocationPresent(ctx, target)
 	if err != nil {
@@ -173,9 +175,24 @@ func validateAllocation(allocation Allocation, target runtimeslotreconciler.Allo
 	}
 	switch allocation.DesiredStatus {
 	case "run", "stop", "evict":
-		return nil
 	default:
 		return fmt.Errorf("nomad server allocation has invalid desired status %q: %w", allocation.DesiredStatus, errdefs.ErrFailedPrecondition)
+	}
+	switch allocation.ClientStatus {
+	case "pending", "running", "complete", "failed", "lost", "unknown":
+		return nil
+	default:
+		return fmt.Errorf("nomad server allocation has invalid client status %q: %w", allocation.ClientStatus, errdefs.ErrFailedPrecondition)
+	}
+}
+
+// allocationClientTerminal mirrors Nomad's terminal client-state boundary.
+func allocationClientTerminal(status string) bool {
+	switch status {
+	case "complete", "failed", "lost":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/manager/pkg/runtimeslotnomad/controller_test.go
+++ b/manager/pkg/runtimeslotnomad/controller_test.go
@@ -103,6 +103,59 @@ func TestControllerObservesServerAndDirectClientOwnership(t *testing.T) {
 	}
 }
 
+func TestControllerObservesTerminalClientAllocationAsPhysicallyAbsent(t *testing.T) {
+	target := testTarget()
+	for _, status := range []string{"complete", "failed", "lost"} {
+		t.Run(status, func(t *testing.T) {
+			api := &fakeAPI{allocation: testAllocation()}
+			api.allocation.ClientStatus = status
+			controller, err := New(api)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			observation, err := controller.Observe(t.Context(), target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if observation.PhysicalPresent {
+				t.Fatalf("terminal allocation observation = %+v", observation)
+			}
+
+			api.client = true
+			clientOwned, err := controller.Observe(t.Context(), target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !clientOwned.PhysicalPresent {
+				t.Fatal("direct client state was ignored for a terminal server allocation")
+			}
+		})
+	}
+}
+
+func TestControllerRetainsNonterminalServerOwnership(t *testing.T) {
+	target := testTarget()
+	for _, status := range []string{"pending", "running", "unknown"} {
+		t.Run(status, func(t *testing.T) {
+			api := &fakeAPI{allocation: testAllocation()}
+			api.allocation.ClientStatus = status
+			controller, err := New(api)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			observation, err := controller.Observe(t.Context(), target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !observation.PhysicalPresent {
+				t.Fatalf("nonterminal allocation observation = %+v", observation)
+			}
+		})
+	}
+}
+
 func TestControllerPurgesServerThenExactClient(t *testing.T) {
 	target := testTarget()
 	api := &fakeAPI{allocation: testAllocation(), client: true}
@@ -182,6 +235,22 @@ func TestControllerRejectsMismatchedServerIdentityBeforeNodeAccess(t *testing.T)
 	}
 }
 
+func TestControllerRejectsInvalidServerStatusBeforeNodeAccess(t *testing.T) {
+	api := &fakeAPI{allocation: testAllocation()}
+	api.allocation.ClientStatus = "dead"
+	controller, err := New(api)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = controller.Observe(t.Context(), testTarget())
+	if !errors.Is(err, errdefs.ErrFailedPrecondition) {
+		t.Fatalf("Observe() error = %v", err)
+	}
+	if api.clientCalls != 0 {
+		t.Fatalf("direct client calls = %d", api.clientCalls)
+	}
+}
+
 func TestControllerPropagatesClientGCNotReady(t *testing.T) {
 	api := &fakeAPI{
 		allocation: testAllocation(), client: true,
@@ -225,6 +294,7 @@ func testTarget() runtimeslotreconciler.AllocationTarget {
 
 func testAllocation() *Allocation {
 	return &Allocation{
-		ID: "allocation-1", Namespace: "default", NodeID: "node-1", DesiredStatus: "run",
+		ID: "allocation-1", Namespace: "default", NodeID: "node-1",
+		DesiredStatus: "run", ClientStatus: "running",
 	}
 }

--- a/manager/pkg/runtimeslotnomad/http_api_test.go
+++ b/manager/pkg/runtimeslotnomad/http_api_test.go
@@ -228,7 +228,7 @@ func newNomadMTLSTestServer(
 			}
 			_ = json.NewEncoder(writer).Encode(Allocation{
 				ID: "allocation-1", Namespace: "default", NodeID: "node-1",
-				DesiredStatus: state.desiredStatus,
+				DesiredStatus: state.desiredStatus, ClientStatus: "running",
 			})
 		case "/v1/allocation/allocation-1/stop":
 			if rejectUnexpectedNomadRequest(t, writer, request.Method, http.MethodPost, "method") ||


### PR DESCRIPTION
## Summary
- include Nomad `ClientStatus` in exact allocation observations
- treat `complete`, `failed`, and `lost` server records as terminal even when their historical desired status remains `run`
- retain fail-closed ownership for pending/running/unknown states and always honor direct client allocation state

## Production evidence
A failed warm allocation had already been client-GCed and replaced, but its server record remained `DesiredStatus=run`, causing the terminal reconciler to retry forever and block sandbox resume.

## Validation
- `go test ./manager/pkg/runtimeslotnomad ./manager/pkg/runtimeslotreconciler`
- coverage for all Nomad terminal and nonterminal client statuses
