### PR TITLE
fix(manager): clean never-run migrated claims

### DIFF
--- a/manager/pkg/sandboxstore/claim_reservation.go
+++ b/manager/pkg/sandboxstore/claim_reservation.go
@@ -21,6 +21,7 @@ const (
 	SandboxRuntimeClaimPhaseReady          = "ready"
 	SandboxRuntimeClaimPhaseCleanupPending = "cleanup_pending"
 	SandboxRuntimeClaimPhaseCleaned        = "cleaned"
+	legacyACKRuntimeClaimOperationPrefix   = "legacy-ack-claim-"
 
 	MaxSandboxRuntimeClaimCleanupLimit = 1_000
 )
@@ -794,6 +795,9 @@ func fenceSandboxClaimRuntimeSlotForCleanup(
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return nil, fmt.Errorf("lock sandbox cleanup runtime slot: %w", err)
 	}
+	if errors.Is(err, pgx.ErrNoRows) && isNeverRunLegacyACKRuntimeClaim(record, claim) {
+		candidate.PhysicalStateRequired = false
+	}
 	if err == nil {
 		if slot.SandboxID != record.ID ||
 			(record.ClusterID != "" && slot.ClusterID != record.ClusterID) {
@@ -827,6 +831,26 @@ func fenceSandboxClaimRuntimeSlotForCleanup(
 		}
 	}
 	return candidate, nil
+}
+
+// isNeverRunLegacyACKRuntimeClaim recognizes the deterministic ready claims
+// emitted for paused sandboxes by the retired ACK-to-Nomad catalog importer.
+// Those claims deliberately had no runtime slot until their first resume.
+func isNeverRunLegacyACKRuntimeClaim(record *SandboxRecord, claim *SandboxRuntimeClaim) bool {
+	if record == nil || claim == nil || claim.CompletedAt.IsZero() ||
+		record.RuntimeID != "" || record.RuntimeNamespace != "" {
+		return false
+	}
+	suffix, found := strings.CutPrefix(claim.OperationID, legacyACKRuntimeClaimOperationPrefix)
+	if !found || len(suffix) != 64 {
+		return false
+	}
+	for _, character := range suffix {
+		if (character < '0' || character > '9') && (character < 'a' || character > 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 // MarkSandboxRuntimeClaimCleaned closes the durable cleanup workflow only

--- a/manager/pkg/sandboxstore/claim_reservation_integration_test.go
+++ b/manager/pkg/sandboxstore/claim_reservation_integration_test.go
@@ -291,6 +291,44 @@ func TestFenceExpiredSandboxClaimWithoutSlotCanBeCleaned(t *testing.T) {
 	require.Equal(t, SandboxRuntimeClaimPhaseCleaned, phase)
 }
 
+func TestRequestSandboxRuntimeClaimCleanupCleansNeverRunLegacyACKClaim(t *testing.T) {
+	ctx := context.Background()
+	pool := newSandboxStoreIntegrationPool(t)
+	store := NewPGSandboxStore(pool)
+	record := rootFSTestSandboxRecord("sandbox-never-run-legacy-ack", "team-1")
+	operationID := legacyACKRuntimeClaimOperationPrefix + strings.Repeat("a", 64)
+	_, err := store.ReserveSandboxClaim(ctx, &ReserveSandboxClaimRequest{
+		Record: record, OperationID: operationID, LeaseTTL: 15 * time.Second,
+	})
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		UPDATE manager.sandboxes
+		SET desired_state = $2
+		WHERE sandbox_id = $1
+	`, record.ID, SandboxDesiredStatePaused)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		UPDATE manager.sandbox_runtime_claims
+		SET phase = $2, lease_expires_at = NULL, completed_at = NOW()
+		WHERE sandbox_id = $1
+	`, record.ID, SandboxRuntimeClaimPhaseReady)
+	require.NoError(t, err)
+
+	candidate, err := store.RequestSandboxRuntimeClaimCleanup(
+		ctx, record.ID, "sandbox deletion requested",
+	)
+	require.NoError(t, err)
+	require.Empty(t, candidate.SlotID)
+	require.False(t, candidate.PhysicalStateRequired)
+	require.NoError(t, store.MarkSandboxDeleted(ctx, record.ID, time.Now().UTC()))
+	require.NoError(t, store.MarkSandboxRuntimeClaimCleaned(ctx, record.ID, operationID))
+	var phase string
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT phase FROM manager.sandbox_runtime_claims WHERE sandbox_id = $1
+	`, record.ID).Scan(&phase))
+	require.Equal(t, SandboxRuntimeClaimPhaseCleaned, phase)
+}
+
 func TestRequestSandboxRuntimeClaimCleanupFencesReadyAllocationAtomically(t *testing.T) {
 	ctx := context.Background()
 	pool := newSandboxStoreIntegrationPool(t)


### PR DESCRIPTION
## Summary
- recognize the deterministic completed claims emitted for paused sandboxes by the retired ACK-to-Nomad importer
- allow logical cleanup only when that exact claim has no runtime binding and no runtime-slot record
- preserve fail-closed behavior for ordinary completed claims with missing physical state

## Tests
- `go test ./manager/pkg/sandboxclaimreconciler ./manager/pkg/sandboxstore`
- `INTEGRATION_DATABASE_URL=... go test ./manager/pkg/sandboxstore -count=1`
- targeted PostgreSQL regression covering both the migrated no-slot claim and ordinary missing-slot fail-closed path