### PR TITLE
Sync docs with Nomad rootfs lifecycle

### DIFF
--- a/docs/sandbox/docker-in-sandbox/page.mdx
+++ b/docs/sandbox/docker-in-sandbox/page.mdx
@@ -283,7 +283,7 @@ main().catch((err) => {
     {
       label: "CLI",
       language: "bash",
-      code: `SANDBOX_ID="$(s0 -o json sandbox create --template default --hard-ttl 1800 | jq -r '.ID')"
+      code: `SANDBOX_ID="$(s0 -o json sandbox create --template default --hard-ttl 1800 | jq -r '.id')"
 trap 's0 sandbox delete "$SANDBOX_ID" >/dev/null 2>&1 || true' EXIT
 
 s0 sandbox exec "$SANDBOX_ID" -- rm -f /tmp/sandbox0-test-databases.ready

--- a/docs/sandbox/functions/page.mdx
+++ b/docs/sandbox/functions/page.mdx
@@ -287,41 +287,6 @@ if err != nil {
 }`
     },
     {
-      label: "TypeScript",
-      language: "typescript",
-      code: `const sandbox = await client.sandboxes.claim('default', {
-    autoResume: true,
-    services: [
-        {
-            id: 'webhook',
-            runtime: {
-                type: 'function',
-                _function: {
-                    runtime: 'python',
-                    handler: 'handler',
-                    maxConcurrency: 1,
-                    source: {
-                        type: 'inline',
-                        code: 'def handler(request):\\n    return {"status": 200, "body": "ok"}\\n',
-                    },
-                },
-            },
-            ingress: {
-                _public: true,
-                routes: [
-                    {
-                        id: 'webhook',
-                        pathPrefix: '/webhook',
-                        methods: ['POST'],
-                        resume: true,
-                    },
-                ],
-            },
-        },
-    ],
-});`
-    },
-    {
       label: "Python",
       language: "python",
       code: `from sandbox0.apispec.models.sandbox_config import SandboxConfig
@@ -360,6 +325,41 @@ sandbox = client.sandboxes.claim(
         ],
     }),
 )`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const sandbox = await client.sandboxes.claim('default', {
+    autoResume: true,
+    services: [
+        {
+            id: 'webhook',
+            runtime: {
+                type: 'function',
+                _function: {
+                    runtime: 'python',
+                    handler: 'handler',
+                    maxConcurrency: 1,
+                    source: {
+                        type: 'inline',
+                        code: 'def handler(request):\\n    return {"status": 200, "body": "ok"}\\n',
+                    },
+                },
+            },
+            ingress: {
+                _public: true,
+                routes: [
+                    {
+                        id: 'webhook',
+                        pathPrefix: '/webhook',
+                        methods: ['POST'],
+                        resume: true,
+                    },
+                ],
+            },
+        },
+    ],
+});`
     },
     {
       label: "CLI",

--- a/docs/sandbox/page.mdx
+++ b/docs/sandbox/page.mdx
@@ -101,10 +101,12 @@ Set `config.resources.memory` at claim time when one sandbox needs a different m
 The request only accepts memory. Manager derives CPU from
 `team_template_memory_per_cpu` and applies the platform minimum. PostgreSQL
 records the exact resource lease and ctld enforces it in the sandbox cgroup;
-Nomad carrier resources are overhead only. Existing running sandboxes can
-update memory with the Update Sandbox API.
+Nomad carrier resources are overhead only. To change memory, claim another
+sandbox with the required resource override; the Update Sandbox API does not
+change an existing sandbox's resource lease.
 
-SDK helpers expose this as `WithSandboxMemory` / `UpdateSandboxMemory` in Go, `memory` / `updateMemory` in TypeScript, `memory` / `update_memory` in Python, and `--memory` in the `s0` CLI.
+Claim-time helpers expose this as `WithSandboxMemory` in Go, `memory` in Python,
+`memory` in TypeScript, and `--memory` in the `s0` CLI.
 
 ### TTL vs Hard TTL
 

--- a/docs/sandbox/services/page.mdx
+++ b/docs/sandbox/services/page.mdx
@@ -202,19 +202,19 @@ for _, service := range resp.Services {
 }`
     },
     {
+      label: "Python",
+      language: "python",
+      code: `resp = sandbox.get_services()
+for service in resp.services:
+    print(f"{service.id} url={service.public_url} port={service.port}")`
+    },
+    {
       label: "TypeScript",
       language: "typescript",
       code: `const resp = await sandbox.getServices();
 for (const service of resp.services ?? []) {
     console.log(\`\${service.id} url=\${service.publicUrl ?? ''} port=\${service.port ?? ''}\`);
 }`
-    },
-    {
-      label: "Python",
-      language: "python",
-      code: `resp = sandbox.get_services()
-for service in resp.services:
-    print(f"{service.id} url={service.public_url} port={service.port}")`
     },
     {
       label: "CLI",
@@ -272,44 +272,6 @@ if err != nil {
 fmt.Printf("services: %d\\n", len(resp.Services))`
     },
     {
-      label: "TypeScript",
-      language: "typescript",
-      code: `import { createHash } from 'node:crypto';
-
-const tokenHash = createHash('sha256')
-    .update(process.env.PUBLIC_API_TOKEN!)
-    .digest('hex');
-
-const resp = await sandbox.updateServices([
-    {
-        id: 'api',
-        port: 8080,
-        runtime: {
-            type: 'cmd',
-            command: ['python3', '-m', 'http.server', '8080'],
-            cwd: '/workspace',
-        },
-        ingress: {
-            _public: true,
-            routes: [
-                {
-                    id: 'api',
-                    pathPrefix: '/api',
-                    methods: ['GET', 'POST'],
-                    auth: {
-                        mode: 'bearer',
-                        bearerTokenSha256: tokenHash,
-                    },
-                    timeoutSeconds: 30,
-                    resume: true,
-                },
-            ],
-        },
-    },
-]);
-console.log('services:', resp.services?.length ?? 0);`
-    },
-    {
       label: "Python",
       language: "python",
       code: `import hashlib
@@ -354,6 +316,44 @@ resp = sandbox.update_services([
 print(f"services: {len(resp.services)}")`
     },
     {
+      label: "TypeScript",
+      language: "typescript",
+      code: `import { createHash } from 'node:crypto';
+
+const tokenHash = createHash('sha256')
+    .update(process.env.PUBLIC_API_TOKEN!)
+    .digest('hex');
+
+const resp = await sandbox.updateServices([
+    {
+        id: 'api',
+        port: 8080,
+        runtime: {
+            type: 'cmd',
+            command: ['python3', '-m', 'http.server', '8080'],
+            cwd: '/workspace',
+        },
+        ingress: {
+            _public: true,
+            routes: [
+                {
+                    id: 'api',
+                    pathPrefix: '/api',
+                    methods: ['GET', 'POST'],
+                    auth: {
+                        mode: 'bearer',
+                        bearerTokenSha256: tokenHash,
+                    },
+                    timeoutSeconds: 30,
+                    resume: true,
+                },
+            ],
+        },
+    },
+]);
+console.log('services:', resp.services?.length ?? 0);`
+    },
+    {
       label: "CLI",
       language: "bash",
       code: `s0 sandbox service update --services-file services.yaml -s sb_abc123`
@@ -390,14 +390,14 @@ if err != nil {
 }`
     },
     {
-      label: "TypeScript",
-      language: "typescript",
-      code: `await sandbox.clearServices();`
-    },
-    {
       label: "Python",
       language: "python",
       code: `sandbox.clear_services()`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `await sandbox.clearServices();`
     },
     {
       label: "CLI",
@@ -472,36 +472,6 @@ if err != nil {
 }`
     },
     {
-      label: "TypeScript",
-      language: "typescript",
-      code: `const sandbox = await client.sandboxes.claim('default', {
-    autoResume: true,
-    services: [
-        {
-            id: 'api',
-            port: 8080,
-            runtime: {
-                type: 'cmd',
-                command: ['python3', '-m', 'http.server', '8080'],
-                cwd: '/workspace',
-            },
-            ingress: {
-                _public: true,
-                routes: [
-                    {
-                        id: 'api',
-                        pathPrefix: '/api',
-                        rewritePrefix: '/',
-                        methods: ['GET', 'POST'],
-                        resume: true,
-                    },
-                ],
-            },
-        },
-    ],
-});`
-    },
-    {
       label: "Python",
       language: "python",
       code: `from sandbox0.apispec.models.sandbox_config import SandboxConfig
@@ -535,6 +505,36 @@ sandbox = client.sandboxes.claim(
         ],
     }),
 )`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const sandbox = await client.sandboxes.claim('default', {
+    autoResume: true,
+    services: [
+        {
+            id: 'api',
+            port: 8080,
+            runtime: {
+                type: 'cmd',
+                command: ['python3', '-m', 'http.server', '8080'],
+                cwd: '/workspace',
+            },
+            ingress: {
+                _public: true,
+                routes: [
+                    {
+                        id: 'api',
+                        pathPrefix: '/api',
+                        rewritePrefix: '/',
+                        methods: ['GET', 'POST'],
+                        resume: true,
+                    },
+                ],
+            },
+        },
+    ],
+});`
     },
     {
       label: "CLI",

--- a/docs/sandbox/snapshot-restore/page.mdx
+++ b/docs/sandbox/snapshot-restore/page.mdx
@@ -128,47 +128,23 @@ Create a snapshot from a running or paused sandbox. Pause the sandbox and wait u
     {
       label: "Go",
       language: "go",
-      code: `_, err := client.PauseSandbox(ctx, sandbox.ID)
+      code: `paused, err := client.PauseSandboxAndWait(ctx, sandbox.ID, nil)
 if err != nil {
     log.Fatal(err)
 }
-
-for {
-    sb, err := client.GetSandbox(ctx, sandbox.ID)
-    if err != nil {
-        log.Fatal(err)
-    }
-    if sb.Status == apispec.SandboxLifecycleStatusPaused {
-        break
-    }
-    time.Sleep(time.Second)
-}`
+fmt.Printf("Sandbox status: %s\\n", paused.Status)`
     },
     {
       label: "Python",
       language: "python",
-      code: `import time
-
-client.sandboxes.pause(sandbox.id)
-
-while True:
-    sb = client.sandboxes.get(sandbox.id)
-    if sb.status == "paused":
-        break
-    time.sleep(1)`
+      code: `paused = client.sandboxes.pause_and_wait(sandbox.id)
+print(f"Sandbox status: {paused.status}")`
     },
     {
       label: "TypeScript",
       language: "typescript",
-      code: `await client.sandboxes.pause(sandbox.id);
-
-while (true) {
-    const sb = await client.sandboxes.get(sandbox.id);
-    if (sb.status === "paused") {
-        break;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-}`
+      code: `const paused = await client.sandboxes.pauseAndWait(sandbox.id);
+console.log("Sandbox status:", paused.status);`
     },
     {
       label: "CLI",
@@ -393,7 +369,7 @@ if err != nil {
 }
 fmt.Printf("Restored snapshot %s, status=%s\\n", restored.SnapshotID, restored.Status)
 
-_, err = client.ResumeSandbox(ctx, sandbox.ID)
+_, err = client.ResumeSandboxAndWait(ctx, sandbox.ID, nil)
 if err != nil {
     log.Fatal(err)
 }`
@@ -409,7 +385,7 @@ restored = client.sandboxes.restore_rootfs(
 )
 print(f"Restored snapshot {restored.snapshot_id}, status={restored.status}")
 
-client.sandboxes.resume(sandbox.id)`
+client.sandboxes.resume_and_wait(sandbox.id)`
     },
     {
       label: "TypeScript",
@@ -419,7 +395,7 @@ client.sandboxes.resume(sandbox.id)`
 });
 console.log("Restored snapshot:", restored.snapshotId, "status:", restored.status);
 
-await client.sandboxes.resume(sandbox.id);`
+await client.sandboxes.resumeAndWait(sandbox.id);`
     },
     {
       label: "CLI",
@@ -462,7 +438,7 @@ if err != nil {
 }
 fmt.Printf("Forked sandbox: %s\\n", forked.Sandbox.ID)
 
-_, err = client.ResumeSandbox(ctx, forked.Sandbox.ID)
+_, err = client.ResumeSandboxAndWait(ctx, forked.Sandbox.ID, nil)
 if err != nil {
     log.Fatal(err)
 }`
@@ -473,7 +449,7 @@ if err != nil {
       code: `forked = client.sandboxes.fork(sandbox.id)
 print(f"Forked sandbox: {forked.sandbox.id}")
 
-client.sandboxes.resume(forked.sandbox.id)`
+client.sandboxes.resume_and_wait(forked.sandbox.id)`
     },
     {
       label: "TypeScript",
@@ -481,7 +457,7 @@ client.sandboxes.resume(forked.sandbox.id)`
       code: `const forked = await client.sandboxes.fork(sandbox.id);
 console.log("Forked sandbox:", forked.sandbox.id);
 
-await client.sandboxes.resume(forked.sandbox.id);`
+await client.sandboxes.resumeAndWait(forked.sandbox.id);`
     },
     {
       label: "CLI",
@@ -512,13 +488,52 @@ not accept an image tag or build an image implicitly.
 | `target_base_artifact_digest` | string | Required canonical SHA-256 digest of the target attested Base artifact |
 | `rollback_ttl` | integer | Optional rollback retention in seconds; defaults to 86400 and cannot exceed 604800 |
 
-    curl -X PUT "https://api.sandbox0.ai/api/v1/sandboxes/$SANDBOX_ID/rootfs/rebase" \
-        -H "Authorization: Bearer $SANDBOX0_API_KEY" \
-        -H "Content-Type: application/json" \
-        -d '{
-            "target_base_artifact_digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-            "rollback_ttl": 86400
-        }'
+<Tabs
+  tabs={[
+    {
+      label: "Go",
+      language: "go",
+      code: `rebased, err := client.RebaseSandboxRootFS(ctx, sandbox.ID, apispec.RebaseSandboxRootFSRequest{
+    TargetBaseArtifactDigest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    RollbackTTL:              apispec.NewOptInt32(86400),
+})
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("Rebased generation: %s\\n", rebased.GenerationID)`
+    },
+    {
+      label: "Python",
+      language: "python",
+      code: `from sandbox0.apispec.models.rebase_sandbox_root_fs_request import RebaseSandboxRootFSRequest
+
+rebased = client.sandboxes.rebase_rootfs(
+    sandbox.id,
+    RebaseSandboxRootFSRequest(
+        target_base_artifact_digest="sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        rollback_ttl=86400,
+    ),
+)
+print(f"Rebased generation: {rebased.generation_id}")`
+    },
+    {
+      label: "TypeScript",
+      language: "typescript",
+      code: `const rebased = await client.sandboxes.rebaseRootFS(sandbox.id, {
+    targetBaseArtifactDigest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    rollbackTtl: 86400,
+});
+console.log("Rebased generation:", rebased.generationId);`
+    },
+    {
+      label: "CLI",
+      language: "bash",
+      code: `s0 sandbox rebase sb_abc123 \
+    --target-base-artifact-digest sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+    --rollback-ttl 86400`
+    }
+  ]}
+/>
 
 The sandbox must already be paused, have no live runtime slot or writer grant,
 and use the block-COW storage format. An exact retry returns the same target
@@ -583,16 +598,15 @@ For coding-agent and test-generation workflows, a common pattern is:
 
 1. claim a sandbox and initialize the repository or dependency cache
 2. write a marker, lockfile, or workspace state that future tasks should inherit
-3. pause the sandbox and wait for `status` to become `paused`
-4. create a rootfs snapshot for that initialized state
-5. claim each task sandbox with the same template and `snapshot_id`
-6. run task-specific work in the newly claimed sandbox
+3. create a rootfs snapshot for that initialized state; a running source remains running
+4. claim each task sandbox with the same template and `snapshot_id`
+5. run task-specific work in the newly claimed sandbox
 
 ## Next Steps
 
 <CardGroup>
   <Card title="Pause And Resume" href="/docs/sandbox/pause-resume" cta="Continue">
-    Control the lifecycle state required before snapshot, restore, and fork operations.
+    Release compute and reach the paused state required before restore and rebase operations.
   </Card>
 
   <Card title="Files" href="/docs/sandbox/files" cta="Continue">

--- a/docs/template/configuration/page.mdx
+++ b/docs/template/configuration/page.mdx
@@ -59,7 +59,7 @@ spec:
 
 CPU is platform-derived from memory and is intentionally absent from the
 public API. Claim-time `config.resources.memory` can override the template
-default, and the runtime update API can change memory for the active resource
+default. The runtime update API does not change an existing sandbox's resource
 lease. Every value remains subject to the platform maximum.
 
 Carrier allocation resources do not define these limits. Manager leases exact


### PR DESCRIPTION
## Summary

- document claim-time-only memory overrides and remove obsolete runtime memory update helpers
- use lifecycle-aware pause/resume SDK helpers and add Go, Python, TypeScript, CLI rebase examples
- describe running-source snapshot/fork semantics and fix current `s0 -o json sandbox create` ID extraction
- normalize all multi-language docs tabs to Go, Python, TypeScript, CLI

## Validation

- canonical tab-order audit: 0 mismatches
- `git diff --check`
- Go, Python, and TypeScript documentation calls compile against the SDK PR branches
- current `s0` CLI JSON paths, paused snapshot/fork, and invalid rebase path verified on ali-ue1
- website production build and rendered MDX checks pass through the sandbox0-cloud consumer

## Remote deployment drift

ali-ue1 still rejects a running-source rootfs snapshot with `409 sandbox rootfs operation requires a paused sandbox`, and its pre-upgrade fork lifecycle fence can remain active after the fork response. The docs follow the latest canonical OpenAPI and manager implementation; these remote results are retained as deployment upgrade gates.