### PR TITLE
fix(manager): keep pause pending until runtime slot terminalizes

### DIFF
--- a/manager/pkg/nomadclaim/service.go
+++ b/manager/pkg/nomadclaim/service.go
@@ -349,7 +349,7 @@ func (s *Service) CompletePausingSandboxRuntime(ctx context.Context, sandboxID s
 		if err != nil {
 			return fmt.Errorf("quiesce planned-paused Nomad runtime slot: %w", err)
 		}
-		return nil
+		return errNomadSandboxPausePending
 	}
 	target := protocol.NodeChannelTarget{
 		SlotID: candidate.SlotID, ClusterID: candidate.ClusterID,

--- a/manager/pkg/nomadclaim/service_test.go
+++ b/manager/pkg/nomadclaim/service_test.go
@@ -1231,22 +1231,23 @@ func TestServicePressurePauseReturnsDurableOperationBeforeNomadStop(t *testing.T
 	}
 }
 
-func TestServiceQuiescesSlotOnlyAfterPlannedPauseCommitted(t *testing.T) {
+func TestServiceKeepsCommittedPausePendingUntilSlotIsTerminal(t *testing.T) {
 	fixture := newClaimServiceFixture(t)
 	fixture.store.pauseCandidate = &sandboxstore.NomadSandboxPauseCandidate{
 		SandboxID: "sandbox-1", AlreadyPaused: true,
 		ClaimOperationID: "claim-operation-1", ClaimID: "claim-1", SlotID: "slot-1",
 	}
 
-	if err := fixture.service.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"); err != nil {
-		t.Fatal(err)
-	}
+	require.ErrorIs(t, fixture.service.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"), errNomadSandboxPausePending)
 	if len(fixture.store.quiesceCalls) != 1 || fixture.store.quiesceCalls[0].SlotID != "slot-1" {
 		t.Fatalf("quiesce calls = %+v", fixture.store.quiesceCalls)
 	}
 	if len(fixture.allocation.requests) != 0 {
 		t.Fatalf("committed pause stopped allocation again: %+v", fixture.allocation.requests)
 	}
+
+	fixture.store.pauseCandidate.SlotID = ""
+	require.NoError(t, fixture.service.CompletePausingSandboxRuntime(context.Background(), "sandbox-1"))
 }
 
 func TestServiceResumesPausedNomadSandboxThroughDurableSlotClaim(t *testing.T) {

--- a/manager/pkg/service/nomad_sandbox_reader.go
+++ b/manager/pkg/service/nomad_sandbox_reader.go
@@ -47,7 +47,11 @@ func (r *NomadSandboxReader) GetSandbox(ctx context.Context, sandboxID string) (
 		return nil, sandboxstore.ErrSandboxRecordNotFound
 	}
 	projected := sandboxRecordToSandbox(record)
-	if record.DesiredState != sandboxstore.SandboxDesiredStateActive {
+	switch record.DesiredState {
+	case sandboxstore.SandboxDesiredStatePaused:
+		return r.projectPaused(ctx, record, projected)
+	case sandboxstore.SandboxDesiredStateActive:
+	default:
 		return projected, nil
 	}
 	activeTxn, err := r.store.GetActiveLifecycleTxn(ctx, sandboxID)
@@ -83,11 +87,14 @@ func (r *NomadSandboxReader) ListSandboxes(ctx context.Context, request *sandbox
 			continue
 		}
 		projected := sandboxRecordToSandbox(record)
-		if record.DesiredState == sandboxstore.SandboxDesiredStateActive {
+		switch record.DesiredState {
+		case sandboxstore.SandboxDesiredStatePaused:
+			projected, err = r.projectPaused(ctx, record, projected)
+		case sandboxstore.SandboxDesiredStateActive:
 			projected, err = r.projectActive(ctx, record, nil, projected)
-			if err != nil {
-				return nil, err
-			}
+		}
+		if err != nil {
+			return nil, err
 		}
 		if normalized.Status != "" && projected.Status != normalized.Status {
 			continue
@@ -130,6 +137,28 @@ func (r *NomadSandboxReader) GetSandboxStatus(ctx context.Context, sandboxID str
 		return nil, err
 	}
 	return sandboxStatusResponse(sandbox), nil
+}
+
+func (r *NomadSandboxReader) projectPaused(
+	ctx context.Context,
+	record *sandboxstore.SandboxRecord,
+	projected *managerapi.Sandbox,
+) (*managerapi.Sandbox, error) {
+	slot, err := r.store.GetRuntimeSlotBySandboxID(ctx, record.ID)
+	if errors.Is(err, sandboxstore.ErrRuntimeSlotNotFound) {
+		return projected, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get paused Nomad runtime slot projection: %w", err)
+	}
+	if slot == nil || slot.SandboxID != record.ID {
+		return nil, fmt.Errorf("paused Nomad runtime slot projection does not match sandbox %s", record.ID)
+	}
+	projected.Status = managerapi.SandboxStatusStarting
+	projected.Paused = false
+	projected.RuntimeID = slot.AllocationID
+	projected.InternalAddr = ""
+	return projected, nil
 }
 
 func (r *NomadSandboxReader) projectActive(

--- a/manager/pkg/service/nomad_sandbox_reader_test.go
+++ b/manager/pkg/service/nomad_sandbox_reader_test.go
@@ -61,6 +61,53 @@ func TestNomadSandboxReaderProjectsRuntimeSlotAndLifecycleFence(t *testing.T) {
 	}
 }
 
+func TestNomadSandboxReaderProjectsPausedOnlyAfterRuntimeSlotIsTerminal(t *testing.T) {
+	now := time.Date(2026, time.August, 30, 3, 0, 0, 0, time.UTC)
+	store := &memorySandboxStore{
+		records: map[string]*sandboxstore.SandboxRecord{
+			"sandbox-a": {
+				ID: "sandbox-a", TeamID: "team-a", TemplateID: "default",
+				DesiredState: sandboxstore.SandboxDesiredStatePaused,
+				CreatedAt:    now,
+			},
+		},
+		runtimeSlots: map[string]*sandboxstore.RuntimeSlot{
+			"sandbox-a": {
+				ID: "slot-a", SandboxID: "sandbox-a", AllocationID: "allocation-a",
+				State: sandboxstore.RuntimeSlotStateQuiescing,
+			},
+		},
+	}
+	reader, err := NewNomadSandboxReader(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pausing, err := reader.GetSandbox(context.Background(), "sandbox-a")
+	if err != nil {
+		t.Fatalf("GetSandbox() error = %v", err)
+	}
+	if pausing.Paused || pausing.Status != managerapi.SandboxStatusStarting || pausing.RuntimeID != "allocation-a" {
+		t.Fatalf("non-terminal pause projection = %+v", pausing)
+	}
+	listed, err := reader.ListSandboxes(context.Background(), &sandboxstore.ListSandboxesRequest{TeamID: "team-a"})
+	if err != nil {
+		t.Fatalf("ListSandboxes() error = %v", err)
+	}
+	if listed.Count != 1 || listed.Sandboxes[0].Paused || listed.Sandboxes[0].Status != managerapi.SandboxStatusStarting {
+		t.Fatalf("non-terminal pause list projection = %+v", listed)
+	}
+
+	delete(store.runtimeSlots, "sandbox-a")
+	paused, err := reader.GetSandbox(context.Background(), "sandbox-a")
+	if err != nil {
+		t.Fatalf("GetSandbox() after terminalization error = %v", err)
+	}
+	if !paused.Paused || paused.Status != managerapi.SandboxStatusPaused || paused.RuntimeID != "" {
+		t.Fatalf("terminal pause projection = %+v", paused)
+	}
+}
+
 func TestNomadSandboxReaderFailsClosedForInvalidRequests(t *testing.T) {
 	store := &memorySandboxStore{records: map[string]*sandboxstore.SandboxRecord{}}
 	reader, err := NewNomadSandboxReader(store)


### PR DESCRIPTION
## Summary
- keep durable Nomad pauses pending while the previous runtime slot and resource lease remain non-terminal
- project a paused sandbox as transitional until its physical runtime slot is gone
- prevent SDK `pauseAndWait()` from returning before an immediate resume is admissible

## Tests
- `go test ./manager/pkg/service ./manager/pkg/nomadclaim`
- `go test ./manager/...`

## Production evidence
Sandpi reproduced the race as an immediate `pauseAndWait()` → `resumeAndWait()` 409: `previous runtime slot is not terminal`.