### PR TITLE
fix(manager): fence stale pause completion retries

### DIFF
--- a/manager/pkg/nomadclaim/service.go
+++ b/manager/pkg/nomadclaim/service.go
@@ -55,6 +55,7 @@ type Store interface {
 	RequestSandboxRuntimeClaimCleanup(context.Context, string, string) (*sandboxstore.SandboxClaimCleanupCandidate, error)
 	RequestHardExpiredSandboxRuntimeClaimCleanup(context.Context, string, string) (*sandboxstore.SandboxClaimCleanupCandidate, error)
 	RequestNomadSandboxPause(context.Context, string, string) (*sandboxstore.NomadSandboxPauseCandidate, error)
+	ContinueNomadSandboxPause(context.Context, string) (*sandboxstore.NomadSandboxPauseCandidate, error)
 	RequestNomadSandboxTTLPause(context.Context, string) (*sandboxstore.NomadSandboxPauseCandidate, error)
 	RetryNomadSandboxResume(context.Context, *sandboxstore.RetryNomadSandboxResumeRequest) (*sandboxstore.NomadSandboxResumeCandidate, bool, error)
 	RequestNomadSandboxResume(context.Context, *sandboxstore.RequestNomadSandboxResumeRequest) (*sandboxstore.NomadSandboxResumeCandidate, error)
@@ -335,9 +336,13 @@ func (s *Service) RequestRootFSWriterPressurePause(
 // the allocation. Retries preserve this ordering across every response-loss
 // boundary while node recovery publishes the planned RootFS generation.
 func (s *Service) CompletePausingSandboxRuntime(ctx context.Context, sandboxID string) error {
-	candidate, err := s.requestNomadSandboxPause(ctx, sandboxID, sandboxstore.SandboxLifecycleSourceManual)
+	candidate, err := s.store.ContinueNomadSandboxPause(ctx, sandboxID)
+	if errors.Is(err, sandboxstore.ErrNomadSandboxPauseNotPending) ||
+		errors.Is(err, sandboxstore.ErrSandboxRecordNotFound) {
+		return nil
+	}
 	if err != nil {
-		return err
+		return mapNomadSandboxPauseError(sandboxID, err)
 	}
 	if candidate.AlreadyPaused {
 		if candidate.SlotID == "" {
@@ -371,7 +376,11 @@ func (s *Service) CompletePausingSandboxRuntime(ctx context.Context, sandboxID s
 		// A physically absent allocation can publish and terminalize between the
 		// node acknowledgement and this CAS. Accept only a fresh authoritative
 		// observation that the exact pause has already committed.
-		refreshed, refreshErr := s.requestNomadSandboxPause(ctx, sandboxID, candidate.Source)
+		refreshed, refreshErr := s.store.ContinueNomadSandboxPause(ctx, sandboxID)
+		if errors.Is(refreshErr, sandboxstore.ErrNomadSandboxPauseNotPending) ||
+			errors.Is(refreshErr, sandboxstore.ErrSandboxRecordNotFound) {
+			return nil
+		}
 		if refreshErr == nil && refreshed.AlreadyPaused && refreshed.SlotID == "" {
 			return nil
 		}
@@ -386,9 +395,13 @@ func (s *Service) CompletePausingSandboxRuntime(ctx context.Context, sandboxID s
 	}); err != nil {
 		return fmt.Errorf("stop Nomad allocation for planned pause: %w", err)
 	}
-	refreshed, err := s.requestNomadSandboxPause(ctx, sandboxID, candidate.Source)
+	refreshed, err := s.store.ContinueNomadSandboxPause(ctx, sandboxID)
+	if errors.Is(err, sandboxstore.ErrNomadSandboxPauseNotPending) ||
+		errors.Is(err, sandboxstore.ErrSandboxRecordNotFound) {
+		return nil
+	}
 	if err != nil {
-		return err
+		return mapNomadSandboxPauseError(sandboxID, err)
 	}
 	if refreshed.AlreadyPaused {
 		return s.CompletePausingSandboxRuntime(ctx, sandboxID)

--- a/manager/pkg/nomadclaim/service_test.go
+++ b/manager/pkg/nomadclaim/service_test.go
@@ -89,6 +89,8 @@ type fakeClaimStore struct {
 	pauseCandidate           *sandboxstore.NomadSandboxPauseCandidate
 	pauseErr                 error
 	pauseSources             []string
+	pauseContinueErr         error
+	pauseContinueCalls       []string
 	pressurePause            *sandboxstore.NomadSandboxPauseCandidate
 	pressurePauseErr         error
 	pressureRequests         []*sandboxstore.RootFSWriterPressurePauseRequest
@@ -509,6 +511,22 @@ func (f *fakeClaimStore) RequestNomadSandboxPause(
 	}
 	if f.pauseCandidate == nil {
 		return nil, sandboxstore.ErrNomadSandboxPauseNotReady
+	}
+	copy := *f.pauseCandidate
+	copy.BindingDigest = append([]byte(nil), f.pauseCandidate.BindingDigest...)
+	return &copy, nil
+}
+
+func (f *fakeClaimStore) ContinueNomadSandboxPause(
+	_ context.Context,
+	sandboxID string,
+) (*sandboxstore.NomadSandboxPauseCandidate, error) {
+	f.pauseContinueCalls = append(f.pauseContinueCalls, sandboxID)
+	if f.pauseContinueErr != nil {
+		return nil, f.pauseContinueErr
+	}
+	if f.pauseCandidate == nil {
+		return nil, sandboxstore.ErrNomadSandboxPauseNotPending
 	}
 	copy := *f.pauseCandidate
 	copy.BindingDigest = append([]byte(nil), f.pauseCandidate.BindingDigest...)
@@ -1070,6 +1088,7 @@ func TestServiceRequestsPlannedPauseAndStopsExactAllocation(t *testing.T) {
 	if len(enqueuer.sandboxIDs) != 1 || enqueuer.sandboxIDs[0] != "sandbox-1" {
 		t.Fatalf("pause enqueues = %v", enqueuer.sandboxIDs)
 	}
+	require.Equal(t, []string{"sandbox-1", "sandbox-1"}, fixture.store.pauseContinueCalls)
 	if len(fixture.allocation.requests) != 1 {
 		t.Fatalf("allocation stops = %+v", fixture.allocation.requests)
 	}
@@ -1083,6 +1102,25 @@ func TestServiceRequestsPlannedPauseAndStopsExactAllocation(t *testing.T) {
 	if stop.OperationID != "retire-1" || stop.Target.AllocationID != "allocation-1" ||
 		stop.Target.AllocationNamespace != "nomad" || stop.Target.NodeID != "node-1" {
 		t.Fatalf("allocation stop = %+v", stop)
+	}
+}
+
+func TestServiceDropsStalePauseCompletionAfterResume(t *testing.T) {
+	for name, staleErr := range map[string]error{
+		"resumed": sandboxstore.ErrNomadSandboxPauseNotPending,
+		"deleted": sandboxstore.ErrSandboxRecordNotFound,
+	} {
+		t.Run(name, func(t *testing.T) {
+			fixture := newClaimServiceFixture(t)
+			fixture.store.pauseContinueErr = staleErr
+
+			require.NoError(t, fixture.service.CompletePausingSandboxRuntime(t.Context(), "sandbox-1"))
+			require.Equal(t, []string{"sandbox-1"}, fixture.store.pauseContinueCalls)
+			require.Empty(t, fixture.store.pauseSources)
+			require.Empty(t, fixture.plannedRetire.requests)
+			require.Empty(t, fixture.store.quiesceCalls)
+			require.Empty(t, fixture.allocation.requests)
+		})
 	}
 }
 
@@ -1158,7 +1196,7 @@ func TestServiceAutomaticPausePersistsAutoSourceBeforeStop(t *testing.T) {
 	if err := fixture.service.PauseSandboxByID(context.Background(), "sandbox-1"); err != nil {
 		t.Fatal(err)
 	}
-	if len(fixture.store.pauseSources) < 2 || fixture.store.pauseSources[0] != "sandbox-1:auto" {
+	if !reflect.DeepEqual(fixture.store.pauseSources, []string{"sandbox-1:auto"}) {
 		t.Fatalf("pause sources = %v", fixture.store.pauseSources)
 	}
 	if len(enqueuer.sandboxIDs) != 1 || len(fixture.allocation.requests) != 1 {

--- a/manager/pkg/sandboxstore/nomad_pause.go
+++ b/manager/pkg/sandboxstore/nomad_pause.go
@@ -14,10 +14,11 @@ import (
 )
 
 var (
-	ErrNomadSandboxPauseConflict  = errors.New("nomad sandbox pause conflict")
-	ErrNomadSandboxPauseNotReady  = errors.New("nomad sandbox pause is not ready")
-	ErrNomadSandboxTTLNotExpired  = errors.New("nomad sandbox TTL is not expired")
-	ErrNomadSandboxHardTTLExpired = errors.New("nomad sandbox hard TTL is expired")
+	ErrNomadSandboxPauseConflict   = errors.New("nomad sandbox pause conflict")
+	ErrNomadSandboxPauseNotReady   = errors.New("nomad sandbox pause is not ready")
+	ErrNomadSandboxPauseNotPending = errors.New("nomad sandbox pause is not pending")
+	ErrNomadSandboxTTLNotExpired   = errors.New("nomad sandbox TTL is not expired")
+	ErrNomadSandboxHardTTLExpired  = errors.New("nomad sandbox hard TTL is expired")
 )
 
 // NomadSandboxPauseCandidate is the exact active allocation and writer
@@ -65,7 +66,19 @@ func (s *PGSandboxStore) RequestNomadSandboxPause(
 	sandboxID string,
 	source string,
 ) (*NomadSandboxPauseCandidate, error) {
-	return s.requestNomadSandboxPause(ctx, sandboxID, source, nil, false)
+	return s.requestNomadSandboxPause(ctx, sandboxID, source, nil, false, false)
+}
+
+// ContinueNomadSandboxPause returns the exact active planned-pause operation
+// without creating one. It is the retry boundary for asynchronous completion,
+// so a stale queue item cannot pause a sandbox that has already resumed.
+func (s *PGSandboxStore) ContinueNomadSandboxPause(
+	ctx context.Context,
+	sandboxID string,
+) (*NomadSandboxPauseCandidate, error) {
+	return s.requestNomadSandboxPause(
+		ctx, sandboxID, SandboxLifecycleSourceManual, nil, false, true,
+	)
 }
 
 // RequestNomadSandboxTTLPause starts an automatic pause only if the soft TTL
@@ -75,7 +88,7 @@ func (s *PGSandboxStore) RequestNomadSandboxTTLPause(
 	ctx context.Context,
 	sandboxID string,
 ) (*NomadSandboxPauseCandidate, error) {
-	return s.requestNomadSandboxPause(ctx, sandboxID, SandboxLifecycleSourceAuto, nil, true)
+	return s.requestNomadSandboxPause(ctx, sandboxID, SandboxLifecycleSourceAuto, nil, true, false)
 }
 
 // RequestNomadSandboxPressurePause persists the same planned pause while
@@ -92,7 +105,7 @@ func (s *PGSandboxStore) RequestNomadSandboxPressurePause(
 	}
 	copy := *request
 	copy.BindingDigest = append([]byte(nil), request.BindingDigest...)
-	return s.requestNomadSandboxPause(ctx, copy.SandboxID, SandboxLifecycleSourceAuto, &copy, false)
+	return s.requestNomadSandboxPause(ctx, copy.SandboxID, SandboxLifecycleSourceAuto, &copy, false, false)
 }
 
 func (s *PGSandboxStore) requestNomadSandboxPause(
@@ -101,6 +114,7 @@ func (s *PGSandboxStore) requestNomadSandboxPause(
 	source string,
 	pressure *RootFSWriterPressurePauseRequest,
 	requireExpiredTTL bool,
+	continueOnly bool,
 ) (*NomadSandboxPauseCandidate, error) {
 	if s == nil || s.pool == nil {
 		return nil, fmt.Errorf("sandbox store is not configured")
@@ -123,6 +137,18 @@ func (s *PGSandboxStore) requestNomadSandboxPause(
 	record, err := lockNomadSandboxClaimRecord(ctx, tx, sandboxID)
 	if err != nil {
 		return nil, err
+	}
+	var continuedLifecycle *SandboxLifecycleTxn
+	if continueOnly {
+		continuedLifecycle, err = getActiveLifecycleTxn(ctx, tx, sandboxID)
+		if err != nil {
+			return nil, fmt.Errorf("load active Nomad pause lifecycle: %w", err)
+		}
+		if continuedLifecycle == nil || continuedLifecycle.Kind != SandboxLifecycleKindPause ||
+			(continuedLifecycle.Source != SandboxLifecycleSourceManual &&
+				continuedLifecycle.Source != SandboxLifecycleSourceAuto) {
+			return nil, ErrNomadSandboxPauseNotPending
+		}
 	}
 	alreadyPaused := false
 	switch record.DesiredState {
@@ -254,9 +280,12 @@ func (s *PGSandboxStore) requestNomadSandboxPause(
 		default:
 			return nil, fmt.Errorf("%w: writer grant is %s", ErrNomadSandboxPauseNotReady, grant.State)
 		}
-		lifecycle, err = getActiveLifecycleTxn(ctx, tx, sandboxID)
-		if err != nil {
-			return nil, fmt.Errorf("load active Nomad pause lifecycle: %w", err)
+		lifecycle = continuedLifecycle
+		if lifecycle == nil {
+			lifecycle, err = getActiveLifecycleTxn(ctx, tx, sandboxID)
+			if err != nil {
+				return nil, fmt.Errorf("load active Nomad pause lifecycle: %w", err)
+			}
 		}
 		if lifecycle == nil {
 			if slot.State != RuntimeSlotStateActive {

--- a/manager/pkg/sandboxstore/nomad_pause_integration_test.go
+++ b/manager/pkg/sandboxstore/nomad_pause_integration_test.go
@@ -54,6 +54,27 @@ func TestRequestNomadSandboxPausePersistsDeterministicIntentIntegration(t *testi
 	require.Equal(t, 1, lifecycleCount)
 }
 
+func TestContinueNomadSandboxPauseDoesNotStartNewLifecycleIntegration(t *testing.T) {
+	fixture := newNomadPauseStoreFixture(t, "stale-completion")
+
+	_, err := fixture.store.ContinueNomadSandboxPause(fixture.ctx, fixture.sandboxID)
+	require.ErrorIs(t, err, ErrNomadSandboxPauseNotPending)
+	active, err := fixture.store.GetActiveLifecycleTxn(fixture.ctx, fixture.sandboxID)
+	require.NoError(t, err)
+	require.Nil(t, active)
+	record, err := fixture.store.GetSandbox(fixture.ctx, fixture.sandboxID)
+	require.NoError(t, err)
+	require.Equal(t, SandboxDesiredStateActive, record.DesiredState)
+
+	requested, err := fixture.store.RequestNomadSandboxPause(
+		fixture.ctx, fixture.sandboxID, SandboxLifecycleSourceManual,
+	)
+	require.NoError(t, err)
+	continued, err := fixture.store.ContinueNomadSandboxPause(fixture.ctx, fixture.sandboxID)
+	require.NoError(t, err)
+	require.Equal(t, requested, continued)
+}
+
 func TestRequestNomadSandboxPauseRejectsMismatchedRuntimeIntegration(t *testing.T) {
 	fixture := newNomadPauseStoreFixture(t, "mismatch")
 	_, err := fixture.pool.Exec(fixture.ctx, `


### PR DESCRIPTION
## Problem

A completed pause queue item is keyed only by sandbox ID. If the sandbox resumes before a delayed retry runs, `CompletePausingSandboxRuntime` called the initiating store method again and created a fresh manual pause for the new runtime generation.

Observed in production during the Sandpi migration: generation 1 paused, generation 2 reached command-ready, then a stale generation-1 completion stopped generation 2 fourteen seconds later.

## Fix

- add a continuation-only PostgreSQL boundary that atomically requires an active planned-pause lifecycle
- make asynchronous completion use that boundary instead of the pause initiator
- drop stale completion items after resume or deletion
- retain the existing exact slot/writer planned-retire ordering

## Tests

- `go test ./...`
- PostgreSQL integration tests for request/continue behavior against a local PostgreSQL instance
- regression test proves stale completion performs no retire, quiesce, or allocation stop
