### PR TITLE
fix(manager): atomically bind runtime writer grants

### DIFF
--- a/manager/pkg/runtimeslotclaim/planner.go
+++ b/manager/pkg/runtimeslotclaim/planner.go
@@ -41,8 +41,11 @@ type Store interface {
 	GetRootFSFilesystem(context.Context, string) (*sandboxstore.RootFSFilesystem, error)
 	GetRootFSGeneration(context.Context, string) (*sandboxstore.RootFSGeneration, error)
 	GetRootFSWriterGrant(context.Context, string) (*sandboxstore.RootFSWriterGrant, error)
-	IssueRootFSWriterGrant(context.Context, *sandboxstore.IssueRootFSWriterGrantRequest) (*sandboxstore.IssuedRootFSWriterGrant, error)
-	BindRuntimeSlotWriterGrant(context.Context, *sandboxstore.BindRuntimeSlotWriterGrantRequest) (*sandboxstore.RuntimeSlot, error)
+	IssueAndBindRuntimeSlotWriterGrant(
+		context.Context,
+		*sandboxstore.IssueRootFSWriterGrantRequest,
+		*sandboxstore.BindRuntimeSlotWriterGrantRequest,
+	) (*sandboxstore.IssueAndBindRuntimeSlotWriterGrantResult, error)
 }
 
 // CapacityDemandRecorder persists a short-lived, idempotent pressure signal
@@ -489,7 +492,7 @@ func (p *Planner) Claim(ctx context.Context, request Request) (result *Result, r
 		return nil, errors.New("runtime slot claim lease expired before writer issue")
 	}
 
