### PR TITLE
fix(runtime): configure sandbox DNS and redirect TCP

### DIFF
--- a/ctld/internal/ctld/networking/redirect/manager_test.go
+++ b/ctld/internal/ctld/networking/redirect/manager_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-func TestBuildIPTablesRestoreInputRoutesSpecificAndGenericTraffic(t *testing.T) {
+func TestBuildIPTablesRestoreInputUsesTCPRedirectAndUDPTPROXY(t *testing.T) {
 	cfg := Config{
 		ProxyHTTPPort:  18080,
 		ProxyHTTPSPort: 18443,
@@ -23,12 +23,12 @@ func TestBuildIPTablesRestoreInputRoutesSpecificAndGenericTraffic(t *testing.T) 
 	mustContain(t, restore, "-A "+chainName+" -d 10.0.0.0/8 -j RETURN")
 	mustContain(t, restore, "-A "+chainName+" -d 192.168.0.0/16 -j RETURN")
 
-	mustContain(t, restore, "-m set --match-set "+ipsetName+" src -p tcp --dport 443 -m conntrack --ctstate NEW -j TPROXY --on-port 18443")
-	mustContain(t, restore, "-m set --match-set "+ipsetName+" src -p tcp --dport 443 -m connmark --mark 0x1/0x1 -j TPROXY --on-port 18443")
-	mustContain(t, restore, "-m set --match-set "+ipsetName+" src -p tcp --dport 853 -m socket --transparent -j TPROXY --on-port 18443")
-	mustContain(t, restore, "-m set --match-set "+ipsetName+" src -p tcp -m conntrack --ctstate NEW -j TPROXY --on-port 18080")
-	mustContain(t, restore, "-m set --match-set "+ipsetName+" src -p tcp -m connmark --mark 0x1/0x1 -j TPROXY --on-port 18080")
-	mustContain(t, restore, "-m set --match-set "+ipsetName+" src -p tcp -m socket --transparent -j TPROXY --on-port 18080")
+	mustNotContain(t, restore, "-p tcp --dport 443 -m conntrack")
+	mustNotContain(t, restore, "-p tcp --dport 443 -m connmark")
+	mustNotContain(t, restore, "-p tcp --dport 853 -m socket")
+	mustNotContain(t, restore, "-p tcp -m conntrack")
+	mustNotContain(t, restore, "-p tcp -m connmark")
+	mustNotContain(t, restore, "-p tcp -m socket")
 	mustContain(t, restore, "-p udp --dport 443 -m conntrack --ctstate NEW -j TPROXY --on-port 18443")
 	mustContain(t, restore, "-p udp --dport 443 -m connmark --mark 0x1/0x1 -j TPROXY --on-port 18443")
 	mustContain(t, restore, "-p udp --dport 443 -m conntrack --ctstate NEW -j CONNMARK --set-mark 0x1/0x1")
@@ -231,6 +231,13 @@ func mustContain(t *testing.T, got string, want string) {
 	t.Helper()
 	if !strings.Contains(got, want) {
 		t.Fatalf("expected output to contain %q, got:\n%s", want, got)
+	}
+}
+
+func mustNotContain(t *testing.T, got string, unwanted string) {
+	t.Helper()
+	if strings.Contains(got, unwanted) {
+		t.Fatalf("expected output not to contain %q, got:\n%s", unwanted, got)
 	}
 }
 

--- a/ctld/internal/ctld/networking/redirect/rules.go
+++ b/ctld/internal/ctld/networking/redirect/rules.go
@@ -31,9 +31,6 @@ func buildIPTablesRestoreInput(cfg Config, bypassCIDRs []string) string {
 
 	// Source-IP membership scopes these rules to registered Nomad network
 	// namespaces, so they do not depend on a particular bridge interface name.
-	appendTPROXYRules(&buf, "", "tcp", 443, cfg.ProxyHTTPSPort)
-	appendTPROXYRules(&buf, "", "tcp", 853, cfg.ProxyHTTPSPort)
-	appendTPROXYRules(&buf, "", "tcp", 0, cfg.ProxyHTTPPort)
 	appendTPROXYRules(&buf, "", "udp", 443, cfg.ProxyHTTPSPort)
 	appendTPROXYRules(&buf, "", "udp", 853, cfg.ProxyHTTPSPort)
 	appendTPROXYRules(&buf, "", "udp", 0, cfg.ProxyHTTPPort)

--- a/nomad-driver-sandbox0/go.mod
+++ b/nomad-driver-sandbox0/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.6.0 // indirect
+	github.com/docker/docker v28.5.2+incompatible // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -117,6 +118,7 @@ require (
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/hpcloud/tail v1.0.1-0.20170814160653-37f427138745 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
+	github.com/ishidawataru/sctp v0.0.0-20191218070446-00ab2ac2db07 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.7.5 // indirect
@@ -138,6 +140,7 @@ require (
 	github.com/mitchellh/pointerstructure v1.2.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/locker v1.0.1 // indirect
+	github.com/moby/sys/atomicwriter v0.1.0 // indirect
 	github.com/moby/sys/mount v0.3.4 // indirect
 	github.com/moby/sys/mountinfo v0.7.2 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect

--- a/nomad-driver-sandbox0/go.sum
+++ b/nomad-driver-sandbox0/go.sum
@@ -116,6 +116,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=
+github.com/docker/docker v28.5.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -298,6 +300,8 @@ github.com/hpcloud/tail v1.0.1-0.20170814160653-37f427138745 h1:8as8OQ+RF1QrsHvW
 github.com/hpcloud/tail v1.0.1-0.20170814160653-37f427138745/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
+github.com/ishidawataru/sctp v0.0.0-20191218070446-00ab2ac2db07 h1:rw3IAne6CDuVFlZbPOkA7bhxlqawFh7RJJ+CejfMaxE=
+github.com/ishidawataru/sctp v0.0.0-20191218070446-00ab2ac2db07/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
@@ -368,6 +372,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
+github.com/moby/sys/atomicwriter v0.1.0 h1:kw5D/EqkBwsBFi0ss9v1VG3wIkVhzGvLklJ+w3A14Sw=
+github.com/moby/sys/atomicwriter v0.1.0/go.mod h1:Ul8oqv2ZMNHOceF643P6FKPXeCmYtlQMvpizfsSoaWs=
 github.com/moby/sys/mount v0.3.4 h1:yn5jq4STPztkkzSKpZkLcmjue+bZJ0u2AuQY1iNI1Ww=
 github.com/moby/sys/mount v0.3.4/go.mod h1:KcQJMbQdJHPlq5lcYT+/CjatWM4PuxKe+XLSVS4J6Os=
 github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9KouLrg=
@@ -707,6 +713,8 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=
+gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 kernel.org/pub/linux/libs/security/libcap/psx v1.2.71 h1:i19+O6oaKRqgflRO4o7WKdU8LJ7vKNSFLDDqHB6CvQ8=

--- a/nomad-driver-sandbox0/internal/driver/handle.go
+++ b/nomad-driver-sandbox0/internal/driver/handle.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/containerd/errdefs"
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/drivers/shared/resolvconf"
 	"github.com/hashicorp/nomad/plugins/drivers"
 
 	"github.com/sandbox0-ai/sandbox0/pkg/rootfshandoff"
@@ -334,6 +335,10 @@ func (h *taskHandle) writeClaimBundle(
 	if resourceLease.SlotID != h.taskConfig.ID || resourceLease.NodeID != h.taskConfig.NodeID {
 		return fmt.Errorf("runtime resource lease does not match the Nomad carrier")
 	}
+	resolvMount, err := resolvconf.GenerateDNSMount(h.bundleDir, h.taskConfig.DNS)
+	if err != nil {
+		return fmt.Errorf("generate sandbox resolver configuration: %w", err)
+	}
 	cgroupPath, err := runtimeLeaseCgroupsPath(h.resourceCgroupRoot, resourceLease.CgroupName)
 	if err != nil {
 		return err
@@ -374,6 +379,7 @@ func (h *taskHandle) writeClaimBundle(
 		AllocID:                       h.taskConfig.AllocID,
 		TaskID:                        h.taskConfig.ID,
 		NetNSPath:                     netnsPath,
+		ResolvConfPath:                resolvMount.HostPath,
 		ProcdInternalJWTPublicKeyFile: h.procdInternalJWTPublicKeyFile,
 		Resources:                     resources,
 		SecurityClass:                 h.driverConfig.SecurityClass,

--- a/nomad-driver-sandbox0/internal/driver/oci.go
+++ b/nomad-driver-sandbox0/internal/driver/oci.go
@@ -32,6 +32,7 @@ type specOptions struct {
 	AllocID                       string
 	TaskID                        string
 	NetNSPath                     string
+	ResolvConfPath                string
 	ProcdInternalJWTPublicKeyFile string
 	Resources                     *driversResources
 	SecurityClass                 string
@@ -123,6 +124,14 @@ func buildSpec(options specOptions) specs.Spec {
 		{Destination: "/dev/shm", Type: "tmpfs", Source: "shm", Options: []string{"nosuid", "noexec", "nodev", "mode=1777", "size=67108864"}},
 		{Destination: "/dev/mqueue", Type: "mqueue", Source: "mqueue", Options: []string{"nosuid", "noexec", "nodev"}},
 		{Destination: "/sys", Type: "sysfs", Source: "sysfs", Options: []string{"nosuid", "noexec", "nodev", "ro"}},
+	}
+	if options.ResolvConfPath != "" {
+		mounts = append(mounts, specs.Mount{
+			Destination: "/etc/resolv.conf",
+			Type:        "bind",
+			Source:      options.ResolvConfPath,
+			Options:     []string{"rbind", "ro", "nosuid", "nodev", "noexec"},
+		})
 	}
 	for _, mount := range options.EphemeralMounts {
 		ephemeral := specs.Mount{

--- a/nomad-driver-sandbox0/internal/driver/oci_test.go
+++ b/nomad-driver-sandbox0/internal/driver/oci_test.go
@@ -15,11 +15,15 @@
 package driver
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/nomad/plugins/drivers"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sandbox0-ai/sandbox0/pkg/runtimecontrol"
+	protocol "github.com/sandbox0-ai/sandbox0/pkg/runtimeslot"
 )
 
 func TestRuntimeLeaseCgroupsPathIsRelativeToUnifiedMount(t *testing.T) {
@@ -39,6 +43,7 @@ func TestRuntimeLeaseCgroupsPathIsRelativeToUnifiedMount(t *testing.T) {
 func TestBuildSpecAppliesExactRuntimeResourceLease(t *testing.T) {
 	spec := buildSpec(specOptions{
 		Command: "/procd", ProcdInternalJWTPublicKeyFile: "/etc/sandbox0/internal-auth/data-public.pem",
+		ResolvConfPath: "/alloc/sandbox0/resolv.conf",
 		Resources: &driversResources{
 			CPUPeriod: 100000, CPUQuota: 150000, CPUShares: 1536,
 			CPUSetCpus: "0-1", MemoryLimitBytes: 768 * 1024 * 1024,
@@ -66,6 +71,12 @@ func TestBuildSpecAppliesExactRuntimeResourceLease(t *testing.T) {
 	if keyMount == nil || keyMount.Source != "/etc/sandbox0/internal-auth/data-public.pem" ||
 		!strings.Contains(strings.Join(keyMount.Options, ","), "ro") {
 		t.Fatalf("OCI procd internal JWT public-key mount = %+v", spec.Mounts)
+	}
+	resolvMount := findOCIMount(spec.Mounts, "/etc/resolv.conf")
+	if resolvMount == nil || resolvMount.Type != "bind" ||
+		resolvMount.Source != "/alloc/sandbox0/resolv.conf" ||
+		!containsString(resolvMount.Options, "ro") {
+		t.Fatalf("OCI resolver mount = %+v", spec.Mounts)
 	}
 }
 
@@ -104,6 +115,58 @@ func TestBuildSpecAppliesSecurityClassAndEphemeralMounts(t *testing.T) {
 	}
 	if shmCount != 1 {
 		t.Fatalf("shm mount count = %d", shmCount)
+	}
+}
+
+func TestWriteClaimBundleGeneratesNomadDNSConfiguration(t *testing.T) {
+	bundleDir := t.TempDir()
+	handle := newTaskHandle(taskHandleOptions{
+		taskConfig: &drivers.TaskConfig{
+			ID: "slot-1", NodeID: "node-1", AllocID: "alloc-1",
+			DNS: &drivers.DNSConfig{
+				Servers:  []string{"192.0.2.53", "198.51.100.53"},
+				Searches: []string{"sandbox.internal"},
+				Options:  []string{"timeout:2", "attempts:2"},
+			},
+		},
+		driverConfig:       TaskConfig{Command: "/procd"},
+		bundleDir:          bundleDir,
+		resourceCgroupRoot: "/sys/fs/cgroup/sandbox0",
+	})
+	lease, err := protocol.NewRuntimeResourceLease(
+		"operation-1", "claim-1", "slot-1", "cluster-1", "node-1", "node-1", "boot-1",
+		protocol.RuntimeResourceRequest{
+			Version: protocol.RuntimeResourceRequestVersion, CPUMillicores: 500,
+			MemoryBytes: 256 << 20, PIDsLimit: protocol.DefaultRuntimePIDsLimit,
+		},
+		"0-1", "0",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := handle.writeClaimBundle(nil, lease); err != nil {
+		t.Fatal(err)
+	}
+	resolverPath := filepath.Join(bundleDir, "resolv.conf")
+	resolver, err := os.ReadFile(resolverPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range []string{
+		"nameserver 192.0.2.53", "nameserver 198.51.100.53",
+		"search sandbox.internal", "options timeout:2 attempts:2",
+	} {
+		if !strings.Contains(string(resolver), expected) {
+			t.Fatalf("resolver configuration %q does not contain %q", resolver, expected)
+		}
+	}
+	config, err := os.ReadFile(filepath.Join(bundleDir, "config.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(config), `"source": "`+resolverPath+`"`) ||
+		!strings.Contains(string(config), `"destination": "/etc/resolv.conf"`) {
+		t.Fatalf("OCI bundle does not mount generated resolver configuration: %s", config)
 	}
 }
 


### PR DESCRIPTION
## Summary
- generate each claimed Nomad sandbox resolver config with Nomad's official resolver helper and bind-mount it into the OCI rootfs
- remove the broken legacy TCP TPROXY rules so the existing NAT REDIRECT path handles TCP while UDP continues to use TPROXY
- cover explicit DNS generation, OCI resolver mounting, and protocol-specific redirect rules

## Production evidence
On ali-ue1, sandbox TCP SYNs reached the TPROXY rules but never reached the proxy. A temporary source-scoped mangle RETURN made the existing NAT REDIRECT path handle the same connection immediately. Rootfs-only sandboxes also had a zero-byte `/etc/resolv.conf`; copying the node resolver restored DNS.

## Tests
- `go -C nomad-driver-sandbox0 test ./... -count=1`
- `go -C ctld test ./... -count=1`
