### PR TITLE
fix(ctld): allow bounded rootfs startup recovery

### DIFF
--- a/pkg/nomadruntime/runtime.go
+++ b/pkg/nomadruntime/runtime.go
@@ -342,7 +342,12 @@ func newRuntime(ctx context.Context, config *Config, logger logger) (*rootfsRunt
 	if err != nil {
 		return nil, fmt.Errorf("create RootFS session manager: %w", err)
 	}
-	reconcileCtx, reconcileCancel := context.WithTimeout(ctx, 30*time.Second)
+	// Recovery is fail-closed: do not expose the node runtime socket until all
+	// crash-surviving journal intents have completed. Immutable object
+	// verification may need to transfer a full pack, so use the same bounded
+	// timeout as steady-state session reconciliation instead of the shorter
+	// health-probe window.
+	reconcileCtx, reconcileCancel := context.WithTimeout(ctx, rootFSSessionReconcileTimeout)
 	err = sessions.ReconcileFreezes(reconcileCtx)
 	if err == nil {
 		err = sessions.ReconcileRunningForkCaptures(reconcileCtx)

--- a/pkg/nomadruntime/service.go
+++ b/pkg/nomadruntime/service.go
@@ -48,8 +48,12 @@ const (
 	rootFSSessionReconcileTimeout   = 3 * time.Minute
 	runtimeSlotJournalPruneInterval = time.Minute
 	nomadAllocationResponseMaxBytes = 64 << 20
-	nodeRuntimeStartupTimeout       = 30 * time.Second
-	nodeRuntimeHealthInterval       = time.Second
+	// Startup must allow the durable RootFS journal to finish its bounded
+	// recovery before the private runtime socket can become healthy. A release
+	// retry can verify a 64 MiB immutable object and legitimately exceed the
+	// ordinary 30-second health window.
+	nodeRuntimeStartupTimeout = rootFSSessionReconcileTimeout + 30*time.Second
+	nodeRuntimeHealthInterval = time.Second
 )
 
 // Service is the HA-primary-scoped Nomad node runtime owned by ctld.

--- a/pkg/nomadruntime/service_test.go
+++ b/pkg/nomadruntime/service_test.go
@@ -27,6 +27,11 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
+func TestNodeRuntimeStartupCoversDurableSessionReconciliation(t *testing.T) {
+	require.Equal(t, 3*time.Minute, rootFSSessionReconcileTimeout)
+	require.Greater(t, nodeRuntimeStartupTimeout, rootFSSessionReconcileTimeout)
+}
+
 func TestNodeRuntimeRPCDelegatesLifecycleOverPrivateUnixSocket(t *testing.T) {
 	socket := filepath.Join(t.TempDir(), "ctld Nomad runtime.sock")
 	runtime := &fakeRootFSRuntime{source: t.TempDir()}


### PR DESCRIPTION
## Summary
- let ctld startup journal recovery use the existing three-minute reconciliation bound
- keep the private node runtime unavailable until fail-closed recovery finishes
- give the outer startup health gate a bounded margin beyond journal recovery

This repairs reboot recovery when idempotent verification of a 64 MiB encrypted immutable pack legitimately exceeds 30 seconds.

## Validation
- `go test ./pkg/nomadruntime ./pkg/rootfssession`
- `git diff --check`