### PR TITLE
fix(ctld): fence orphaned runtime slot networks

### DIFF
--- a/ctld/internal/ctld/networking/daemon.go
+++ b/ctld/internal/ctld/networking/daemon.go
@@ -632,6 +632,7 @@ func (d *Daemon) syncRedirect(
 	stats := runtimeSlots.Stats()
 	daemonMetrics.SetRedirectSyncObjectCount("runtime_slot_warm", stats.Warm)
 	daemonMetrics.SetRedirectSyncObjectCount("runtime_slot_claimed", stats.Claimed)
+	daemonMetrics.SetRedirectSyncObjectCount("runtime_slot_orphaned", stats.Orphaned)
 	daemonMetrics.SetRedirectSyncObjectCount("runtime_slot_terminal", stats.Terminal)
 	pendingRevisions := uint64(0)
 	if stats.Revision > stats.AppliedRevision {

--- a/ctld/internal/ctld/networking/slotnetwork/inspector_linux.go
+++ b/ctld/internal/ctld/networking/slotnetwork/inspector_linux.go
@@ -5,6 +5,7 @@ package slotnetwork
 import (
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -26,6 +27,9 @@ func newNamespaceInspector(root string) NamespaceInspector {
 func (i *namespaceInspector) Inspect(path, expectedIdentity string) (string, error) {
 	resolved, err := filepath.EvalSymlinks(filepath.Clean(path))
 	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("resolve network namespace: %w: %w: %w", err, errExactNamespaceAbsent, errdefs.ErrFailedPrecondition)
+		}
 		return "", fmt.Errorf("resolve network namespace: %w: %w", err, errdefs.ErrFailedPrecondition)
 	}
 	relative, err := filepath.Rel(i.root, resolved)
@@ -35,6 +39,9 @@ func (i *namespaceInspector) Inspect(path, expectedIdentity string) (string, err
 	}
 	handle, err := netns.GetFromPath(resolved)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("open network namespace: %w: %w: %w", err, errExactNamespaceAbsent, errdefs.ErrFailedPrecondition)
+		}
 		return "", fmt.Errorf("open network namespace: %w: %w", err, errdefs.ErrFailedPrecondition)
 	}
 	defer handle.Close()
@@ -44,7 +51,7 @@ func (i *namespaceInspector) Inspect(path, expectedIdentity string) (string, err
 	}
 	identity := fmt.Sprintf("netns-v1:%x:%x", uint64(stat.Dev), stat.Ino)
 	if identity != expectedIdentity {
-		return "", fmt.Errorf("network namespace incarnation changed: %w", errdefs.ErrFailedPrecondition)
+		return "", fmt.Errorf("network namespace incarnation changed: %w: %w", errExactNamespaceAbsent, errdefs.ErrFailedPrecondition)
 	}
 	netlinkHandle, err := netlink.NewHandleAt(handle)
 	if err != nil {

--- a/ctld/internal/ctld/networking/slotnetwork/inspector_linux_test.go
+++ b/ctld/internal/ctld/networking/slotnetwork/inspector_linux_test.go
@@ -3,10 +3,20 @@
 package slotnetwork
 
 import (
+	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/containerd/errdefs"
 )
+
+func TestNamespaceInspectorClassifiesMissingExactIncarnation(t *testing.T) {
+	root := t.TempDir()
+	_, err := newNamespaceInspector(root).Inspect(filepath.Join(root, "missing"), "netns-v1:1:2")
+	if !errors.Is(err, errExactNamespaceAbsent) || !errdefs.IsFailedPrecondition(err) {
+		t.Fatalf("missing namespace error = %v", err)
+	}
+}
 
 func TestSelectRoutableIPv4ClassifiesNetworkReadiness(t *testing.T) {
 	if _, err := selectRoutableIPv4(nil); !errdefs.IsUnavailable(err) {

--- a/ctld/internal/ctld/networking/slotnetwork/registry.go
+++ b/ctld/internal/ctld/networking/slotnetwork/registry.go
@@ -45,6 +45,8 @@ var (
 	operationsBucket = []byte("operations-v1")
 	metadataBucket   = []byte("metadata-v1")
 	generationKey    = []byte("generation")
+
+	errExactNamespaceAbsent = errors.New("exact runtime slot network namespace is absent")
 )
 
 // Config constrains durable state and namespace inspection for one node-local
@@ -83,8 +85,9 @@ type registryRecord struct {
 }
 
 type registryEntry struct {
-	record   registryRecord
-	revision uint64
+	record         registryRecord
+	revision       uint64
+	physicalAbsent bool
 }
 
 // Stats is a lock-consistent view of bounded registry cardinality and apply
@@ -92,6 +95,7 @@ type registryEntry struct {
 type Stats struct {
 	Warm            int
 	Claimed         int
+	Orphaned        int
 	Terminal        int
 	Revision        uint64
 	AppliedRevision uint64
@@ -424,6 +428,9 @@ func matchRegistration(entry registryEntry, request protocol.RuntimeSlotNetworkR
 	if entry.record.Registration != request {
 		return 0, fmt.Errorf("runtime slot network registration changed: %w", errdefs.ErrAlreadyExists)
 	}
+	if entry.physicalAbsent {
+		return 0, fmt.Errorf("runtime slot network registration lost its exact namespace: %w", errdefs.ErrFailedPrecondition)
+	}
 	if entry.record.State == recordStateTerminal {
 		return 0, fmt.Errorf("runtime slot network registration is terminal: %w", errdefs.ErrFailedPrecondition)
 	}
@@ -559,6 +566,9 @@ func (r *Registry) prepareState(
 	if !ok {
 		return rootfshandoff.NetworkPolicyToken{}, 0, true, fmt.Errorf("runtime slot has no warm network registration: %w", errdefs.ErrFailedPrecondition)
 	}
+	if entry.physicalAbsent {
+		return rootfshandoff.NetworkPolicyToken{}, 0, true, fmt.Errorf("runtime slot network namespace is absent: %w", errdefs.ErrFailedPrecondition)
+	}
 	switch entry.record.State {
 	case recordStateClaimed:
 		token, revision, err := matchPrepare(entry, request)
@@ -586,6 +596,9 @@ func matchWarmPrepare(record registryRecord, request protocol.RuntimeSlotNetwork
 }
 
 func matchPrepare(entry registryEntry, request protocol.RuntimeSlotNetworkPrepareRequest) (rootfshandoff.NetworkPolicyToken, uint64, error) {
+	if entry.physicalAbsent {
+		return rootfshandoff.NetworkPolicyToken{}, 0, fmt.Errorf("runtime slot network namespace is absent: %w", errdefs.ErrFailedPrecondition)
+	}
 	if entry.record.State != recordStateClaimed || entry.record.Prepare == nil {
 		return rootfshandoff.NetworkPolicyToken{}, 0, fmt.Errorf("runtime slot network policy is not claimed: %w", errdefs.ErrFailedPrecondition)
 	}
@@ -699,11 +712,16 @@ func recordMatchesCleanup(record registryRecord, request protocol.NodeCleanupCon
 	return nil
 }
 
-// Snapshot returns the exact warm and claimed desired set and the revision that
-// an external redirect reconciliation may acknowledge.
+// Snapshot returns the exact physically present warm and claimed desired set
+// and the revision that an external redirect reconciliation may acknowledge.
+// A disappeared namespace is fenced in memory so an orphaned durable record
+// cannot collide with an IP that Nomad has reassigned to a newer allocation.
 func (r *Registry) Snapshot() ([]*model.SandboxInfo, uint64, error) {
 	if r == nil {
 		return nil, 0, fmt.Errorf("runtime slot network registry is unavailable: %w", errdefs.ErrUnavailable)
+	}
+	if err := r.fenceAbsentNamespaces(); err != nil {
+		return nil, 0, err
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -712,7 +730,8 @@ func (r *Registry) Snapshot() ([]*model.SandboxInfo, uint64, error) {
 	}
 	keys := make([]string, 0, len(r.entries))
 	for key, entry := range r.entries {
-		if entry.record.State == recordStateWarm || entry.record.State == recordStateClaimed {
+		if !entry.physicalAbsent &&
+			(entry.record.State == recordStateWarm || entry.record.State == recordStateClaimed) {
 			keys = append(keys, key)
 		}
 	}
@@ -732,6 +751,92 @@ func (r *Registry) Snapshot() ([]*model.SandboxInfo, uint64, error) {
 	return sandboxes, r.revision, nil
 }
 
+type namespaceCandidate struct {
+	key          string
+	registration protocol.RuntimeSlotNetworkRegistrationRequest
+	sourceIP     string
+}
+
+func (r *Registry) fenceAbsentNamespaces() error {
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return fmt.Errorf("runtime slot network registry is closed: %w", errdefs.ErrUnavailable)
+	}
+	bySourceIP := make(map[string][]namespaceCandidate)
+	for key, entry := range r.entries {
+		if entry.physicalAbsent ||
+			(entry.record.State != recordStateWarm && entry.record.State != recordStateClaimed) {
+			continue
+		}
+		candidate := namespaceCandidate{
+			key: key, registration: entry.record.Registration, sourceIP: entry.record.SourceIP,
+		}
+		bySourceIP[candidate.sourceIP] = append(bySourceIP[candidate.sourceIP], candidate)
+	}
+	candidates := make([]namespaceCandidate, 0)
+	for _, collisions := range bySourceIP {
+		if len(collisions) > 1 {
+			candidates = append(candidates, collisions...)
+		}
+	}
+	r.mu.Unlock()
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].key < candidates[j].key })
+
+	absent := make([]namespaceCandidate, 0)
+	for _, candidate := range candidates {
+		registration := candidate.registration
+		sourceIP, err := r.inspector.Inspect(
+			filepath.Join(r.config.NetNSRoot, registration.NetNSRelativePath),
+			registration.NetNSIdentity,
+		)
+		if errors.Is(err, errExactNamespaceAbsent) {
+			absent = append(absent, candidate)
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("revalidate runtime slot network namespace %s: %w", candidate.key, err)
+		}
+		if sourceIP != candidate.sourceIP {
+			return fmt.Errorf(
+				"runtime slot network source IP changed from %s to %s for %s: %w",
+				candidate.sourceIP, sourceIP, candidate.key, errdefs.ErrFailedPrecondition,
+			)
+		}
+	}
+	if len(absent) == 0 {
+		return nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return fmt.Errorf("runtime slot network registry is closed: %w", errdefs.ErrUnavailable)
+	}
+	changed := make([]string, 0, len(absent))
+	for _, candidate := range absent {
+		entry, ok := r.entries[candidate.key]
+		if !ok || entry.physicalAbsent || entry.record.Registration != candidate.registration ||
+			entry.record.SourceIP != candidate.sourceIP ||
+			(entry.record.State != recordStateWarm && entry.record.State != recordStateClaimed) {
+			continue
+		}
+		entry.physicalAbsent = true
+		r.entries[candidate.key] = entry
+		changed = append(changed, candidate.key)
+	}
+	if len(changed) == 0 {
+		return nil
+	}
+	r.revision++
+	for _, key := range changed {
+		entry := r.entries[key]
+		entry.revision = r.revision
+		r.entries[key] = entry
+	}
+	return nil
+}
+
 // Stats returns registry cardinality and apply lag without exposing records.
 func (r *Registry) Stats() Stats {
 	if r == nil {
@@ -741,6 +846,10 @@ func (r *Registry) Stats() Stats {
 	defer r.mu.Unlock()
 	stats := Stats{Revision: r.revision, AppliedRevision: r.appliedRevision}
 	for _, entry := range r.entries {
+		if entry.physicalAbsent {
+			stats.Orphaned++
+			continue
+		}
 		switch entry.record.State {
 		case recordStateWarm:
 			stats.Warm++

--- a/ctld/internal/ctld/networking/slotnetwork/registry_test.go
+++ b/ctld/internal/ctld/networking/slotnetwork/registry_test.go
@@ -217,6 +217,50 @@ func TestRegistryRequiresWarmRegistrationAndUniqueClaimOperation(t *testing.T) {
 	}
 }
 
+func TestRegistryFencesAbsentNamespaceBeforeSourceIPReuse(t *testing.T) {
+	directory := t.TempDir()
+	netnsRoot := filepath.Join(directory, "netns")
+	if err := ensureDirectory(netnsRoot); err != nil {
+		t.Fatal(err)
+	}
+	inspector := &fakeNamespaceInspector{podIP: "192.0.2.8"}
+	registry := newTestRegistry(t, filepath.Join(directory, "network.db"), netnsRoot, inspector, time.Hour)
+	defer registry.Close()
+	autoAcknowledge(registry)
+	first := testRegistrationRequest()
+	if err := registry.Register(t.Context(), first); err != nil {
+		t.Fatal(err)
+	}
+	second := first
+	second.SlotID = "slot-2"
+	second.AllocationID = "allocation-2"
+	second.NetNSRelativePath = "allocation-2"
+	second.NetNSIdentity = "netns-v1:1:3"
+	if err := registry.Register(t.Context(), second); err != nil {
+		t.Fatal(err)
+	}
+	before := registry.Stats().Revision
+	inspector.mu.Lock()
+	inspector.errors = []error{fmt.Errorf("namespace removed: %w", errExactNamespaceAbsent), nil}
+	inspector.mu.Unlock()
+	sandboxes, revision, err := registry.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sandboxes) != 1 || sandboxes[0].Name != second.SlotID || sandboxes[0].SourceIP != "192.0.2.8" {
+		t.Fatalf("snapshot after source IP reuse = %+v", sandboxes)
+	}
+	stats := registry.Stats()
+	if revision <= before || stats.Revision != revision || stats.Orphaned != 1 || stats.Warm != 1 {
+		t.Fatalf("registry stats after fencing = %+v, revision %d", stats, revision)
+	}
+	registry.Acknowledge(revision)
+	cleanup := testCleanupRequest()
+	if err := registry.Cleanup(t.Context(), cleanup); err != nil {
+		t.Fatalf("cleanup of fenced record = %v", err)
+	}
+}
+
 func TestRegistryRejectsChangedAndLegacyPolicyRequests(t *testing.T) {
 	directory := t.TempDir()
 	netnsRoot := filepath.Join(directory, "netns")


### PR DESCRIPTION
## Summary
- detect duplicate runtime-slot source IPs before ctld policy compilation
- revalidate each colliding slot against its exact netns incarnation
- fence only records whose exact namespace is proven absent, while preserving their durable cleanup replay
- keep ambiguous or still-live collisions fail closed
- expose orphaned runtime-slot network cardinality as a redirect-sync metric

## Why
A Nomad allocation can disappear after forced client GC before its ctld network cleanup completes. Its durable local record then collides when CNI reuses the source IP. The collision prevents redirect acknowledgement, makes ctld unready, and causes all subsequent prepare calls to time out.

## Validation
- ok  	github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/networking/slotnetwork	(cached)
ok  	github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/networking	(cached)
- ok  	github.com/sandbox0-ai/sandbox0/ctld/cmd/ctld	(cached)
ok  	github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/ha	(cached)
ok  	github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/networking	(cached)
?   	github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/networking/conntrack	[no test files]
ok  	github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/networking/metering	(cached)
?   	github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/networking/model	[no test files]
ok  	github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/networking/policy	(cached)
ok  	github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/networking/proxy	(cached)
ok  	github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/networking/redirect	(cached)
ok  	github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/networking/slotnetwork	(cached)
ok  	github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/runtimemetrics	(cached)
ok  	github.com/sandbox0-ai/sandbox0/ctld/internal/ctld/server	(cached)
ok  	github.com/sandbox0-ai/sandbox0/pkg/nomadruntime	(cached)
- 

No local e2e was run; GitHub PR CI owns e2e.