### PR TITLE
fix(manager): fence aborted resume runtimes

### DIFF
--- a/manager/pkg/runtimeslotreconciler/reconciler.go
+++ b/manager/pkg/runtimeslotreconciler/reconciler.go
@@ -238,9 +238,6 @@ func (r *Reconciler) reconcile(ctx context.Context, slotID string) (bool, error)
 	if slot.State == sandboxstore.RuntimeSlotStateTerminal {
 		return false, nil
 	}
-	if !runtimeSlotDue(slot) {
-		return false, nil
-	}
 	if slot.ClaimID != "" && slot.State != sandboxstore.RuntimeSlotStateQuiescing &&
 		slot.State != sandboxstore.RuntimeSlotStateOrphaned {
 		slot, err = r.store.FenceRuntimeSlotForReconcile(ctx, &sandboxstore.FenceRuntimeSlotForReconcileRequest{
@@ -250,8 +247,10 @@ func (r *Reconciler) reconcile(ctx context.Context, slotID string) (bool, error)
 			return false, nil
 		}
 		if err != nil {
-			return false, fmt.Errorf("fence expired claim: %w", err)
+			return false, fmt.Errorf("fence runtime slot claim: %w", err)
 		}
+	} else if !runtimeSlotDue(slot) {
+		return false, nil
 	}
 	if err := validateSlotIdentity(slot); err != nil {
 		return false, err

--- a/manager/pkg/runtimeslotreconciler/reconciler_test.go
+++ b/manager/pkg/runtimeslotreconciler/reconciler_test.go
@@ -696,15 +696,16 @@ func TestReconcilerRejectsChangedWriterFenceProofBeforeNodeCleanup(t *testing.T)
 	}
 }
 
