### PR TITLE
fix(nomad): bind ctld to client certificate IP

### DIFF
--- a/deploy/nomad/ctld/README.md
+++ b/deploy/nomad/ctld/README.md
@@ -24,6 +24,9 @@ write permission. Set the four `SANDBOX0_RESOURCE_*` values to the allocatable
 capacity of the dedicated cpuset after reserving host/ctld/Nomad overhead; do
 not copy carrier-job resources into these values. Start from
 `nomad-plugin.hcl.example` for the Nomad client plugin configuration. Register
+`SANDBOX0_NOMAD_ADDRESS` with the node's private IP, and issue the Nomad client
+certificate with that exact IP SAN; a loopback URL is not valid for an
+IP-scoped certificate. Register
 the Nomad client with `client.node_pool = "sandbox0"` and set node metadata
 `sandbox0_dedicated=true`; do not target that pool from general jobs. Then
 install:

--- a/deploy/nomad/ctld/assets_test.go
+++ b/deploy/nomad/ctld/assets_test.go
@@ -71,7 +71,7 @@ func TestExampleConfigsDecodeAfterEnvironmentExpansion(t *testing.T) {
 		"SANDBOX0_ROOTFS_NBD_DEVICES":        "/dev/nbd0,/dev/nbd1",
 		"SANDBOX0_MANAGER_AUTHORITY_URL":     "https://manager.internal:9444",
 		"SANDBOX0_MANAGER_AUTHORITY_URI_SAN": "spiffe://sandbox0.internal/region/runtime-slot-channel",
-		"SANDBOX0_NOMAD_ADDRESS":             "https://127.0.0.1:4646",
+		"SANDBOX0_NOMAD_ADDRESS":             "https://10.0.0.10:4646",
 		"SANDBOX0_NOMAD_NODE_ID":             "node-1",
 		"SANDBOX0_NODE_UID":                  "node-uid-1",
 		"SANDBOX0_NODE_NAME":                 "node-1",

--- a/deploy/nomad/ctld/ctld.env.example
+++ b/deploy/nomad/ctld/ctld.env.example
@@ -16,6 +16,6 @@ SANDBOX0_ROOTFS_SECRET_KEY=replace-with-secret-key
 SANDBOX0_DATABASE_URL=postgres://sandbox0@postgres.example.com/sandbox0?sslmode=verify-full
 SANDBOX0_MANAGER_AUTHORITY_URL=https://manager.internal:9444
 SANDBOX0_MANAGER_AUTHORITY_URI_SAN=spiffe://sandbox0.internal/region/runtime-slot-channel
-SANDBOX0_NOMAD_ADDRESS=https://127.0.0.1:4646
+SANDBOX0_NOMAD_ADDRESS=https://10.0.0.10:4646
 SANDBOX0_CLUSTER_DNS_CIDR=10.0.0.53/32
 SANDBOX0_PLATFORM_ALLOWED_CIDRS=10.0.0.0/8

--- a/manager/pkg/nodeenrollment/runtime_config_test.go
+++ b/manager/pkg/nodeenrollment/runtime_config_test.go
@@ -15,7 +15,7 @@ func TestRuntimeConfigTemplateRendersExactNodeWithoutLivePeerState(t *testing.T)
 	required := map[string]string{
 		"etc/sandbox0/ctld.yaml.tmpl":                "node_uid: {{.NodeUID}}\nnode_id: {{.NodeID}}\n",
 		"etc/sandbox0/ctld-networking.yaml.tmpl":     "node_name: {{.NodeName}}\n",
-		"etc/sandbox0/ctld.env.tmpl":                 "SANDBOX0_NODE_UID={{.NodeUID}}\nSANDBOX0_PRIVATE_IP={{.PrivateIP}}\n",
+		"etc/sandbox0/ctld.env.tmpl":                 "SANDBOX0_NODE_UID={{.NodeUID}}\nSANDBOX0_PRIVATE_IP={{.PrivateIP}}\nSANDBOX0_NOMAD_ADDRESS=https://{{.PrivateIP}}:4646\n",
 		"etc/sandbox0/ctld-a.env":                    "SANDBOX0_CTLD_HA_METRICS_ADDR=:9192\n",
 		"etc/sandbox0/ctld-b.env":                    "SANDBOX0_CTLD_HA_METRICS_ADDR=:9193\n",
 		"etc/sandbox0/internal-auth/data-public.pem": "public-key\n",
@@ -38,6 +38,8 @@ func TestRuntimeConfigTemplateRendersExactNodeWithoutLivePeerState(t *testing.T)
 	require.NoError(t, err)
 	files := readRuntimeConfigArchive(t, payload)
 	require.Contains(t, files["node-runtime/etc/sandbox0/ctld.yaml"], "ecs/us-east-1/i-123")
+	require.Contains(t, files["node-runtime/etc/sandbox0/ctld.env"],
+		"SANDBOX0_NOMAD_ADDRESS=https://10.0.0.10:4646")
 	require.Contains(t, files["node-runtime/opt/cni/config/10-sandbox0.conflist"], "172.27.0.0/26")
 	for name, contents := range files {
 		require.NotContains(t, contents, "{{", name)

--- a/pkg/nodebootstrap/bootstrap.go
+++ b/pkg/nodebootstrap/bootstrap.go
@@ -204,6 +204,7 @@ func (b *Bootstrapper) Initial(ctx context.Context, responseFile string) error {
 	}
 	defer staged.close()
 	if err := validateRuntimeConfigIdentity(staged, response.NodeName, nodeID, finalized.NodeUID,
+		identity.privateIP,
 		b.config.RegionID, b.config.ClusterID, response.AllocationCIDR); err != nil {
 		return err
 	}

--- a/pkg/nodebootstrap/files.go
+++ b/pkg/nodebootstrap/files.go
@@ -170,7 +170,7 @@ func (s *stagedRuntimeConfig) install() error {
 // staging and installation path as part of Bootstrapper.Initial.
 func InstallRenderedRuntimeConfig(
 	payload []byte,
-	nodeName, nodeID, nodeUID, regionID, clusterID, allocationCIDR string,
+	nodeName, nodeID, nodeUID, privateIP, regionID, clusterID, allocationCIDR string,
 ) error {
 	if os.Geteuid() != 0 {
 		return errors.New("rendered node runtime config installation requires root")
@@ -180,7 +180,7 @@ func InstallRenderedRuntimeConfig(
 		return err
 	}
 	defer staged.close()
-	if err := validateRuntimeConfigIdentity(staged, nodeName, nodeID, nodeUID,
+	if err := validateRuntimeConfigIdentity(staged, nodeName, nodeID, nodeUID, privateIP,
 		regionID, clusterID, allocationCIDR); err != nil {
 		return err
 	}
@@ -189,7 +189,7 @@ func InstallRenderedRuntimeConfig(
 
 func validateRuntimeConfigIdentity(
 	staged *stagedRuntimeConfig,
-	nodeName, nodeID, nodeUID, regionID, clusterID, allocationCIDR string,
+	nodeName, nodeID, nodeUID, privateIP, regionID, clusterID, allocationCIDR string,
 ) error {
 	values, err := parseEnvironmentFile(staged.path("etc/sandbox0/ctld.env"))
 	if err != nil {
@@ -199,6 +199,7 @@ func validateRuntimeConfigIdentity(
 		"SANDBOX0_NODE_NAME":     nodeName,
 		"SANDBOX0_NOMAD_NODE_ID": nodeID,
 		"SANDBOX0_NODE_UID":      nodeUID,
+		"SANDBOX0_NOMAD_ADDRESS": "https://" + privateIP + ":4646",
 		"SANDBOX0_REGION_ID":     regionID,
 		"SANDBOX0_CLUSTER_ID":    clusterID,
 	}

--- a/pkg/nodebootstrap/nodebootstrap_test.go
+++ b/pkg/nodebootstrap/nodebootstrap_test.go
@@ -62,6 +62,7 @@ func TestRuntimeConfigArchiveBindsExactNodeIdentity(t *testing.T) {
 		"SANDBOX0_NODE_NAME=s0-i-123",
 		"SANDBOX0_NOMAD_NODE_ID=11111111-1111-1111-1111-111111111111",
 		"SANDBOX0_NODE_UID=ecs/us-east-1/i-123",
+		"SANDBOX0_NOMAD_ADDRESS=https://10.0.1.9:4646",
 		"SANDBOX0_REGION_ID=ali-ue1",
 		"SANDBOX0_CLUSTER_ID=nomad",
 		"SANDBOX0_AUTHORITY_URL=https://authority.ali-ue1.internal:8421",
@@ -77,7 +78,11 @@ func TestRuntimeConfigArchiveBindsExactNodeIdentity(t *testing.T) {
 	defer staged.close()
 	require.NoError(t, validateRuntimeConfigIdentity(staged,
 		"s0-i-123", "11111111-1111-1111-1111-111111111111", "ecs/us-east-1/i-123",
+		"10.0.1.9",
 		"ali-ue1", "nomad", "172.27.0.0/26"))
+	require.ErrorContains(t, validateRuntimeConfigIdentity(staged,
+		"s0-i-123", "11111111-1111-1111-1111-111111111111", "ecs/us-east-1/i-123",
+		"10.0.1.10", "ali-ue1", "nomad", "172.27.0.0/26"), "SANDBOX0_NOMAD_ADDRESS")
 }
 
 func TestRemoveRuntimeAuthorityHostAliasesKeepsDNSAuthoritative(t *testing.T) {

--- a/tools/node-runtime-config/main.go
+++ b/tools/node-runtime-config/main.go
@@ -115,7 +115,7 @@ func install(arguments []string) error {
 		return err
 	}
 	return nodebootstrap.InstallRenderedRuntimeConfig(payload, identity.nodeName,
-		identity.nodeID, identity.nodeUID, identity.regionID, identity.clusterID,
+		identity.nodeID, identity.nodeUID, identity.privateIP, identity.regionID, identity.clusterID,
 		identity.allocationCIDR)
 }
 

--- a/tools/node-runtime-config/main_test.go
+++ b/tools/node-runtime-config/main_test.go
@@ -50,6 +50,7 @@ func TestRenderUsesExactSharedRuntimeTemplate(t *testing.T) {
 		"SANDBOX0_NODE_NAME=sandbox-1",
 		"SANDBOX0_NOMAD_NODE_ID=node-1",
 		"SANDBOX0_NODE_UID=ecs/us-east-1/i-fixed",
+		"SANDBOX0_NOMAD_ADDRESS=https://10.0.1.2:4646",
 		"SANDBOX0_REGION_ID=ali-ue1",
 		"SANDBOX0_CLUSTER_ID=nomad",
 	} {
@@ -86,6 +87,7 @@ func writeTemplate(t *testing.T, destination string) {
 			"SANDBOX0_NODE_UID={{.NodeUID}}",
 			"SANDBOX0_AGENT_UID={{.AgentUID}}",
 			"SANDBOX0_PRIVATE_IP={{.PrivateIP}}",
+			"SANDBOX0_NOMAD_ADDRESS=https://{{.PrivateIP}}:4646",
 			"SANDBOX0_REGION_ID={{.RegionID}}",
 			"SANDBOX0_CLUSTER_ID={{.ClusterID}}",
 			"SANDBOX0_AUTHORITY_URL={{.ManagerAuthorityURL}}",


### PR DESCRIPTION
## Summary
- require rendered ctld config to use the exact node private IP for the local Nomad HTTPS endpoint
- pass private-IP identity through both fixed and elastic runtime-config installation paths
- update the deployment example and tests so loopback cannot be paired with an IP-scoped client certificate

## Production evidence
ctld repeatedly rejected `https://127.0.0.1:4646` because the Nomad client certificate is valid for the exact node private IP.

## Validation
- `go test ./pkg/nodebootstrap ./manager/pkg/nodeenrollment ./tools/node-runtime-config ./deploy/nomad/ctld`
- `git diff --check`
