### PR TITLE
fix(nomad): use node allocation CNI for warm slots

### DIFF
--- a/deploy/nomad/README.md
+++ b/deploy/nomad/README.md
@@ -138,7 +138,9 @@ mutually authenticated.
 4. Submit `nomad-driver-sandbox0/example/warm-slot.nomad` with
    `-var='datacenter=<region-id-with-hyphens-replaced-by-underscores>'`. Keep
    `restart { attempts = 0 }`: a consumed slot gets a fresh allocation and
-   network namespace, never a task restart in the same allocation.
+   network namespace, never a task restart in the same allocation. Keep the
+   task groups on `cni/sandbox0`; Nomad's built-in `bridge` network does not
+   use the node's rendered allocation-CIDR configuration.
 5. Confirm PostgreSQL has live node capacity, resource-neutral ready slots,
    connected node channels, default-deny networking, and replacement slots.
 6. Run `tools/runtime-slot-slo` through the public regional endpoint as

--- a/deploy/nomad/assets_test.go
+++ b/deploy/nomad/assets_test.go
@@ -54,6 +54,12 @@ func TestAcceptanceExamplesUseDedicatedResourceNeutralWarmCarriers(t *testing.T)
 	if cpu, memory := strings.Count(warmJob, "cpu    = 50"), strings.Count(warmJob, "memory = 64"); cpu != minimumAcceptanceWidth || memory != minimumAcceptanceWidth {
 		t.Fatalf("warm carrier overhead records = cpu %d memory %d, want %d each", cpu, memory, minimumAcceptanceWidth)
 	}
+	if networks := strings.Count(warmJob, `mode = "cni/sandbox0"`); networks != minimumAcceptanceWidth {
+		t.Fatalf("warm carrier Sandbox0 CNI networks = %d, want %d", networks, minimumAcceptanceWidth)
+	}
+	if regexp.MustCompile(`(?m)^\s*mode\s*=\s*"bridge"\s*$`).MatchString(warmJob) {
+		t.Fatal("warm carriers must not use Nomad's built-in shared bridge network")
+	}
 	if !strings.Contains(warmJob, `attribute = "${meta.sandbox0_dedicated}"`) ||
 		!strings.Contains(warmJob, `attribute = "${meta.sandbox0_admitted}"`) ||
 		!strings.Contains(warmJob, `value     = "true"`) {

--- a/docs/self-hosted/configuration/page.mdx
+++ b/docs/self-hosted/configuration/page.mdx
@@ -227,6 +227,11 @@ restart {
 }
 ```
 
+Each task group must also keep `network { mode = "cni/sandbox0" }`. That name
+selects the rendered per-node CNI configuration and its leased allocation
+CIDR. Nomad `bridge` mode selects a different built-in network and must not be
+used for these carriers.
+
 Each carrier is one-shot. Nomad replaces the allocation after consumption.
 Pool width, node capacity, and NBD count are independent constraints and should
 be monitored together.

--- a/docs/self-hosted/install/page.mdx
+++ b/docs/self-hosted/install/page.mdx
@@ -172,6 +172,10 @@ nomad job run \
 Keep `restart { attempts = 0 }`. A carrier is one-shot and must be replaced by a
 fresh allocation and network namespace after consumption.
 
+Keep every carrier on `mode = "cni/sandbox0"`. The control-plane-rendered
+`sandbox0` CNI network binds the node's allocated CIDR; Nomad's built-in
+`bridge` mode uses its separate default network and is not interchangeable.
+
 Confirm manager sees:
 
 - live node capacity and current boot IDs;

--- a/docs/template/pool/page.mdx
+++ b/docs/template/pool/page.mdx
@@ -67,7 +67,8 @@ inventory in the `system` job at
 `nomad-driver-sandbox0/example/warm-slot.nomad`. The current job creates eight
 single-use carriers on every admitted dedicated node. A terminal sandbox
 consumes its allocation, and Nomad creates a fresh allocation with a fresh
-network namespace. Task restart in the old allocation is disabled.
+network namespace on the identity-bound `cni/sandbox0` network. Task restart
+in the old allocation is disabled.
 
 A ready carrier alone is insufficient. A claim also requires all of the
 following:

--- a/nomad-driver-sandbox0/example/warm-slot.nomad
+++ b/nomad-driver-sandbox0/example/warm-slot.nomad
@@ -32,7 +32,7 @@ job "sandbox0-warm-slots" {
     }
 
     network {
-      mode = "bridge"
+      mode = "cni/sandbox0"
 
       port "procd" {
         to = 49983
@@ -64,7 +64,7 @@ job "sandbox0-warm-slots" {
     }
 
     network {
-      mode = "bridge"
+      mode = "cni/sandbox0"
 
       port "procd" {
         to = 49983
@@ -96,7 +96,7 @@ job "sandbox0-warm-slots" {
     }
 
     network {
-      mode = "bridge"
+      mode = "cni/sandbox0"
 
       port "procd" {
         to = 49983
@@ -128,7 +128,7 @@ job "sandbox0-warm-slots" {
     }
 
     network {
-      mode = "bridge"
+      mode = "cni/sandbox0"
 
       port "procd" {
         to = 49983
@@ -160,7 +160,7 @@ job "sandbox0-warm-slots" {
     }
 
     network {
-      mode = "bridge"
+      mode = "cni/sandbox0"
 
       port "procd" {
         to = 49983
@@ -192,7 +192,7 @@ job "sandbox0-warm-slots" {
     }
 
     network {
-      mode = "bridge"
+      mode = "cni/sandbox0"
 
       port "procd" {
         to = 49983
@@ -224,7 +224,7 @@ job "sandbox0-warm-slots" {
     }
 
     network {
-      mode = "bridge"
+      mode = "cni/sandbox0"
 
       port "procd" {
         to = 49983
@@ -256,7 +256,7 @@ job "sandbox0-warm-slots" {
     }
 
     network {
-      mode = "bridge"
+      mode = "cni/sandbox0"
 
       port "procd" {
         to = 49983


### PR DESCRIPTION
Production evidence showed every carrier veth attached to Nomad’s built-in `nomad` bridge while the rendered per-node allocation route and CNI contract use `s0nomad`. The host therefore selected the down `s0nomad` route, ARP remained incomplete, stock runsc received no usable traffic, and procd never became ready. This switches all eight resource-neutral carriers from built-in `bridge` mode to the rendered `cni/sandbox0` network, adds a fail-closed asset test, and updates deployment/docs.\n\nValidated with focused Go tests and Nomad 1.11.3 `job validate`; no local e2e was run.