-func TestReconcilerSkipsCandidateWhoseLivenessRecovered(t *testing.T) {
+func TestReconcilerRechecksClaimedCandidateWhoseLivenessRecovered(t *testing.T) {
 	fixture := newReconcileFixture(t, true)
 	fixture.store.slot.HeartbeatExpiresAt = fixture.store.slot.AuthorityObservedAt.Add(time.Minute)
 	result, err := fixture.reconciler.RunOnce(context.Background())
 	if err != nil || result.Skipped != 1 {
 		t.Fatalf("RunOnce() = %+v, %v", result, err)
 	}
-	if fixture.store.fenceCalls != 0 || len(fixture.node.requests) != 0 {
-		t.Fatalf("recovered slot was fenced or cleaned")
+	if fixture.store.fenceCalls != 1 || len(fixture.node.requests) != 0 {
+		t.Fatalf("recovered slot fence recheck = %d, node cleanup = %d",
+			fixture.store.fenceCalls, len(fixture.node.requests))
 	}
 }
 

--- a/manager/pkg/sandboxstore/nomad_resume.go
+++ b/manager/pkg/sandboxstore/nomad_resume.go
@@ -280,9 +280,9 @@ func (s *PGSandboxStore) RequestNomadSandboxResume(
 }
 
 // AbortNomadSandboxResume terminally closes only the exact uncommitted resume
-// attempt. It deliberately leaves physical slot and writer cleanup to the
-// terminal reconciler, which must prove node and cgroup absence before it can
-// release the resource lease. A concurrent successful commit always wins.
+// attempt and quiesces any physical slot owned by it. The terminal reconciler
+// still proves node and cgroup absence before releasing the resource lease. A
+// concurrent successful commit always wins.
 func (s *PGSandboxStore) AbortNomadSandboxResume(
 	ctx context.Context,
 	sandboxID string,
@@ -327,6 +327,11 @@ func (s *PGSandboxStore) AbortNomadSandboxResume(
 		return false, fmt.Errorf("lock Nomad resume lifecycle for abort: %w", err)
 	}
 	if lifecycle.Phase == SandboxLifecyclePhaseCommitted || lifecycle.Phase == SandboxLifecyclePhaseAborted {
+		if lifecycle.Phase == SandboxLifecyclePhaseAborted {
+			if err := quiesceAbortedNomadResumeSlots(ctx, tx, sandboxID, operationID); err != nil {
+				return false, err
+			}
+		}
 		if err := tx.Commit(ctx); err != nil {
 			return false, fmt.Errorf("commit terminal Nomad resume abort retry: %w", err)
 		}
@@ -356,10 +361,28 @@ func (s *PGSandboxStore) AbortNomadSandboxResume(
 	if tag.RowsAffected() != 1 {
 		return false, fmt.Errorf("%w: resume lifecycle changed during abort", ErrNomadSandboxResumeConflict)
 	}
+	if err := quiesceAbortedNomadResumeSlots(ctx, tx, sandboxID, operationID); err != nil {
+		return false, err
+	}
 	if err := tx.Commit(ctx); err != nil {
 		return false, fmt.Errorf("commit Nomad sandbox resume abort: %w", err)
 	}
 	return true, nil
+}
+
+func quiesceAbortedNomadResumeSlots(ctx context.Context, tx pgx.Tx, sandboxID, operationID string) error {
+	if _, err := tx.Exec(ctx, `
+		UPDATE manager.runtime_slots
+		SET state = $3, revision = revision + 1,
+			heartbeat_expires_at = LEAST(heartbeat_expires_at, NOW()),
+			quiescing_at = COALESCE(quiescing_at, NOW()), updated_at = NOW()
+		WHERE sandbox_id = $1 AND claim_operation_id = $2
+			AND state IN ($4, $5, $6)
+	`, sandboxID, operationID, RuntimeSlotStateQuiescing,
+		RuntimeSlotStateClaiming, RuntimeSlotStateStarting, RuntimeSlotStateActive); err != nil {
+		return fmt.Errorf("quiesce aborted Nomad resume slots: %w", err)
+	}
+	return nil
 }
 
 // CompleteNomadSandboxResume atomically makes an exact command-ready slot the

--- a/manager/pkg/sandboxstore/nomad_resume_integration_test.go
+++ b/manager/pkg/sandboxstore/nomad_resume_integration_test.go
@@ -2,6 +2,7 @@ package sandboxstore
 
 import (
 	"bytes"
+	"context"
 	"strconv"
 	"strings"
 	"testing"
@@ -108,66 +109,10 @@ func TestNomadSandboxResumePersistsClaimsAndCommitsExactRuntimeIntegration(t *te
 	require.Equal(t, requested.OperationID, durableRetry.OperationID)
 	require.Equal(t, requested.SourceGenerationID, durableRetry.SourceGenerationID)
 
-	registration := runtimeSlotTestRegistration("slot-nomad-resume-new", "allocation-nomad-resume-new")
-	registration.AllocationNamespace = "nomad"
-	_, err = registerRuntimeSlotWithTestCapacity(t, fixture.ctx, fixture.store, registration)
-	require.NoError(t, err)
-	readyProof := bytes.Repeat([]byte{0xa1}, 32)
-	_, err = fixture.store.ReportRuntimeSlotReady(fixture.ctx, &ReportRuntimeSlotReadyRequest{
-		SlotID: registration.SlotID, AllocationID: registration.AllocationID,
-		NodeUID: registration.NodeUID, NodeBootID: registration.NodeBootID,
-		RuntimeReadyDigest: readyProof, NetworkReadyDigest: readyProof,
-		StorageReadyDigest: readyProof, HeartbeatTTL: time.Minute,
-	})
-	require.NoError(t, err)
-	claimID := "claim-nomad-resume-new"
-	acquire := &AcquireRuntimeSlotRequest{
-		OperationID: requested.OperationID, ClaimID: claimID, SandboxID: requested.SandboxID,
-		FilesystemID: requested.FilesystemID, SourceGenerationID: requested.SourceGenerationID,
-		CompatibilityDigest: registration.CompatibilityDigest, ClusterID: registration.ClusterID,
-		RuntimeAssignmentRevision: strings.Repeat("ab", 32),
-		NetworkPolicyDigest:       "sha256:" + strings.Repeat("cd", 32), ClaimTTL: time.Minute,
-		Resources: runtimeSlotTestResources(),
-	}
-	claimed, err := fixture.store.AcquireRuntimeSlot(fixture.ctx, acquire)
-	require.NoError(t, err)
-	require.Equal(t, registration.SlotID, claimed.ID)
-
-	binding := bytes.Repeat([]byte{0xa2}, 32)
-	issue := rootFSWriterGrantTestIssueRequest(
-		fixture.sandboxID, "grant-nomad-resume-new", claimID, registration.SlotID, binding,
-	)
-	issue.ExpectedFilesystemID = requested.FilesystemID
-	issue.InitialGenerationID = requested.SourceGenerationID
-	issue.ExpectedWriterEpoch = fixture.writerEpoch
-	issue.RuntimeNamespace = registration.AllocationNamespace
-	issue.RuntimeID = "slot"
-	issue.RuntimeIncarnationID = registration.AllocationID
-	issue.NodeName = registration.NodeID
-	issue.NodeUID = registration.NodeUID
-	issue.NodeBootID = registration.NodeBootID
-	issue.RuntimeGeneration = strconv.FormatInt(requested.RuntimeGeneration, 10)
-	issued, err := fixture.store.IssueRootFSWriterGrant(fixture.ctx, issue)
-	require.NoError(t, err)
-	_, err = fixture.store.BindRuntimeSlotWriterGrant(fixture.ctx, &BindRuntimeSlotWriterGrantRequest{
-		SlotID: claimed.ID, OperationID: acquire.OperationID, ClaimID: claimID, GrantID: issue.GrantID,
-	})
-	require.NoError(t, err)
-	_, err = fixture.store.ConsumeRootFSWriterGrant(fixture.ctx, &ConsumeRootFSWriterGrantRequest{
-		GrantID: issue.GrantID, WriterEpoch: issued.Grant.WriterEpoch, RawToken: issue.RawToken,
-		BindingVersion: RootFSWriterBindingVersion, BindingDigest: binding,
-		ConsumerNodeUID: registration.NodeUID, ConsumerAgentUID: "ctld-resume", LeaseTTL: time.Minute,
-	})
-	require.NoError(t, err)
-	_, err = fixture.store.StartRuntimeSlot(fixture.ctx, &StartRuntimeSlotRequest{
-		SlotID: claimed.ID, AllocationID: registration.AllocationID,
-		NodeUID: registration.NodeUID, NodeBootID: registration.NodeBootID,
-		OperationID: acquire.OperationID, ClaimID: acquire.ClaimID,
-		LaunchAttempt: "launch-nomad-resume", RunscContainerID: "runsc-nomad-resume",
-		RootFSBindingDigest: binding, ClaimNetworkDigest: bytes.Repeat([]byte{0xa3}, 32),
-		ResourceLeaseID: claimed.ResourceLease.LeaseID, ResourceLeaseDigest: claimed.ResourceLeaseDigest,
-	})
-	require.NoError(t, err)
+	runtime := prepareNomadResumeRuntime(t, fixture, requested, "new")
+	registration := runtime.registration
+	acquire := runtime.acquire
+	claimed := runtime.claimed
 	_, err = fixture.store.MarkRuntimeSlotCommandReady(fixture.ctx, &MarkRuntimeSlotCommandReadyRequest{
 		SlotID: claimed.ID, AllocationID: registration.AllocationID,
 		NodeUID: registration.NodeUID, NodeBootID: registration.NodeBootID,
@@ -239,6 +184,104 @@ func TestNomadSandboxResumePersistsClaimsAndCommitsExactRuntimeIntegration(t *te
 	require.Equal(t, RuntimeSlotStateQuiescing, cleanup.SlotState)
 }
 
+func TestNomadSandboxResumeFencesLateCommandReadyAfterAbortIntegration(t *testing.T) {
+	fixture := newNomadPauseStoreFixture(t, "resume-late-ready")
+	terminalizeNomadPauseFixture(t, fixture)
+	requested, err := fixture.store.RequestNomadSandboxResume(fixture.ctx, &RequestNomadSandboxResumeRequest{
+		SandboxID: fixture.sandboxID, ExpectedTeamID: "team-slot",
+	})
+	require.NoError(t, err)
+	runtime := prepareNomadResumeRuntime(t, fixture, requested, "late-ready")
+
+	aborted, err := fixture.store.AbortNomadSandboxResume(
+		fixture.ctx, fixture.sandboxID, requested.OperationID, "planner command-ready deadline elapsed",
+	)
+	require.NoError(t, err)
+	require.True(t, aborted)
+	quiescing, err := fixture.store.GetRuntimeSlot(fixture.ctx, runtime.claimed.ID)
+	require.NoError(t, err)
+	require.Equal(t, RuntimeSlotStateQuiescing, quiescing.State)
+	require.False(t, quiescing.HeartbeatExpiresAt.After(quiescing.AuthorityObservedAt))
+
+	commandReady := &MarkRuntimeSlotCommandReadyRequest{
+		SlotID: runtime.claimed.ID, AllocationID: runtime.registration.AllocationID,
+		NodeUID: runtime.registration.NodeUID, NodeBootID: runtime.registration.NodeBootID,
+		OperationID: runtime.acquire.OperationID, ClaimID: runtime.acquire.ClaimID,
+		ProcdInstanceID: "late-procd", ProcdAddress: "http://192.0.2.11:49983",
+		CommandReadyDigest: bytes.Repeat([]byte{0xb4}, 32),
+	}
+	_, err = fixture.store.MarkRuntimeSlotCommandReady(fixture.ctx, commandReady)
+	require.ErrorIs(t, err, ErrRuntimeSlotConflict)
+
+	// Recreate the state written by managers that predated the abort fence. A
+	// live heartbeat and writer lease must not hide this durable contradiction.
+	_, err = fixture.pool.Exec(fixture.ctx, `
+		UPDATE manager.runtime_slots
+		SET state = $2, revision = revision + 1,
+			heartbeat_expires_at = NOW() + INTERVAL '1 minute', quiescing_at = NULL,
+			procd_instance_id = $3, procd_address = $4, command_ready_digest = $5,
+			command_ready_at = NOW(), updated_at = NOW()
+		WHERE slot_id = $1
+	`, runtime.claimed.ID, RuntimeSlotStateActive, commandReady.ProcdInstanceID,
+		commandReady.ProcdAddress, commandReady.CommandReadyDigest)
+	require.NoError(t, err)
+	candidates, err := fixture.store.ListRuntimeSlotsForReconcile(fixture.ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	require.Equal(t, runtime.claimed.ID, candidates[0].ID)
+
+	legacyActive, err := fixture.store.GetRuntimeSlot(fixture.ctx, runtime.claimed.ID)
+	require.NoError(t, err)
+	fenced, err := fixture.store.FenceRuntimeSlotForReconcile(fixture.ctx, &FenceRuntimeSlotForReconcileRequest{
+		SlotID: legacyActive.ID, ExpectedRevision: legacyActive.Revision,
+	})
+	require.NoError(t, err)
+	require.Equal(t, RuntimeSlotStateQuiescing, fenced.State)
+
+	renewRequest := &RenewRootFSWriterGrantRequest{
+		GrantID: runtime.issue.GrantID, WriterEpoch: runtime.issued.Grant.WriterEpoch,
+		BindingVersion: RootFSWriterBindingVersion, BindingDigest: runtime.binding,
+		ConsumerNodeUID: runtime.registration.NodeUID,
+	}
+	policy := RootFSWriterLeaseRenewalPolicy{LeaseTTL: time.Minute, GracePeriod: time.Second}
+	_, err = fixture.store.RenewRootFSWriterGrant(fixture.ctx, renewRequest, policy)
+	require.ErrorIs(t, err, ErrRootFSWriterGrantInvalidState)
+	batch, err := fixture.store.RenewRootFSWriterGrants(
+		fixture.ctx, []*RenewRootFSWriterGrantRequest{renewRequest}, policy,
+	)
+	require.NoError(t, err)
+	require.Len(t, batch, 1)
+	require.ErrorIs(t, batch[0].Err, ErrRootFSWriterGrantInvalidState)
+
+	crashOperationID := "reconcile-writer-late-ready"
+	err = fixture.store.WithSandboxLock(fixture.ctx, fixture.sandboxID, func(
+		lockCtx context.Context,
+		tx SandboxStoreTx,
+		_ *SandboxRecord,
+	) error {
+		return tx.BeginLifecycleTxn(lockCtx, &SandboxLifecycleTxn{
+			ID: crashOperationID, SandboxID: fixture.sandboxID,
+			Kind: SandboxLifecycleKindPause, Phase: SandboxLifecyclePhasePublishing,
+			Source: SandboxLifecycleSourceCrash, Cancelable: false,
+			FromGeneration:       requested.RuntimeGeneration,
+			FromRuntimeNamespace: runtime.registration.AllocationNamespace,
+			FromRuntimeID:        runtime.registration.AllocationID,
+			ExpectedGenerationID: requested.SourceGenerationID,
+		})
+	})
+	require.NoError(t, err)
+	begun, err := fixture.store.BeginRootFSWriterCrashAbandon(fixture.ctx, &BeginRootFSWriterCrashAbandonRequest{
+		GrantID: runtime.issue.GrantID, WriterEpoch: runtime.issued.Grant.WriterEpoch,
+		OperationID: crashOperationID, BindingVersion: RootFSWriterBindingVersion,
+		BindingDigest: runtime.binding, NodeUID: runtime.registration.NodeUID,
+		NodeBootID:              runtime.registration.NodeBootID,
+		ExpectedOldGenerationID: requested.SourceGenerationID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, RootFSWriterGrantStateRetiring, begun.State,
+		"the durable slot fence must revoke a live writer lease without waiting for wall-clock expiry")
+}
+
 func TestNomadSandboxResumeWaitsForTerminalRuntimeAndReservesQuotaIntegration(t *testing.T) {
 	fixture := newNomadPauseStoreFixture(t, "resume-gates")
 	pause, err := fixture.store.RequestNomadSandboxPause(
@@ -261,6 +304,88 @@ func TestNomadSandboxResumeWaitsForTerminalRuntimeAndReservesQuotaIntegration(t 
 	active, getErr := fixture.store.GetActiveLifecycleTxn(fixture.ctx, fixture.sandboxID)
 	require.NoError(t, getErr)
 	require.Nil(t, active)
+}
+
+type preparedNomadResumeRuntime struct {
+	registration *RegisterRuntimeSlotRequest
+	acquire      *AcquireRuntimeSlotRequest
+	claimed      *RuntimeSlot
+	issue        *IssueRootFSWriterGrantRequest
+	issued       *IssuedRootFSWriterGrant
+	binding      []byte
+}
+
+func prepareNomadResumeRuntime(
+	t *testing.T,
+	fixture *nomadPauseStoreFixture,
+	requested *NomadSandboxResumeCandidate,
+	suffix string,
+) *preparedNomadResumeRuntime {
+	t.Helper()
+	registration := runtimeSlotTestRegistration("slot-nomad-resume-"+suffix, "allocation-nomad-resume-"+suffix)
+	registration.AllocationNamespace = "nomad"
+	_, err := registerRuntimeSlotWithTestCapacity(t, fixture.ctx, fixture.store, registration)
+	require.NoError(t, err)
+	readyProof := bytes.Repeat([]byte{0xa1}, 32)
+	_, err = fixture.store.ReportRuntimeSlotReady(fixture.ctx, &ReportRuntimeSlotReadyRequest{
+		SlotID: registration.SlotID, AllocationID: registration.AllocationID,
+		NodeUID: registration.NodeUID, NodeBootID: registration.NodeBootID,
+		RuntimeReadyDigest: readyProof, NetworkReadyDigest: readyProof,
+		StorageReadyDigest: readyProof, HeartbeatTTL: time.Minute,
+	})
+	require.NoError(t, err)
+	claimID := "claim-nomad-resume-" + suffix
+	acquire := &AcquireRuntimeSlotRequest{
+		OperationID: requested.OperationID, ClaimID: claimID, SandboxID: requested.SandboxID,
+		FilesystemID: requested.FilesystemID, SourceGenerationID: requested.SourceGenerationID,
+		CompatibilityDigest: registration.CompatibilityDigest, ClusterID: registration.ClusterID,
+		RuntimeAssignmentRevision: strings.Repeat("ab", 32),
+		NetworkPolicyDigest:       "sha256:" + strings.Repeat("cd", 32), ClaimTTL: time.Minute,
+		Resources: runtimeSlotTestResources(),
+	}
+	claimed, err := fixture.store.AcquireRuntimeSlot(fixture.ctx, acquire)
+	require.NoError(t, err)
+	require.Equal(t, registration.SlotID, claimed.ID)
+
+	binding := bytes.Repeat([]byte{0xa2}, 32)
+	issue := rootFSWriterGrantTestIssueRequest(
+		fixture.sandboxID, "grant-nomad-resume-"+suffix, claimID, registration.SlotID, binding,
+	)
+	issue.ExpectedFilesystemID = requested.FilesystemID
+	issue.InitialGenerationID = requested.SourceGenerationID
+	issue.ExpectedWriterEpoch = fixture.writerEpoch
+	issue.RuntimeNamespace = registration.AllocationNamespace
+	issue.RuntimeID = "slot"
+	issue.RuntimeIncarnationID = registration.AllocationID
+	issue.NodeName = registration.NodeID
+	issue.NodeUID = registration.NodeUID
+	issue.NodeBootID = registration.NodeBootID
+	issue.RuntimeGeneration = strconv.FormatInt(requested.RuntimeGeneration, 10)
+	issued, err := fixture.store.IssueRootFSWriterGrant(fixture.ctx, issue)
+	require.NoError(t, err)
+	_, err = fixture.store.BindRuntimeSlotWriterGrant(fixture.ctx, &BindRuntimeSlotWriterGrantRequest{
+		SlotID: claimed.ID, OperationID: acquire.OperationID, ClaimID: claimID, GrantID: issue.GrantID,
+	})
+	require.NoError(t, err)
+	_, err = fixture.store.ConsumeRootFSWriterGrant(fixture.ctx, &ConsumeRootFSWriterGrantRequest{
+		GrantID: issue.GrantID, WriterEpoch: issued.Grant.WriterEpoch, RawToken: issue.RawToken,
+		BindingVersion: RootFSWriterBindingVersion, BindingDigest: binding,
+		ConsumerNodeUID: registration.NodeUID, ConsumerAgentUID: "ctld-resume", LeaseTTL: time.Minute,
+	})
+	require.NoError(t, err)
+	_, err = fixture.store.StartRuntimeSlot(fixture.ctx, &StartRuntimeSlotRequest{
+		SlotID: claimed.ID, AllocationID: registration.AllocationID,
+		NodeUID: registration.NodeUID, NodeBootID: registration.NodeBootID,
+		OperationID: acquire.OperationID, ClaimID: acquire.ClaimID,
+		LaunchAttempt: "launch-nomad-resume-" + suffix, RunscContainerID: "runsc-nomad-resume-" + suffix,
+		RootFSBindingDigest: binding, ClaimNetworkDigest: bytes.Repeat([]byte{0xa3}, 32),
+		ResourceLeaseID: claimed.ResourceLease.LeaseID, ResourceLeaseDigest: claimed.ResourceLeaseDigest,
+	})
+	require.NoError(t, err)
+	return &preparedNomadResumeRuntime{
+		registration: registration, acquire: acquire, claimed: claimed,
+		issue: issue, issued: issued, binding: binding,
+	}
 }
 
 func terminalizeNomadPauseFixture(t *testing.T, fixture *nomadPauseStoreFixture) *NomadSandboxPauseCandidate {

--- a/manager/pkg/sandboxstore/runtime_slot.go
+++ b/manager/pkg/sandboxstore/runtime_slot.go
@@ -379,8 +379,12 @@ func (s *PGSandboxStore) FenceRuntimeSlotForReconcile(
 		if slot.Revision != normalized.ExpectedRevision {
 			return nil, fmt.Errorf("%w: runtime slot revision changed", ErrRuntimeSlotConflict)
 		}
+		resumeAuthorityAborted, err := runtimeSlotResumeAuthorityAborted(ctx, tx, slot)
+		if err != nil {
+			return nil, err
+		}
 		due := !slot.HeartbeatExpiresAt.After(slot.AuthorityObservedAt) ||
-			runtimeSlotPreCommandReadyClaimExpired(slot)
+			runtimeSlotPreCommandReadyClaimExpired(slot) || resumeAuthorityAborted
 		if !due {
 			return nil, ErrRuntimeSlotNotDue
 		}
@@ -404,14 +408,15 @@ func (s *PGSandboxStore) FenceRuntimeSlotForReconcile(
 			case RootFSWriterGrantStateIssued, RootFSWriterGrantStateRetiring,
 				RootFSWriterGrantStateRetired, RootFSWriterGrantStateCanceled:
 			case RootFSWriterGrantStateConsumed:
-				if leaseExpiresAt == nil || leaseExpiresAt.Add(RootFSWriterCrashAbandonGrace).After(authorityObservedAt) {
+				if !resumeAuthorityAborted &&
+					(leaseExpiresAt == nil || leaseExpiresAt.Add(RootFSWriterCrashAbandonGrace).After(authorityObservedAt)) {
 					return nil, ErrRuntimeSlotNotDue
 				}
 			default:
 				return nil, fmt.Errorf("%w: runtime slot writer grant is in invalid state %s", ErrRuntimeSlotInvalid, grantState)
 			}
 		}
-		_, err := tx.Exec(ctx, `
+		_, err = tx.Exec(ctx, `
 			UPDATE manager.runtime_slots
 			SET state = $2, revision = revision + 1,
 				heartbeat_expires_at = LEAST(heartbeat_expires_at, NOW()),
@@ -875,21 +880,62 @@ func (s *PGSandboxStore) MarkRuntimeSlotCommandReady(ctx context.Context, reques
 	if err != nil {
 		return nil, err
 	}
-	return s.withLockedRuntimeSlot(ctx, normalized.SlotID, func(tx pgx.Tx, slot *RuntimeSlot) (*RuntimeSlot, error) {
-		if !runtimeSlotCallerMatches(slot, normalized.AllocationID, normalized.NodeUID, normalized.NodeBootID) {
-			return nil, fmt.Errorf("%w: command-ready caller does not match slot incarnation", ErrRuntimeSlotConflict)
-		}
-		if !runtimeSlotClaimIdentityMatches(slot, normalized.OperationID, normalized.ClaimID) {
-			return nil, fmt.Errorf("%w: command-ready caller does not match slot claim", ErrRuntimeSlotConflict)
-		}
-		if slot.State == RuntimeSlotStateActive {
-			if slot.ProcdInstanceID == normalized.ProcdInstanceID &&
-				slot.ProcdAddress == normalized.ProcdAddress &&
-				bytes.Equal(slot.CommandReadyDigest, normalized.CommandReadyDigest) {
-				return nil, nil
-			}
+	if s == nil || s.pool == nil {
+		return nil, fmt.Errorf("sandbox store is not configured")
+	}
+
+	// Read the immutable claim identity before opening the transaction so the
+	// transaction can follow the canonical sandbox -> claim/lifecycle -> slot
+	// lock order. Completion and abort use the same order, which makes a late
+	// node proof serialize with the logical operation that authorizes it.
+	preliminary, err := s.GetRuntimeSlot(ctx, normalized.SlotID)
+	if err != nil {
+		return nil, err
+	}
+	if !runtimeSlotCallerMatches(preliminary, normalized.AllocationID, normalized.NodeUID, normalized.NodeBootID) {
+		return nil, fmt.Errorf("%w: command-ready caller does not match slot incarnation", ErrRuntimeSlotConflict)
+	}
+	if !runtimeSlotClaimIdentityMatches(preliminary, normalized.OperationID, normalized.ClaimID) {
+		return nil, fmt.Errorf("%w: command-ready caller does not match slot claim", ErrRuntimeSlotConflict)
+	}
+
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := lockRuntimeSlotClaimAdmission(ctx, tx, &AcquireRuntimeSlotRequest{
+		OperationID: normalized.OperationID, SandboxID: preliminary.SandboxID,
+		SourceGenerationID: preliminary.SourceGenerationID,
+	}); err != nil {
+		return nil, err
+	}
+	slot, err := scanRuntimeSlot(tx.QueryRow(ctx, runtimeSlotSelectSQL()+`
+		WHERE slot_id = $1
+		FOR UPDATE OF runtime_slots
+	`, normalized.SlotID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("%w: %s", ErrRuntimeSlotNotFound, normalized.SlotID)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if slot.SandboxID != preliminary.SandboxID || slot.SourceGenerationID != preliminary.SourceGenerationID {
+		return nil, fmt.Errorf("%w: command-ready slot authority changed", ErrRuntimeSlotConflict)
+	}
+	if !runtimeSlotCallerMatches(slot, normalized.AllocationID, normalized.NodeUID, normalized.NodeBootID) {
+		return nil, fmt.Errorf("%w: command-ready caller does not match slot incarnation", ErrRuntimeSlotConflict)
+	}
+	if !runtimeSlotClaimIdentityMatches(slot, normalized.OperationID, normalized.ClaimID) {
+		return nil, fmt.Errorf("%w: command-ready caller does not match slot claim", ErrRuntimeSlotConflict)
+	}
+	if slot.State == RuntimeSlotStateActive {
+		if slot.ProcdInstanceID != normalized.ProcdInstanceID ||
+			slot.ProcdAddress != normalized.ProcdAddress ||
+			!bytes.Equal(slot.CommandReadyDigest, normalized.CommandReadyDigest) {
 			return nil, fmt.Errorf("%w: command-ready proof changed", ErrRuntimeSlotConflict)
 		}
+	} else {
 		if slot.State != RuntimeSlotStateStarting {
 			return nil, fmt.Errorf("%w: slot is not starting", ErrRuntimeSlotInvalid)
 		}
@@ -899,16 +945,25 @@ func (s *PGSandboxStore) MarkRuntimeSlotCommandReady(ctx context.Context, reques
 		if runtimeSlotPreCommandReadyClaimExpired(slot) {
 			return nil, fmt.Errorf("%w: slot claim lease expired before command readiness", ErrRuntimeSlotInvalid)
 		}
-		_, err := tx.Exec(ctx, `
+		if _, err := tx.Exec(ctx, `
 			UPDATE manager.runtime_slots
 			SET state = $2, revision = revision + 1,
 				procd_instance_id = $3, procd_address = $4, command_ready_digest = $5,
 				command_ready_at = NOW(), updated_at = NOW()
 			WHERE slot_id = $1
 		`, slot.ID, RuntimeSlotStateActive, normalized.ProcdInstanceID, normalized.ProcdAddress,
-			normalized.CommandReadyDigest)
+			normalized.CommandReadyDigest); err != nil {
+			return nil, mapRuntimeSlotConflict("mark runtime slot command ready", err)
+		}
+	}
+	result, err := scanRuntimeSlot(tx.QueryRow(ctx, runtimeSlotSelectSQL()+` WHERE slot_id = $1`, slot.ID))
+	if err != nil {
 		return nil, err
-	})
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, mapRuntimeSlotConflict("commit runtime slot command ready", err)
+	}
+	return result, nil
 }
 
 // BeginRuntimeSlotQuiesce durably removes a claimed slot from the active path
@@ -1064,8 +1119,8 @@ func (s *PGSandboxStore) FinalizeRuntimeSlot(ctx context.Context, request *Final
 }
 
 // ListRuntimeSlotsForReconcile prioritizes orphaned and explicitly quiescing
-// physical incarnations before lease-expired candidates without deleting their
-// durable claim and writer identities.
+// physical incarnations before lease-expired or authority-revoked candidates
+// without deleting their durable claim and writer identities.
 func (s *PGSandboxStore) ListRuntimeSlotsForReconcile(ctx context.Context, limit int) ([]RuntimeSlot, error) {
 	if limit <= 0 || limit > MaxRuntimeSlotReconcileLimit {
 		return nil, fmt.Errorf("runtime slot reconcile limit must be between 1 and %d", MaxRuntimeSlotReconcileLimit)
@@ -1074,12 +1129,21 @@ func (s *PGSandboxStore) ListRuntimeSlotsForReconcile(ctx context.Context, limit
 		WHERE state IN ($1, $2)
 			OR (state <> $3 AND heartbeat_expires_at <= NOW())
 			OR (state IN ($4, $5) AND claim_lease_expires_at <= NOW())
+			OR (state <> $3 AND EXISTS (
+				SELECT 1
+				FROM manager.sandbox_lifecycle_txns AS lifecycle
+				WHERE lifecycle.txn_id = runtime_slots.claim_operation_id
+					AND lifecycle.sandbox_id = runtime_slots.sandbox_id
+					AND lifecycle.kind = $6 AND lifecycle.source = $7
+					AND lifecycle.phase = $8
+			))
 		ORDER BY
 			CASE WHEN state = $1 THEN 0 WHEN state = $2 THEN 1 ELSE 2 END,
 			heartbeat_expires_at, slot_id
-		LIMIT $6
+		LIMIT $9
 	`, RuntimeSlotStateOrphaned, RuntimeSlotStateQuiescing, RuntimeSlotStateTerminal,
-		RuntimeSlotStateClaiming, RuntimeSlotStateStarting, limit)
+		RuntimeSlotStateClaiming, RuntimeSlotStateStarting,
+		SandboxLifecycleKindResume, SandboxLifecycleSourceManual, SandboxLifecyclePhaseAborted, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -1093,6 +1157,25 @@ func (s *PGSandboxStore) ListRuntimeSlotsForReconcile(ctx context.Context, limit
 		result = append(result, *slot)
 	}
 	return result, rows.Err()
+}
+
+func runtimeSlotResumeAuthorityAborted(ctx context.Context, tx pgx.Tx, slot *RuntimeSlot) (bool, error) {
+	if slot == nil || slot.ClaimOperationID == "" || slot.SandboxID == "" {
+		return false, nil
+	}
+	var aborted bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM manager.sandbox_lifecycle_txns
+			WHERE txn_id = $1 AND sandbox_id = $2
+				AND kind = $3 AND source = $4 AND phase = $5
+		)
+	`, slot.ClaimOperationID, slot.SandboxID, SandboxLifecycleKindResume,
+		SandboxLifecycleSourceManual, SandboxLifecyclePhaseAborted).Scan(&aborted); err != nil {
+		return false, fmt.Errorf("check runtime slot resume authority: %w", err)
+	}
+	return aborted, nil
 }
 
 // runtimeSlotPreCommandReadyClaimExpired keeps the bounded claim lease

--- a/manager/pkg/sandboxstore/writer_grant.go
+++ b/manager/pkg/sandboxstore/writer_grant.go
@@ -166,8 +166,8 @@ type BeginRootFSWriterRetireRequest struct {
 
 // BeginRootFSWriterCrashAbandonRequest establishes the regional fencing point
 // before the node produces a terminal proof. An unexpected loss must wait for
-// lease maturity; durable explicit termination may revoke renewal immediately.
-// In both cases the exact runtime and durable generation are locked first.
+// lease maturity; durable termination or an exact quiesced runtime slot may
+// revoke renewal immediately. The exact runtime and generation are locked first.
 type BeginRootFSWriterCrashAbandonRequest struct {
 	GrantID                 string
 	WriterEpoch             int64
@@ -731,13 +731,16 @@ func renewRootFSWriterGrant(
 				FROM manager.runtime_slots AS slot
 				WHERE slot.slot_id = g.slot_id
 					AND slot.writer_grant_id = g.grant_id
-					AND slot.state IN ($9, $10)
-					AND slot.claim_lease_expires_at <= NOW()
+					AND (
+						(slot.state IN ($9, $10) AND slot.claim_lease_expires_at <= NOW())
+						OR slot.state IN ($11, $12, $13)
+					)
 			)
 	`, normalized.GrantID, policy.LeaseTTL.Milliseconds(), RootFSWriterGrantStateConsumed,
 		normalized.WriterEpoch, normalized.BindingVersion,
 		normalized.BindingDigest, normalized.ConsumerNodeUID, policy.GracePeriod.Milliseconds(),
-		RuntimeSlotStateClaiming, RuntimeSlotStateStarting)
+		RuntimeSlotStateClaiming, RuntimeSlotStateStarting,
+		RuntimeSlotStateQuiescing, RuntimeSlotStateOrphaned, RuntimeSlotStateTerminal)
 	if err != nil {
 		return nil, fmt.Errorf("renew rootfs writer grant: %w", err)
 	}
@@ -835,13 +838,16 @@ func renewRootFSWriterGrants(
 				FROM manager.runtime_slots AS slot
 				WHERE slot.slot_id = g.slot_id
 					AND slot.writer_grant_id = g.grant_id
-					AND slot.state IN ($9, $10)
-					AND slot.claim_lease_expires_at <= authority_clock.observed_at
+					AND (
+						(slot.state IN ($9, $10) AND slot.claim_lease_expires_at <= authority_clock.observed_at)
+						OR slot.state IN ($11, $12, $13)
+					)
 			)
 		RETURNING g.grant_id
 	`, grantIDs, epochs, versions, digests, nodeUIDs, policy.LeaseTTL.Milliseconds(),
 		RootFSWriterGrantStateConsumed, policy.GracePeriod.Milliseconds(),
-		RuntimeSlotStateClaiming, RuntimeSlotStateStarting)
+		RuntimeSlotStateClaiming, RuntimeSlotStateStarting,
+		RuntimeSlotStateQuiescing, RuntimeSlotStateOrphaned, RuntimeSlotStateTerminal)
 	if err != nil {
 		return nil, fmt.Errorf("renew rootfs writer grant batch: %w", err)
 	}
@@ -1147,7 +1153,7 @@ func beginRootFSWriterCrashAbandon(
 	}
 	leaseMature := !record.LeaseExpiresAt.IsZero() &&
 		!record.LeaseExpiresAt.Add(RootFSWriterCrashAbandonGrace).After(record.databaseNow)
-	explicitFence := runtimeMatch.terminating || runtimeMatch.failedClaimCleanup
+	explicitFence := runtimeMatch.terminating || runtimeMatch.failedClaimCleanup || runtimeMatch.renewalRevoked
 	if !leaseMature && !explicitFence {
 		return nil, fmt.Errorf("%w: grant %s remains renewable", ErrRootFSWriterFenceNotMature, normalized.GrantID)
 	}
@@ -1626,6 +1632,7 @@ type rootFSWriterCrashRuntimeMatch struct {
 	terminating         bool
 	failedClaimCleanup  bool
 	failedClaimDeletion bool
+	renewalRevoked      bool
 }
 
 func lockRootFSWriterCrashRuntime(
@@ -1659,6 +1666,20 @@ func lockRootFSWriterCrashRuntime(
 	precommitResume := !deletedAt.Valid && desiredState == SandboxDesiredStatePaused &&
 		currentRuntimeNamespace == "" && currentRuntimeID == "" && runtimeGeneration >= 0 &&
 		runtimeGeneration+1 == lifecycle.FromGeneration
+	if err := db.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM manager.runtime_slots
+			WHERE slot_id = $1 AND writer_grant_id = $2
+				AND sandbox_id = $3 AND claim_id = $4 AND filesystem_id = $5
+				AND node_uid = $6 AND node_boot_id = $7
+				AND state IN ($8, $9)
+		)
+	`, record.SlotID, record.ID, record.SandboxID, record.ClaimID, record.FilesystemID,
+		record.NodeUID, record.NodeBootID, RuntimeSlotStateQuiescing, RuntimeSlotStateOrphaned,
+	).Scan(&match.renewalRevoked); err != nil {
+		return match, fmt.Errorf("verify runtime slot writer renewal fence: %w", err)
+	}
 	match.failedClaimDeletion = desiredState == SandboxDesiredStateDeleted && deletedAt.Valid &&
 		currentRuntimeNamespace == "" && currentRuntimeID == "" && runtimeGeneration == lifecycle.FromGeneration
 	failedClaimCandidate := !deletedAt.Valid &&


### PR DESCRIPTION
## Summary
- serialize command-ready with the logical claim/resume authority before activating a runtime slot
- quiesce exact physical slots when a resume aborts and rediscover pre-fix active slots owned by aborted resumes
- stop writer renewal after a slot fence and let exact quiescing authority revoke a live lease immediately

## Why
A command-ready proof could arrive after its resume lifecycle had already aborted. The slot then became active while the logical sandbox remained paused, and the recovery path could not match the newer writer grant. This left pause/resume permanently blocked.

## Tests
- `go test ./manager/pkg/...`
- full PostgreSQL-backed integration suite: `TEST_DATABASE_URL=... go test ./manager/pkg/sandboxstore ./manager/pkg/runtimeslotwriter ./manager/pkg/runtimeslotreconciler -count=1`
- new integration coverage recreates the production late-command-ready contradiction and verifies durable rediscovery, slot fencing, renewal rejection, and immediate crash-abandon fencing
