### PR TITLE
fix(ctld): budget full dirty-tail startup recovery

### DIFF
--- a/deploy/nomad/ctld/README.md
+++ b/deploy/nomad/ctld/README.md
@@ -109,3 +109,6 @@ one at a time for changes that alter the runsc compatibility digest, RootFS
 format, NBD pool, or network policy format. Roll back with the previous pinned
 binary/config set using the same B-then-A sequence; never downgrade across an
 on-disk journal version that the previous binary cannot read.
+The primary-ready wait includes the bounded 15-minute crash-recovery window
+needed to rebuild and verify a maximum-size durable dirty tail. Healthy
+startups still become ready immediately; this bound is not a claim-path SLO.

--- a/deploy/nomad/ctld/rollout-node.sh
+++ b/deploy/nomad/ctld/rollout-node.sh
@@ -3,7 +3,10 @@ set -eu
 
 wait_ready() {
   slot=$1
-  deadline=$(( $(date +%s) + 120 ))
+  # A promoted primary must finish fail-closed durable RootFS recovery before
+  # it can report ready. The Go runtime bounds that recovery at 15 minutes;
+  # this host rollout adds one minute for election and probe propagation.
+  deadline=$(( $(date +%s) + 960 ))
   while [ "$(date +%s)" -lt "$deadline" ]; do
     if "${CTLD_BIN:-/usr/local/bin/ctld}" \
       -ha-probe=ready \
@@ -13,7 +16,7 @@ wait_ready() {
     fi
     sleep 1
   done
-  echo "ctld slot $slot did not become role-ready within 120 seconds" >&2
+  echo "ctld slot $slot did not become role-ready within 960 seconds" >&2
   return 1
 }
 

--- a/pkg/nomadruntime/runtime.go
+++ b/pkg/nomadruntime/runtime.go
@@ -345,9 +345,8 @@ func newRuntime(ctx context.Context, config *Config, logger logger) (*rootfsRunt
 	// Recovery is fail-closed: do not expose the node runtime socket until all
 	// crash-surviving journal intents have completed. Immutable object
 	// verification may need to transfer a full pack, so use the same bounded
-	// timeout as steady-state session reconciliation instead of the shorter
-	// health-probe window.
-	reconcileCtx, reconcileCancel := context.WithTimeout(ctx, rootFSSessionReconcileTimeout)
+	// startup recovery budget instead of the shorter steady-state window.
+	reconcileCtx, reconcileCancel := context.WithTimeout(ctx, rootFSSessionStartupReconcileTimeout)
 	err = sessions.ReconcileFreezes(reconcileCtx)
 	if err == nil {
 		err = sessions.ReconcileRunningForkCaptures(reconcileCtx)

--- a/pkg/nomadruntime/service.go
+++ b/pkg/nomadruntime/service.go
@@ -43,16 +43,21 @@ import (
 )
 
 const (
-	rootFSSessionReconcileInterval  = time.Second
-	rootFSSessionAttachGrace        = 2 * time.Minute
-	rootFSSessionReconcileTimeout   = 3 * time.Minute
-	runtimeSlotJournalPruneInterval = time.Minute
-	nomadAllocationResponseMaxBytes = 64 << 20
+	rootFSSessionReconcileInterval = time.Second
+	rootFSSessionAttachGrace       = 2 * time.Minute
+	rootFSSessionReconcileTimeout  = 3 * time.Minute
+	// Startup recovery may have to rebuild and idempotently verify the full
+	// configured 10 GiB dirty-tail bound. Keep this separate from the shorter
+	// steady-state reconciliation budget so a normal node does not retain
+	// stalled background operations for the full crash-recovery window.
+	rootFSSessionStartupReconcileTimeout = 15 * time.Minute
+	runtimeSlotJournalPruneInterval      = time.Minute
+	nomadAllocationResponseMaxBytes      = 64 << 20
 	// Startup must allow the durable RootFS journal to finish its bounded
 	// recovery before the private runtime socket can become healthy. A release
 	// retry can verify a 64 MiB immutable object and legitimately exceed the
 	// ordinary 30-second health window.
-	nodeRuntimeStartupTimeout = rootFSSessionReconcileTimeout + 30*time.Second
+	nodeRuntimeStartupTimeout = rootFSSessionStartupReconcileTimeout + 30*time.Second
 	nodeRuntimeHealthInterval = time.Second
 )
 

--- a/pkg/nomadruntime/service_test.go
+++ b/pkg/nomadruntime/service_test.go
@@ -29,7 +29,9 @@ import (
 
 func TestNodeRuntimeStartupCoversDurableSessionReconciliation(t *testing.T) {
 	require.Equal(t, 3*time.Minute, rootFSSessionReconcileTimeout)
-	require.Greater(t, nodeRuntimeStartupTimeout, rootFSSessionReconcileTimeout)
+	require.Equal(t, 15*time.Minute, rootFSSessionStartupReconcileTimeout)
+	require.Greater(t, rootFSSessionStartupReconcileTimeout, rootFSSessionReconcileTimeout)
+	require.Greater(t, nodeRuntimeStartupTimeout, rootFSSessionStartupReconcileTimeout)
 }
 
 func TestNodeRuntimeRPCDelegatesLifecycleOverPrivateUnixSocket(t *testing.T) {


### PR DESCRIPTION
## Summary
- separate the normal three-minute reconciliation timeout from a 15-minute fail-closed startup recovery budget
- allow startup to rebuild and idempotently verify the configured 10 GiB dirty-tail maximum
- align the A/B host rollout readiness gate with the bounded startup recovery window
- document that healthy startup and claim-path SLOs are unchanged

The previous three-minute budget was observed canceling recovery of a maximum-size durable tail.

## Validation
- `go test ./pkg/nomadruntime ./pkg/rootfssession ./deploy/nomad/ctld`
- `sh -n deploy/nomad/ctld/rollout-node.sh`
- `git diff --check`