-	issued, err := p.store.IssueRootFSWriterGrant(ctx, &sandboxstore.IssueRootFSWriterGrantRequest{
+	issueAndBind, err := p.store.IssueAndBindRuntimeSlotWriterGrant(ctx, &sandboxstore.IssueRootFSWriterGrantRequest{
 		GrantID: ids.grantID, SandboxID: normalized.SandboxID,
 		ExpectedFilesystemID: filesystem.ID, ClaimID: ids.claimID, SlotID: slot.ID,
 		OperationID: ids.issueOperationID, RawToken: ids.rawToken,
@@ -500,23 +503,24 @@ func (p *Planner) Claim(ctx context.Context, request Request) (result *Result, r
 		RuntimeGeneration:   strconv.FormatInt(normalized.Runtime.RuntimeGeneration, 10),
 		InitialGenerationID: generation.ID, ExpectedWriterEpoch: expectedWriterEpoch,
 		ConsumeExpiresAt: slot.ClaimLeaseExpiresAt,
+	}, &sandboxstore.BindRuntimeSlotWriterGrantRequest{
+		SlotID: slot.ID, OperationID: normalized.OperationID, ClaimID: ids.claimID, GrantID: ids.grantID,
 	})
 	if err != nil {
 		recordPhase(PhaseWriterIssueBind, phaseStarted, false)
-		return nil, fmt.Errorf("issue RootFS writer grant: %w", err)
+		return nil, fmt.Errorf("issue and bind RootFS writer grant: %w", err)
 	}
+	if issueAndBind == nil {
+		recordPhase(PhaseWriterIssueBind, phaseStarted, false)
+		return nil, errors.New("writer authority returned no issue and bind result")
+	}
+	issued := issueAndBind.Issued
 	if issued == nil || issued.Grant == nil || issued.RawToken != ids.rawToken ||
 		!grantMatchesStage(issued.Grant, stage, slot, ids, normalized, bindingDigest[:]) {
 		recordPhase(PhaseWriterIssueBind, phaseStarted, false)
 		return nil, errors.New("writer authority returned another grant binding")
 	}
-	bound, err := p.store.BindRuntimeSlotWriterGrant(ctx, &sandboxstore.BindRuntimeSlotWriterGrantRequest{
-		SlotID: slot.ID, OperationID: normalized.OperationID, ClaimID: ids.claimID, GrantID: ids.grantID,
-	})
-	if err != nil {
-		recordPhase(PhaseWriterIssueBind, phaseStarted, false)
-		return nil, fmt.Errorf("bind runtime slot writer grant: %w", err)
-	}
+	bound := issueAndBind.Slot
 	if err := validateClaimedSlot(bound, normalized, ids, filesystem, generation, p.claimTTL); err != nil {
 		recordPhase(PhaseWriterIssueBind, phaseStarted, false)
 		return nil, err

--- a/manager/pkg/runtimeslotclaim/planner_test.go
+++ b/manager/pkg/runtimeslotclaim/planner_test.go
@@ -104,12 +104,18 @@ func (f *fakeStore) AcquireRuntimeSlot(_ context.Context, request *sandboxstore.
 	return &clone, nil
 }
 
-func (f *fakeStore) IssueRootFSWriterGrant(_ context.Context, request *sandboxstore.IssueRootFSWriterGrantRequest) (*sandboxstore.IssuedRootFSWriterGrant, error) {
+func (f *fakeStore) IssueAndBindRuntimeSlotWriterGrant(
+	_ context.Context,
+	request *sandboxstore.IssueRootFSWriterGrantRequest,
+	bind *sandboxstore.BindRuntimeSlotWriterGrantRequest,
+) (*sandboxstore.IssueAndBindRuntimeSlotWriterGrantResult, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	cloneRequest := *request
 	cloneRequest.BindingDigest = append([]byte(nil), request.BindingDigest...)
 	f.issues = append(f.issues, &cloneRequest)
+	cloneBind := *bind
+	f.binds = append(f.binds, &cloneBind)
 	if f.grant == nil {
 		f.grant = &sandboxstore.RootFSWriterGrant{
 			ID: request.GrantID, FilesystemID: request.ExpectedFilesystemID,
@@ -129,18 +135,13 @@ func (f *fakeStore) IssueRootFSWriterGrant(_ context.Context, request *sandboxst
 		f.issueLost = false
 		return nil, errors.New("writer issue response lost")
 	}
-	return &sandboxstore.IssuedRootFSWriterGrant{Grant: cloneGrant(f.grant), RawToken: request.RawToken}, nil
-}
-
-func (f *fakeStore) BindRuntimeSlotWriterGrant(_ context.Context, request *sandboxstore.BindRuntimeSlotWriterGrantRequest) (*sandboxstore.RuntimeSlot, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	cloneRequest := *request
-	f.binds = append(f.binds, &cloneRequest)
-	f.slot.WriterGrantID = request.GrantID
+	f.slot.WriterGrantID = bind.GrantID
 	f.slot.AuthorityObservedAt = time.Now().UTC()
-	clone := *f.slot
-	return &clone, nil
+	cloneSlot := *f.slot
+	return &sandboxstore.IssueAndBindRuntimeSlotWriterGrantResult{
+		Issued: &sandboxstore.IssuedRootFSWriterGrant{Grant: cloneGrant(f.grant), RawToken: request.RawToken},
+		Slot:   &cloneSlot,
+	}, nil
 }
 
 func cloneGrant(source *sandboxstore.RootFSWriterGrant) *sandboxstore.RootFSWriterGrant {

--- a/manager/pkg/sandboxstore/migrations/00050_cancel_orphaned_issued_writer_grants.sql
+++ b/manager/pkg/sandboxstore/migrations/00050_cancel_orphaned_issued_writer_grants.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+
+-- Older claim planners issued writer authority and bound the runtime slot in
+-- separate transactions. A concurrent resume abort could therefore leave an
+-- unconsumed grant live after its slot became terminal. Such a grant has never
+-- held runtime write authority and is safe to cancel once no matching live slot
+-- carries it.
+UPDATE manager.rootfs_writer_grants AS writer_grant
+SET state = 'canceled',
+    canceled_at = COALESCE(canceled_at, NOW()),
+    updated_at = NOW()
+WHERE writer_grant.state = 'issued'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM manager.runtime_slots AS slot
+      WHERE slot.slot_id = writer_grant.slot_id
+        AND slot.writer_grant_id = writer_grant.grant_id
+        AND slot.claim_id = writer_grant.claim_id
+        AND slot.sandbox_id = writer_grant.sandbox_id
+        AND slot.state IN ('claiming', 'starting', 'active')
+  );
+
+-- +goose Down
+
+-- Canceled grants cannot be made live again because their bearer tokens may
+-- have escaped before the repair ran.

--- a/manager/pkg/sandboxstore/nomad_resume_integration_test.go
+++ b/manager/pkg/sandboxstore/nomad_resume_integration_test.go
@@ -64,6 +64,78 @@ func TestNomadSandboxResumeAbortIsExactAndAllowsNewAttemptIntegration(t *testing
 	require.Greater(t, second.Record.LifecycleEpoch+1, first.Record.LifecycleEpoch+1)
 }
 
+func TestNomadSandboxResumeAbortCannotLeaveIssuedWriterUnboundIntegration(t *testing.T) {
+	fixture := newNomadPauseStoreFixture(t, "resume-atomic-writer")
+	terminalizeNomadPauseFixture(t, fixture)
+	requested, err := fixture.store.RequestNomadSandboxResume(fixture.ctx, &RequestNomadSandboxResumeRequest{
+		SandboxID: fixture.sandboxID, ExpectedTeamID: "team-slot",
+	})
+	require.NoError(t, err)
+
+	registration := runtimeSlotTestRegistration("slot-resume-atomic-writer", "allocation-resume-atomic-writer")
+	_, err = registerRuntimeSlotWithTestCapacity(t, fixture.ctx, fixture.store, registration)
+	require.NoError(t, err)
+	readyProof := bytes.Repeat([]byte{0xa1}, 32)
+	_, err = fixture.store.ReportRuntimeSlotReady(fixture.ctx, &ReportRuntimeSlotReadyRequest{
+		SlotID: registration.SlotID, AllocationID: registration.AllocationID,
+		NodeUID: registration.NodeUID, NodeBootID: registration.NodeBootID,
+		RuntimeReadyDigest: readyProof, NetworkReadyDigest: readyProof,
+		StorageReadyDigest: readyProof, HeartbeatTTL: time.Minute,
+	})
+	require.NoError(t, err)
+	claimID := "claim-resume-atomic-writer"
+	acquire := &AcquireRuntimeSlotRequest{
+		OperationID: requested.OperationID, ClaimID: claimID, SandboxID: requested.SandboxID,
+		FilesystemID: requested.FilesystemID, SourceGenerationID: requested.SourceGenerationID,
+		CompatibilityDigest: registration.CompatibilityDigest, ClusterID: registration.ClusterID,
+		RuntimeAssignmentRevision: strings.Repeat("ab", 32),
+		NetworkPolicyDigest:       "sha256:" + strings.Repeat("cd", 32), ClaimTTL: time.Minute,
+		Resources: runtimeSlotTestResources(),
+	}
+	claimed, err := fixture.store.AcquireRuntimeSlot(fixture.ctx, acquire)
+	require.NoError(t, err)
+
+	binding := bytes.Repeat([]byte{0xa2}, 32)
+	issue := rootFSWriterGrantTestIssueRequest(
+		fixture.sandboxID, "grant-resume-atomic-writer", claimID, registration.SlotID, binding,
+	)
+	issue.ExpectedFilesystemID = requested.FilesystemID
+	issue.InitialGenerationID = requested.SourceGenerationID
+	issue.ExpectedWriterEpoch = fixture.writerEpoch
+	issue.RuntimeNamespace = registration.AllocationNamespace
+	issue.RuntimeID = "slot"
+	issue.RuntimeIncarnationID = registration.AllocationID
+	issue.NodeName = registration.NodeID
+	issue.NodeUID = registration.NodeUID
+	issue.NodeBootID = registration.NodeBootID
+	issue.RuntimeGeneration = strconv.FormatInt(requested.RuntimeGeneration, 10)
+
+	aborted, err := fixture.store.AbortNomadSandboxResume(
+		fixture.ctx, fixture.sandboxID, requested.OperationID, "concurrent planner lost authority",
+	)
+	require.NoError(t, err)
+	require.True(t, aborted)
+	_, err = fixture.store.IssueAndBindRuntimeSlotWriterGrant(
+		fixture.ctx,
+		issue,
+		&BindRuntimeSlotWriterGrantRequest{
+			SlotID: claimed.ID, OperationID: acquire.OperationID, ClaimID: claimID, GrantID: issue.GrantID,
+		},
+	)
+	require.ErrorIs(t, err, ErrRuntimeSlotInvalid)
+	_, err = fixture.store.GetRootFSWriterGrant(fixture.ctx, issue.GrantID)
+	require.ErrorIs(t, err, ErrRootFSWriterGrantNotFound)
+
+	quiescing, err := fixture.store.GetRuntimeSlot(fixture.ctx, claimed.ID)
+	require.NoError(t, err)
+	require.Equal(t, RuntimeSlotStateQuiescing, quiescing.State)
+	require.Empty(t, quiescing.WriterGrantID)
+	filesystem, err := fixture.store.GetRootFSFilesystem(fixture.ctx, requested.FilesystemID)
+	require.NoError(t, err)
+	require.Equal(t, fixture.writerEpoch, filesystem.WriterEpoch,
+		"failed atomic bind must roll back the writer epoch and grant")
+}
+
 func TestNomadSandboxResumePersistsClaimsAndCommitsExactRuntimeIntegration(t *testing.T) {
 	fixture := newNomadPauseStoreFixture(t, "resume")
 	pause := terminalizeNomadPauseFixture(t, fixture)

--- a/manager/pkg/sandboxstore/runtime_slot.go
+++ b/manager/pkg/sandboxstore/runtime_slot.go
@@ -150,6 +150,13 @@ type BindRuntimeSlotWriterGrantRequest struct {
 	GrantID     string
 }
 
+// IssueAndBindRuntimeSlotWriterGrantResult is the atomic writer-authority and
+// runtime-slot binding returned to the regional claim planner.
+type IssueAndBindRuntimeSlotWriterGrantResult struct {
+	Issued *IssuedRootFSWriterGrant
+	Slot   *RuntimeSlot
+}
+
 type StartRuntimeSlotRequest struct {
 	SlotID              string
 	AllocationID        string
@@ -772,44 +779,105 @@ func (s *PGSandboxStore) BindRuntimeSlotWriterGrant(ctx context.Context, request
 		return nil, err
 	}
 	return s.withLockedRuntimeSlot(ctx, normalized.SlotID, func(tx pgx.Tx, slot *RuntimeSlot) (*RuntimeSlot, error) {
-		if !runtimeSlotClaimIdentityMatches(slot, normalized.OperationID, normalized.ClaimID) {
-			return nil, fmt.Errorf("%w: writer grant caller does not match slot claim", ErrRuntimeSlotConflict)
-		}
-		if slot.WriterGrantID != "" {
-			if slot.WriterGrantID == normalized.GrantID {
-				return nil, nil
-			}
-			return nil, fmt.Errorf("%w: slot is already bound to another writer grant", ErrRuntimeSlotConflict)
-		}
-		if slot.State != RuntimeSlotStateClaiming {
-			return nil, fmt.Errorf("%w: writer grant can only bind a claiming slot", ErrRuntimeSlotInvalid)
-		}
-		var claimID, grantSlotID, sandboxID, filesystemID, nodeUID, nodeBootID, state string
-		if err := tx.QueryRow(ctx, `
-			SELECT claim_id, slot_id, sandbox_id, filesystem_id, node_uid, node_boot_id, state
-			FROM manager.rootfs_writer_grants
-			WHERE grant_id = $1
-			FOR UPDATE
-		`, normalized.GrantID).Scan(
-			&claimID, &grantSlotID, &sandboxID, &filesystemID, &nodeUID, &nodeBootID, &state,
-		); err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return nil, fmt.Errorf("%w: writer grant is absent", ErrRuntimeSlotConflict)
-			}
-			return nil, err
-		}
-		if claimID != slot.ClaimID || grantSlotID != slot.ID || sandboxID != slot.SandboxID ||
-			filesystemID != slot.FilesystemID || nodeUID != slot.NodeUID || nodeBootID != slot.NodeBootID ||
-			(state != RootFSWriterGrantStateIssued && state != RootFSWriterGrantStateConsumed) {
-			return nil, fmt.Errorf("%w: writer grant identity does not match slot claim", ErrRuntimeSlotConflict)
-		}
-		_, err := tx.Exec(ctx, `
-			UPDATE manager.runtime_slots
-			SET writer_grant_id = $2, revision = revision + 1, updated_at = NOW()
-			WHERE slot_id = $1
-		`, slot.ID, normalized.GrantID)
-		return nil, err
+		return bindRuntimeSlotWriterGrant(ctx, tx, slot, normalized)
 	})
+}
+
+// IssueAndBindRuntimeSlotWriterGrant advances writer authority and binds the
+// exact claiming slot in one transaction. Resume aborts lock the same sandbox
+// row, so they can never leave an issued but unbound grant behind.
+func (s *PGSandboxStore) IssueAndBindRuntimeSlotWriterGrant(
+	ctx context.Context,
+	issue *IssueRootFSWriterGrantRequest,
+	bind *BindRuntimeSlotWriterGrantRequest,
+) (*IssueAndBindRuntimeSlotWriterGrantResult, error) {
+	if s == nil || s.pool == nil {
+		return nil, fmt.Errorf("sandbox store is not configured")
+	}
+	normalizedBind, err := normalizeBindRuntimeSlotWriterGrantRequest(bind)
+	if err != nil {
+		return nil, err
+	}
+	if issue == nil || strings.TrimSpace(issue.GrantID) != normalizedBind.GrantID ||
+		strings.TrimSpace(issue.ClaimID) != normalizedBind.ClaimID ||
+		strings.TrimSpace(issue.SlotID) != normalizedBind.SlotID {
+		return nil, fmt.Errorf("writer issue and runtime slot binding identities must match")
+	}
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("begin writer issue and slot bind tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	issued, err := issueRootFSWriterGrant(ctx, tx, issue)
+	if err != nil {
+		return nil, err
+	}
+	slot, err := scanRuntimeSlot(tx.QueryRow(ctx, runtimeSlotSelectSQL()+`
+		WHERE slot_id = $1
+		FOR UPDATE OF runtime_slots
+	`, normalizedBind.SlotID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("%w: %s", ErrRuntimeSlotNotFound, normalizedBind.SlotID)
+	}
+	if err != nil {
+		return nil, err
+	}
+	bound, err := bindRuntimeSlotWriterGrant(ctx, tx, slot, normalizedBind)
+	if err != nil {
+		return nil, mapRuntimeSlotConflict("bind issued writer to runtime slot", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, mapRuntimeSlotConflict("commit writer issue and slot bind", err)
+	}
+	return &IssueAndBindRuntimeSlotWriterGrantResult{Issued: issued, Slot: bound}, nil
+}
+
+func bindRuntimeSlotWriterGrant(
+	ctx context.Context,
+	tx pgx.Tx,
+	slot *RuntimeSlot,
+	request *BindRuntimeSlotWriterGrantRequest,
+) (*RuntimeSlot, error) {
+	if !runtimeSlotClaimIdentityMatches(slot, request.OperationID, request.ClaimID) {
+		return nil, fmt.Errorf("%w: writer grant caller does not match slot claim", ErrRuntimeSlotConflict)
+	}
+	if slot.WriterGrantID != "" {
+		if slot.WriterGrantID == request.GrantID {
+			return slot, nil
+		}
+		return nil, fmt.Errorf("%w: slot is already bound to another writer grant", ErrRuntimeSlotConflict)
+	}
+	if slot.State != RuntimeSlotStateClaiming {
+		return nil, fmt.Errorf("%w: writer grant can only bind a claiming slot", ErrRuntimeSlotInvalid)
+	}
+	var claimID, grantSlotID, sandboxID, filesystemID, nodeUID, nodeBootID, state string
+	if err := tx.QueryRow(ctx, `
+		SELECT claim_id, slot_id, sandbox_id, filesystem_id, node_uid, node_boot_id, state
+		FROM manager.rootfs_writer_grants
+		WHERE grant_id = $1
+		FOR UPDATE
+	`, request.GrantID).Scan(
+		&claimID, &grantSlotID, &sandboxID, &filesystemID, &nodeUID, &nodeBootID, &state,
+	); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("%w: writer grant is absent", ErrRuntimeSlotConflict)
+		}
+		return nil, err
+	}
+	if claimID != slot.ClaimID || grantSlotID != slot.ID || sandboxID != slot.SandboxID ||
+		filesystemID != slot.FilesystemID || nodeUID != slot.NodeUID || nodeBootID != slot.NodeBootID ||
+		(state != RootFSWriterGrantStateIssued && state != RootFSWriterGrantStateConsumed) {
+		return nil, fmt.Errorf("%w: writer grant identity does not match slot claim", ErrRuntimeSlotConflict)
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE manager.runtime_slots
+		SET writer_grant_id = $2, revision = revision + 1, updated_at = NOW()
+		WHERE slot_id = $1
+	`, slot.ID, request.GrantID); err != nil {
+		return nil, err
+	}
+	return scanRuntimeSlot(tx.QueryRow(ctx, runtimeSlotSelectSQL()+` WHERE slot_id = $1`, slot.ID))
 }
 
 // StartRuntimeSlot records the exact post-bind, post-policy launch attempt. It


### PR DESCRIPTION
## Summary
- issue RootFS writer authority and bind the claiming runtime slot in one PostgreSQL transaction
- serialize the atomic path with resume abort through the canonical sandbox lock
- cancel legacy issued grants that have no matching live bound slot
- cover the abort-before-issue race with PostgreSQL integration tests

## Why
A concurrent resume caller could abort the lifecycle while the winning planner was between writer issue and slot bind. The slot then terminalized as grantless while an unconsumed issued grant remained live and blocked every later resume.

## Validation
- `go test ./manager/...`
- `go test -race ./manager/pkg/runtimeslotclaim ./manager/pkg/sandboxstore`
- `TEST_DATABASE_URL=... go test ./manager/pkg/sandboxstore -count=1` (PostgreSQL 15, all integration tests)