### PR TITLE
feat(manager): support rootfs snapshots from running sandboxes

### DIFF
--- a/docs/sandbox/snapshot-restore/page.mdx
+++ b/docs/sandbox/snapshot-restore/page.mdx
@@ -220,6 +220,14 @@ console.log("Snapshot ID:", snapshot.id);`
   ]}
 />
 
+On the Nomad/gVisor runtime, a running-source snapshot is bound to the exact
+live allocation, node incarnation, rootfs writer grant, writer epoch, and
+source generation observed when the operation starts. The checkpoint is
+published as a separate immutable filesystem, so the source writer and source
+rootfs head are unchanged. If the API connection or manager restarts, Sandbox0
+recovers the same pending operation from PostgreSQL; it never substitutes a
+checkpoint from a newer source runtime.
+
 ## List And Get Snapshots
 
 List snapshots created from a sandbox, or fetch a snapshot directly by snapshot ID.

--- a/manager/cmd/manager/main.go
+++ b/manager/cmd/manager/main.go
@@ -330,7 +330,11 @@ func main() {
 	if err != nil {
 		logger.Fatal("Failed to configure Nomad sandbox mutation service", zap.Error(err))
 	}
-	sandboxRootFS, err := service.NewNomadSandboxRootFSService(sandboxStore, clk.Now)
+	runningSnapshotter, ok := sandboxRuntime.(service.SandboxRunningRootFSSnapshotter)
+	if !ok {
+		logger.Fatal("Nomad sandbox runtime lacks exact running RootFS snapshot authority")
+	}
+	sandboxRootFS, err := service.NewNomadSandboxRootFSService(sandboxStore, runningSnapshotter, clk.Now)
 	if err != nil {
 		logger.Fatal("Failed to configure Nomad sandbox RootFS service", zap.Error(err))
 	}
@@ -368,12 +372,14 @@ func main() {
 	}
 
 	forkReconciler, _ := sandboxRuntime.(service.SandboxForkReconciler)
+	snapshotReconciler, _ := sandboxRuntime.(service.SandboxRootFSSnapshotReconciler)
 	rebaseReconciler, _ := sandboxRuntime.(service.SandboxRootFSRebaseReconciler)
 	rootFSRebaser, _ := sandboxRuntime.(service.SandboxRootFSRebaser)
 	var sandboxRootFSController *service.SandboxRootFSController
-	if forkReconciler != nil || rebaseReconciler != nil {
+	if snapshotReconciler != nil || forkReconciler != nil || rebaseReconciler != nil {
 		sandboxRootFSController = service.NewSandboxRootFSController(
 			sandboxStore,
+			snapshotReconciler,
 			forkReconciler,
 			rebaseReconciler,
 			logger,

--- a/manager/pkg/http/handlers_sandbox_ingress_test.go
+++ b/manager/pkg/http/handlers_sandbox_ingress_test.go
@@ -100,6 +100,56 @@ func TestSandboxClaimOperationIDUsesSignedClaimsOnly(t *testing.T) {
 	}
 }
 
+type recordingSandboxRootFSService struct {
+	SandboxRootFSService
+	sandboxID string
+	teamID    string
+	request   *service.CreateSandboxRootFSSnapshotRequest
+}
+
+func (r *recordingSandboxRootFSService) CreateSandboxRootFSSnapshot(
+	_ context.Context,
+	sandboxID, teamID string,
+	request *service.CreateSandboxRootFSSnapshotRequest,
+) (*service.SandboxRootFSSnapshot, error) {
+	r.sandboxID, r.teamID = sandboxID, teamID
+	copy := *request
+	r.request = &copy
+	return &service.SandboxRootFSSnapshot{ID: "snapshot-1", SandboxID: sandboxID}, nil
+}
+
+func TestCreateSandboxRootFSSnapshotUsesSignedOperationIdentity(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	startedAt := time.Date(2026, 8, 21, 7, 8, 9, 123456000, time.FixedZone("offset", 8*60*60))
+	rootFS := &recordingSandboxRootFSService{}
+	server := &Server{sandboxRootFS: rootFS, logger: zap.NewNop()}
+	recorder := httptest.NewRecorder()
+	ginContext, _ := gin.CreateTestContext(recorder)
+	ginContext.Params = gin.Params{{Key: "id", Value: "sandbox-source"}}
+	request := httptest.NewRequest(http.MethodPost,
+		"/api/v1/sandboxes/sandbox-source/snapshots?operation_id=spoofed",
+		strings.NewReader(`{"name":"checkpoint","operation_id":"spoofed","started_at":"2000-01-01T00:00:00Z"}`),
+	)
+	request.Header.Set("Content-Type", "application/json")
+	request = request.WithContext(internalauth.WithClaims(request.Context(), &internalauth.Claims{
+		TeamID: "team-1", UserID: "user-1",
+		Audit: &internalauth.AuditContext{OperationID: "operation-signed", IngressStartedAt: &startedAt},
+	}))
+	ginContext.Request = request
+
+	server.createSandboxRootFSSnapshot(ginContext)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+	if rootFS.sandboxID != "sandbox-source" || rootFS.teamID != "team-1" || rootFS.request == nil ||
+		rootFS.request.Name != "checkpoint" || rootFS.request.OperationID != "operation-signed" ||
+		!rootFS.request.StartedAt.Equal(startedAt.UTC()) {
+		t.Fatalf("rootfs snapshot request = sandbox=%q team=%q request=%+v",
+			rootFS.sandboxID, rootFS.teamID, rootFS.request)
+	}
+}
+
 type recordingSandboxForker struct {
 	sourceID string
 	teamID   string

--- a/manager/pkg/http/handlers_sandbox_rootfs.go
+++ b/manager/pkg/http/handlers_sandbox_rootfs.go
@@ -28,6 +28,8 @@ func (s *Server) createSandboxRootFSSnapshot(c *gin.Context) {
 		spec.JSONError(c, http.StatusBadRequest, spec.CodeBadRequest, fmt.Sprintf("invalid request: %v", err))
 		return
 	}
+	req.OperationID = sandboxClaimOperationID(claims)
+	req.StartedAt = sandboxClaimIngressStartedAt(claims)
 	rootFS, ok := s.requireSandboxRootFS(c)
 	if !ok {
 		return

--- a/manager/pkg/nomadclaim/service.go
+++ b/manager/pkg/nomadclaim/service.go
@@ -927,15 +927,16 @@ func (s *Service) ClaimSandbox(ctx context.Context, request *service.ClaimReques
 	if err != nil {
 		return nil, fmt.Errorf("%w: runtime assignment: %v", service.ErrInvalidClaimRequest, err)
 	}
-	if err := assignment.Validate(); err != nil {
-		return nil, fmt.Errorf("%w: runtime assignment: %v", service.ErrInvalidClaimRequest, err)
-	}
 	rootFS, err := s.prepareRootFS(ctx, tpl, &req, runtimeClass.ArtifactPlatform)
 	if err != nil {
 		if errors.Is(err, sandboxstore.ErrRootFSBaseArtifactNotFound) {
 			return nil, fmt.Errorf("%w: %v", service.ErrDataPlaneNotReady, err)
 		}
 		return nil, err
+	}
+	assignment.ResetCopiedSessionState = rootFS.snapshotID != ""
+	if err := assignment.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: runtime assignment: %v", service.ErrInvalidClaimRequest, err)
 	}
 
 	now := s.now().UTC()
@@ -1227,7 +1228,7 @@ func (s *Service) initializeRootFS(ctx context.Context, req *service.ClaimReques
 	if plan.snapshotID != "" {
 		_, err := s.store.RestoreRootFSFromSnapshot(ctx, &sandboxstore.RestoreRootFSFromSnapshotRequest{
 			SandboxID: req.SandboxID, SnapshotID: plan.snapshotID, TeamID: req.TeamID,
-			OperationID: req.OperationID + "/initial-restore",
+			OperationID: req.OperationID + "/initial-restore", InitialClaimOperationID: req.OperationID,
 		})
 		return err
 	}

--- a/manager/pkg/nomadclaim/service_test.go
+++ b/manager/pkg/nomadclaim/service_test.go
@@ -122,7 +122,7 @@ type fakeClaimStore struct {
 	createdSnapshots         []*sandboxstore.CreateRootFSSnapshotRequest
 	deletedSnapshots         []string
 	templateCaptureCandidate *sandboxstore.NomadTemplateCaptureCandidate
-	templateCaptureRequests  []*sandboxstore.NomadTemplateCaptureRequest
+	templateCaptureRequests  []*sandboxstore.NomadRunningRootFSCaptureRequest
 	rebaseCandidate          *sandboxstore.NomadPausedRebaseCandidate
 	rebaseErr                error
 	rebaseRequests           []*sandboxstore.NomadPausedRebaseRequest
@@ -818,9 +818,9 @@ func (f *fakeClaimStore) DeleteTemplateBuildRootFSCapture(ctx context.Context, s
 	return f.DeleteRootFSSnapshot(ctx, snapshotID, teamID)
 }
 
-func (f *fakeClaimStore) RequestNomadRunningTemplateCapture(
+func (f *fakeClaimStore) RequestNomadRunningRootFSCapture(
 	_ context.Context,
-	request *sandboxstore.NomadTemplateCaptureRequest,
+	request *sandboxstore.NomadRunningRootFSCaptureRequest,
 ) (*sandboxstore.NomadTemplateCaptureCandidate, error) {
 	copyRequest := *request
 	f.templateCaptureRequests = append(f.templateCaptureRequests, &copyRequest)
@@ -828,6 +828,15 @@ func (f *fakeClaimStore) RequestNomadRunningTemplateCapture(
 		return nil, sandboxstore.ErrNomadTemplateCaptureNotReady
 	}
 	copy := *f.templateCaptureCandidate
+	copy.TeamID = request.TeamID
+	copy.CaptureKind = request.CaptureKind
+	copy.Name = request.Name
+	copy.Description = request.Description
+	copy.ExpiresAt = request.ExpiresAt
+	if copy.Source == nil && f.records[request.SourceSandboxID] != nil {
+		source := *f.records[request.SourceSandboxID]
+		copy.Source = &source
+	}
 	copy.BindingDigest = append([]byte(nil), f.templateCaptureCandidate.BindingDigest...)
 	if f.templateCaptureCandidate.Slot != nil {
 		slot := *f.templateCaptureCandidate.Slot
@@ -838,6 +847,20 @@ func (f *fakeClaimStore) RequestNomadRunningTemplateCapture(
 		copy.Snapshot = &snapshot
 	}
 	return &copy, nil
+}
+
+func (f *fakeClaimStore) ContinueNomadRunningRootFSCapture(
+	ctx context.Context,
+	sourceSandboxID string,
+) (*sandboxstore.NomadTemplateCaptureCandidate, error) {
+	if len(f.templateCaptureRequests) == 0 {
+		return nil, nil
+	}
+	request := f.templateCaptureRequests[len(f.templateCaptureRequests)-1]
+	if request.SourceSandboxID != sourceSandboxID {
+		return nil, nil
+	}
+	return f.RequestNomadRunningRootFSCapture(ctx, request)
 }
 
 func (f *fakeClaimStore) RestoreRootFSFromSnapshot(_ context.Context, request *sandboxstore.RestoreRootFSFromSnapshotRequest) (*sandboxstore.RootFSFilesystem, error) {
@@ -1819,6 +1842,148 @@ func TestServiceCapturesActiveNomadTemplateThroughExactWriter(t *testing.T) {
 		nodeRequest.SourceWriterGrantID != "writer-grant" {
 		t.Fatalf("node capture request = %#v", nodeRequest)
 	}
+}
+
+func TestServiceSnapshotsActiveSandboxAndRecoversLostResponse(t *testing.T) {
+	fixture := newClaimServiceFixture(t)
+	sourceID := "source-running-snapshot"
+	operationID := "operation-running-snapshot"
+	snapshotID := runningRootFSSnapshotID(sourceID, operationID)
+	expiresAt := fixture.now.Add(24 * time.Hour)
+	fixture.store.records[sourceID] = &sandboxstore.SandboxRecord{
+		ID: sourceID, TeamID: "team-1", ClusterID: "cluster-1",
+		DesiredState:      sandboxstore.SandboxDesiredStateActive,
+		RuntimeGeneration: 4, RuntimeNamespace: "nomad", RuntimeID: "allocation-snapshot",
+		TemplateSpec: fixture.service.templates.(*fakeTemplateStore).template.Spec,
+	}
+	targetFilesystemID, targetGenerationID := prepareRunningRootFSCaptureCheckpoint(
+		t, &fixture, sourceID, operationID, snapshotID, "release checkpoint", "before migration", expiresAt,
+	)
+	request := &service.CreateSandboxRootFSSnapshotRequest{
+		OperationID: operationID, StartedAt: fixture.now,
+		Name: "release checkpoint", Description: "before migration", ExpiresAt: expiresAt,
+	}
+
+	// The node committed no callback before the response was lost. PostgreSQL
+	// retains the exact writer intent for controller recovery.
+	fixture.runningFork.err = errdefs.ErrUnavailable
+	publish := fixture.runningFork.onCall
+	fixture.runningFork.onCall = nil
+	_, err := fixture.service.CreateRunningSandboxRootFSSnapshot(
+		t.Context(), sourceID, "team-1", request,
+	)
+	if !errors.Is(err, service.ErrSandboxCheckpointRequiresCtld) {
+		t.Fatalf("initial snapshot error = %v, want checkpoint backend unavailable", err)
+	}
+	if fixture.store.templateCaptureCandidate.Completed {
+		t.Fatal("snapshot published before checkpoint callback")
+	}
+
+	fixture.runningFork.err = nil
+	fixture.runningFork.onCall = publish
+	if err := fixture.service.CompleteSandboxRootFSSnapshot(t.Context(), sourceID); err != nil {
+		t.Fatal(err)
+	}
+	snapshot := fixture.store.templateCaptureCandidate.Snapshot
+	if snapshot == nil || snapshot.ID != snapshotID || snapshot.FilesystemID != targetFilesystemID ||
+		snapshot.HeadGenerationID != targetGenerationID || snapshot.SourceSandboxID != sourceID ||
+		snapshot.Name != request.Name || snapshot.Description != request.Description ||
+		!snapshot.ExpiresAt.Equal(expiresAt) {
+		t.Fatalf("recovered snapshot = %#v", snapshot)
+	}
+	if fixture.store.records[sourceID].DesiredState != sandboxstore.SandboxDesiredStateActive ||
+		fixture.store.records[sourceID].RuntimeID != "allocation-snapshot" {
+		t.Fatalf("source runtime changed during snapshot: %#v", fixture.store.records[sourceID])
+	}
+	if len(fixture.runningFork.requests) != 2 {
+		t.Fatalf("node checkpoint requests = %d, want initial dispatch and recovery", len(fixture.runningFork.requests))
+	}
+
+	// An exact ingress retry returns the durable snapshot and never dispatches
+	// another writer checkpoint.
+	retry, err := fixture.service.CreateRunningSandboxRootFSSnapshot(
+		t.Context(), sourceID, "team-1", request,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retry == nil || retry.ID != snapshotID || len(fixture.runningFork.requests) != 2 {
+		t.Fatalf("snapshot retry = %#v, node requests = %d", retry, len(fixture.runningFork.requests))
+	}
+}
+
+func prepareRunningRootFSCaptureCheckpoint(
+	t *testing.T,
+	fixture *claimServiceFixture,
+	sourceID, operationID, snapshotID, name, description string,
+	expiresAt time.Time,
+) (string, string) {
+	t.Helper()
+	targetFilesystemID := sandboxstore.NomadTemplateCaptureFilesystemID(operationID, snapshotID)
+	targetGenerationID := sandboxstore.NomadTemplateCaptureGenerationID(operationID, snapshotID)
+	binding := sha256.Sum256([]byte("running-snapshot-binding-" + operationID))
+	fixture.store.templateCaptureCandidate = &sandboxstore.NomadTemplateCaptureCandidate{
+		OperationID: operationID, SnapshotID: snapshotID,
+		TargetFilesystemID: targetFilesystemID, TargetGenerationID: targetGenerationID,
+		Slot: &sandboxstore.RuntimeSlot{
+			ID: "slot-snapshot", ClusterID: "cluster-1", AllocationID: "allocation-snapshot",
+			NodeID: "node-snapshot", NodeUID: "node-uid-snapshot", NodeBootID: "boot-snapshot",
+		},
+		SourceFilesystemID: "source-filesystem", SourceGenerationID: "source-generation",
+		SourceWriterGrantID: "writer-grant", SourceWriterEpoch: 8,
+		BindingVersion: rootfshandoff.WriterBindingVersion, BindingDigest: binding[:],
+	}
+	currentHead := digest.FromString("running-snapshot-head-" + operationID).String()
+	baseRoot := digest.FromString("running-snapshot-base-" + operationID).String()
+	descriptor := testNomadRebaseDescriptor(t, "running-snapshot", currentHead)
+	proof := rootfshandoff.RunningForkCheckpointProof{
+		Version:     rootfshandoff.RunningForkCheckpointVersion,
+		OperationID: operationID, SourceSandboxID: sourceID,
+		SourceFilesystemID: "source-filesystem", TargetSandboxID: targetFilesystemID,
+		SourceWriterGrantID: "writer-grant", SourceWriterEpoch: 8,
+		BindingVersion: rootfshandoff.WriterBindingVersion, BindingDigest: hex.EncodeToString(binding[:]),
+		ExpectedSourceGenerationID: "source-generation", CheckpointGenerationID: targetGenerationID,
+		CheckpointSequence: 1, CheckpointDescriptorDigest: digest.FromBytes(descriptor).String(),
+	}
+	proofDigest, err := proof.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.runningFork.result = rootfshandoff.RunningForkCheckpointResult{
+		Generation: rootfshandoff.GenerationDescriptor{
+			Version:      rootfshandoff.GenerationDescriptorVersion,
+			GenerationID: targetGenerationID, FilesystemID: targetFilesystemID,
+			SourceOCIDigest:    fixture.store.artifact.SourceOCIDigest,
+			BaseArtifactDigest: fixture.store.artifact.ArtifactDigest,
+			BaseBlockRoot:      baseRoot, CurrentBlockHead: currentHead,
+			WriterEpoch: 8, FormatGeneration: fixture.store.artifact.FormatGeneration,
+			DurabilityState: sandboxstore.RootFSGenerationStateS3Materialized,
+			LocatorVersion:  2, Descriptor: descriptor,
+		},
+		Proof: proof, ProofDigest: hex.EncodeToString(proofDigest[:]),
+	}
+	fixture.runningFork.onCall = func() {
+		fixture.store.generation = &sandboxstore.RootFSGeneration{
+			ID: targetGenerationID, FilesystemID: targetFilesystemID,
+			SourceOCIDigest:    fixture.store.artifact.SourceOCIDigest,
+			BaseArtifactDigest: fixture.store.artifact.ArtifactDigest,
+			BaseBlockRoot:      baseRoot, CurrentBlockHead: currentHead,
+			WriterEpoch: 8, FormatGeneration: fixture.store.artifact.FormatGeneration,
+			DurabilityState: sandboxstore.RootFSGenerationStateS3Materialized,
+			LocatorVersion:  2, Descriptor: descriptor,
+		}
+		fixture.store.snapshot = &sandboxstore.RootFSSnapshot{
+			ID: snapshotID, FilesystemID: targetFilesystemID, TeamID: "team-1",
+			SourceSandboxID: sourceID, HeadGenerationID: targetGenerationID,
+			BaseArtifactDigest: fixture.store.artifact.ArtifactDigest,
+			SourceOCIDigest:    fixture.store.artifact.SourceOCIDigest,
+			FormatGeneration:   fixture.store.artifact.FormatGeneration,
+			Name:               name, Description: description, CreatedAt: fixture.now, ExpiresAt: expiresAt,
+		}
+		fixture.store.templateCaptureCandidate.Completed = true
+		fixture.store.templateCaptureCandidate.Snapshot = fixture.store.snapshot
+	}
+	return targetFilesystemID, targetGenerationID
 }
 
 func TestServiceMapsUnavailableWarmPoolToRetryableError(t *testing.T) {

--- a/manager/pkg/nomadclaim/service_test.go
+++ b/manager/pkg/nomadclaim/service_test.go
@@ -1597,8 +1597,12 @@ func TestServiceRestoresBlockSnapshotBeforeClaim(t *testing.T) {
 	if response.SandboxID == "" || len(fixture.store.restoreCalls) != 1 ||
 		fixture.store.restoreCalls[0].SandboxID != response.SandboxID ||
 		fixture.store.restoreCalls[0].OperationID != "operation-snapshot/initial-restore" ||
+		fixture.store.restoreCalls[0].InitialClaimOperationID != "operation-snapshot" ||
 		len(fixture.store.ensureCalls) != 0 {
 		t.Fatalf("restore calls = %+v ensure calls = %+v", fixture.store.restoreCalls, fixture.store.ensureCalls)
+	}
+	if len(fixture.planner.requests) != 1 || !fixture.planner.requests[0].Runtime.ResetCopiedSessionState {
+		t.Fatalf("snapshot runtime assignment = %+v", fixture.planner.requests)
 	}
 }
 
@@ -1640,6 +1644,9 @@ func TestServiceRestoresAttestedTemplateRootFSBeforeClaim(t *testing.T) {
 		fixture.store.restoreCalls[0].SnapshotID != tpl.RootFS.SnapshotID ||
 		len(fixture.store.ensureCalls) != 0 {
 		t.Fatalf("restore calls = %+v ensure calls = %+v", fixture.store.restoreCalls, fixture.store.ensureCalls)
+	}
+	if len(fixture.planner.requests) != 1 || !fixture.planner.requests[0].Runtime.ResetCopiedSessionState {
+		t.Fatalf("template RootFS runtime assignment = %+v", fixture.planner.requests)
 	}
 }
 

--- a/manager/pkg/nomadclaim/snapshot.go
+++ b/manager/pkg/nomadclaim/snapshot.go
@@ -1,0 +1,163 @@
+package nomadclaim
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/containerd/errdefs"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/sandboxstore"
+	"github.com/sandbox0-ai/sandbox0/manager/pkg/service"
+	"github.com/sandbox0-ai/sandbox0/pkg/apierror"
+)
+
+const defaultNomadRunningSnapshotRecoveryTimeout = 10 * time.Minute
+
+type nomadRunningRootFSCaptureAbortStore interface {
+	AbortStaleNomadRunningRootFSCapture(context.Context, string, string, string) (bool, error)
+}
+
+// CreateRunningSandboxRootFSSnapshot checkpoints the exact live writer and
+// publishes a named immutable snapshot without changing the source runtime.
+func (s *Service) CreateRunningSandboxRootFSSnapshot(
+	ctx context.Context,
+	sandboxID, teamID string,
+	request *service.CreateSandboxRootFSSnapshotRequest,
+) (*sandboxstore.RootFSSnapshot, error) {
+	if request == nil {
+		request = &service.CreateSandboxRootFSSnapshotRequest{}
+	}
+	sandboxID = strings.TrimSpace(sandboxID)
+	teamID = strings.TrimSpace(teamID)
+	operationID := strings.TrimSpace(request.OperationID)
+	if sandboxID == "" || teamID == "" || operationID == "" {
+		return nil, fmt.Errorf("%w: sandbox, team, and signed operation identities are required",
+			service.ErrSandboxLifecycleUnavailable)
+	}
+	store, ok := s.store.(nomadTemplateCaptureStore)
+	if !ok {
+		return nil, service.ErrSandboxRootFSStoreUnavailable
+	}
+	snapshotID := runningRootFSSnapshotID(sandboxID, operationID)
+	snapshot, err := s.ensureRunningRootFSCapture(ctx, store, &sandboxstore.NomadRunningRootFSCaptureRequest{
+		OperationID: operationID, SourceSandboxID: sandboxID,
+		TeamID: teamID, SnapshotID: snapshotID,
+		CaptureKind: sandboxstore.NomadRunningRootFSCaptureKindSnapshot,
+		Name:        strings.TrimSpace(request.Name), Description: strings.TrimSpace(request.Description),
+		ExpiresAt: request.ExpiresAt,
+	})
+	if err != nil {
+		return nil, mapNomadRunningRootFSSnapshotError(sandboxID, err)
+	}
+	return snapshot, nil
+}
+
+// CompleteSandboxRootFSSnapshot reconstructs a pending exact-writer capture
+// entirely from PostgreSQL after an API response or manager process is lost.
+func (s *Service) CompleteSandboxRootFSSnapshot(ctx context.Context, sandboxID string) error {
+	store, ok := s.store.(nomadTemplateCaptureStore)
+	if !ok {
+		return service.ErrSandboxRootFSStoreUnavailable
+	}
+	candidate, err := store.ContinueNomadRunningRootFSCapture(ctx, sandboxID)
+	if err != nil {
+		return s.abortStaleRunningRootFSSnapshot(ctx, sandboxID, err)
+	}
+	if candidate == nil {
+		return nil
+	}
+	if candidate.Completed {
+		return nil
+	}
+	if candidate.Source == nil || candidate.Slot == nil {
+		return fmt.Errorf("pending running rootfs capture has no exact writer authority")
+	}
+	dispatchErr := s.dispatchRunningRootFSCapture(ctx, candidate)
+	request := runningRootFSCaptureRequestFromCandidate(candidate)
+	completed, completionErr := store.RequestNomadRunningRootFSCapture(ctx, request)
+	if completionErr == nil && completed != nil && completed.Completed && completed.Snapshot != nil {
+		return nil
+	}
+	if dispatchErr != nil {
+		return s.abortStaleRunningRootFSSnapshot(ctx, sandboxID,
+			fmt.Errorf("dispatch recovered running rootfs capture: %w", dispatchErr))
+	}
+	if completionErr != nil {
+		return completionErr
+	}
+	return fmt.Errorf("recovered writer checkpoint was not committed")
+}
+
+func (s *Service) abortStaleRunningRootFSSnapshot(
+	ctx context.Context,
+	sandboxID string,
+	completionErr error,
+) error {
+	lifecycle, err := s.store.GetActiveLifecycleTxn(ctx, sandboxID)
+	if err != nil {
+		return errors.Join(completionErr, fmt.Errorf("load running snapshot lifecycle: %w", err))
+	}
+	if lifecycle == nil || lifecycle.Kind != sandboxstore.SandboxLifecycleKindSnapshot ||
+		lifecycle.UpdatedAt.IsZero() || s.now().UTC().Sub(lifecycle.UpdatedAt) < defaultNomadRunningSnapshotRecoveryTimeout {
+		return completionErr
+	}
+	aborter, ok := s.store.(nomadRunningRootFSCaptureAbortStore)
+	if !ok {
+		return completionErr
+	}
+	aborted, abortErr := aborter.AbortStaleNomadRunningRootFSCapture(
+		ctx, lifecycle.ID, sandboxID,
+		"stale running snapshot lost its exact source writer identity",
+	)
+	if abortErr != nil {
+		return errors.Join(completionErr, abortErr)
+	}
+	if aborted {
+		return nil
+	}
+	return completionErr
+}
+
+func runningRootFSCaptureRequestFromCandidate(
+	candidate *sandboxstore.NomadTemplateCaptureCandidate,
+) *sandboxstore.NomadRunningRootFSCaptureRequest {
+	if candidate == nil {
+		return nil
+	}
+	sourceSandboxID := ""
+	if candidate.Source != nil {
+		sourceSandboxID = candidate.Source.ID
+	}
+	return &sandboxstore.NomadRunningRootFSCaptureRequest{
+		OperationID: candidate.OperationID, SourceSandboxID: sourceSandboxID,
+		TeamID: candidate.TeamID, SnapshotID: candidate.SnapshotID,
+		CaptureKind: candidate.CaptureKind, Name: candidate.Name,
+		Description: candidate.Description, ExpiresAt: candidate.ExpiresAt,
+	}
+}
+
+func runningRootFSSnapshotID(sandboxID, operationID string) string {
+	digest := sha256.Sum256([]byte("sandbox0-running-rootfs-snapshot\x00" + sandboxID + "\x00" + operationID))
+	return "rootfs-snapshot-" + hex.EncodeToString(digest[:16])
+}
+
+func mapNomadRunningRootFSSnapshotError(sandboxID string, err error) error {
+	switch {
+	case errors.Is(err, sandboxstore.ErrSandboxRecordNotFound):
+		return apierror.NewNotFound("sandbox", sandboxID)
+	case errors.Is(err, sandboxstore.ErrNomadTemplateCaptureConflict),
+		errors.Is(err, sandboxstore.ErrNomadTemplateCaptureNotReady),
+		errors.Is(err, sandboxstore.ErrRootFSFilesystemConflict),
+		errors.Is(err, sandboxstore.ErrRootFSWriterGrantConflict),
+		errdefs.IsInvalidArgument(err), errdefs.IsPermissionDenied(err), errdefs.IsFailedPrecondition(err):
+		return apierror.NewConflict("sandbox", sandboxID, err)
+	case errdefs.IsUnavailable(err):
+		return fmt.Errorf("%w: %v", service.ErrSandboxCheckpointRequiresCtld, err)
+	default:
+		return fmt.Errorf("create running rootfs snapshot: %w", err)
+	}
+}

--- a/manager/pkg/nomadclaim/template_capture.go
+++ b/manager/pkg/nomadclaim/template_capture.go
@@ -23,7 +23,8 @@ type nomadTemplateCaptureStore interface {
 	DeleteTemplateBuildRootFSCapture(context.Context, string, string) error
 	GetRootFSGeneration(context.Context, string) (*sandboxstore.RootFSGeneration, error)
 	GetReadyRootFSBaseArtifactByDigest(context.Context, string, sandboxstore.RootFSArtifactPlatform, sandboxstore.ReadyRootFSArtifactRequirements) (*sandboxstore.RootFSBaseArtifact, error)
-	RequestNomadRunningTemplateCapture(context.Context, *sandboxstore.NomadTemplateCaptureRequest) (*sandboxstore.NomadTemplateCaptureCandidate, error)
+	RequestNomadRunningRootFSCapture(context.Context, *sandboxstore.NomadRunningRootFSCaptureRequest) (*sandboxstore.NomadTemplateCaptureCandidate, error)
+	ContinueNomadRunningRootFSCapture(context.Context, string) (*sandboxstore.NomadTemplateCaptureCandidate, error)
 }
 
 // EnsureTemplateBuildCapture creates or recovers a deterministic block-COW
@@ -103,31 +104,66 @@ func (s *Service) ensureRunningTemplateCapture(
 	snapshotID string,
 ) (*sandboxstore.RootFSSnapshot, error) {
 	operationID := "nomad-template-capture-" + strings.TrimPrefix(snapshotID, "template-build-")
-	request := &sandboxstore.NomadTemplateCaptureRequest{
+	request := &sandboxstore.NomadRunningRootFSCaptureRequest{
 		OperationID: operationID, SourceSandboxID: source.ID,
 		TeamID: source.TeamID, SnapshotID: snapshotID,
+		CaptureKind: sandboxstore.NomadRunningRootFSCaptureKindTemplate,
+		Name:        "Template RootFS capture",
+		Description: "Internal immutable live-writer checkpoint retained by a template.",
 	}
-	candidate, err := store.RequestNomadRunningTemplateCapture(ctx, request)
+	snapshot, err := s.ensureRunningRootFSCapture(ctx, store, request)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", templatepkg.ErrTemplateSourceUnavailable, err)
+	}
+	return snapshot, nil
+}
+
+func (s *Service) ensureRunningRootFSCapture(
+	ctx context.Context,
+	store nomadTemplateCaptureStore,
+	request *sandboxstore.NomadRunningRootFSCaptureRequest,
+) (*sandboxstore.RootFSSnapshot, error) {
+	candidate, err := store.RequestNomadRunningRootFSCapture(ctx, request)
 	if err != nil {
 		return nil, err
 	}
 	if candidate == nil {
-		return nil, fmt.Errorf("%w: capture authority returned no candidate", templatepkg.ErrTemplateSourceUnavailable)
+		return nil, fmt.Errorf("capture authority returned no candidate")
 	}
 	if candidate.Completed {
 		return candidate.Snapshot, nil
 	}
-	if candidate.Slot == nil || candidate.OperationID != operationID ||
-		candidate.SnapshotID != snapshotID || candidate.SourceFilesystemID == "" ||
+	if candidate.Source == nil || candidate.Source.ID != request.SourceSandboxID ||
+		candidate.Slot == nil || candidate.OperationID != request.OperationID ||
+		candidate.SnapshotID != request.SnapshotID || candidate.SourceFilesystemID == "" ||
 		candidate.SourceGenerationID == "" || candidate.SourceWriterGrantID == "" ||
 		candidate.SourceWriterEpoch <= 0 || candidate.BindingVersion != rootfshandoff.WriterBindingVersion ||
 		len(candidate.BindingDigest) != 32 || candidate.TargetFilesystemID == "" ||
 		candidate.TargetGenerationID == "" {
-		return nil, fmt.Errorf("%w: capture authority returned an incomplete candidate",
-			templatepkg.ErrTemplateSourceUnavailable)
+		return nil, fmt.Errorf("capture authority returned an incomplete candidate")
 	}
+	dispatchErr := s.dispatchRunningRootFSCapture(ctx, candidate)
+	// PostgreSQL remains authoritative after every dispatch, including a lost
+	// node-channel response after the writer callback committed.
+	completed, completionErr := store.RequestNomadRunningRootFSCapture(ctx, request)
+	if completionErr == nil && completed != nil && completed.Completed && completed.Snapshot != nil {
+		return completed.Snapshot, nil
+	}
+	if dispatchErr != nil {
+		return nil, fmt.Errorf("dispatch running rootfs capture: %w", dispatchErr)
+	}
+	if completionErr != nil {
+		return nil, completionErr
+	}
+	return nil, fmt.Errorf("writer checkpoint was not committed")
+}
+
+func (s *Service) dispatchRunningRootFSCapture(
+	ctx context.Context,
+	candidate *sandboxstore.NomadTemplateCaptureCandidate,
+) error {
 	fork := rootfshandoff.RunningForkCheckpointRequest{
-		OperationID: operationID, SourceSandboxID: source.ID,
+		OperationID: candidate.OperationID, SourceSandboxID: candidate.Source.ID,
 		TargetSandboxID:    candidate.TargetFilesystemID,
 		TargetGenerationID: candidate.TargetGenerationID,
 	}
@@ -146,21 +182,7 @@ func (s *Service) ensureRunningTemplateCapture(
 	if dispatchErr == nil {
 		dispatchErr = validateNomadTemplateCaptureCheckpoint(candidate, fork, checkpoint)
 	}
-	// PostgreSQL remains authoritative after every dispatch, including a lost
-	// node-channel response after the writer callback committed.
-	completed, completionErr := store.RequestNomadRunningTemplateCapture(ctx, request)
-	if completionErr == nil && completed != nil && completed.Completed && completed.Snapshot != nil {
-		return completed.Snapshot, nil
-	}
-	if dispatchErr != nil {
-		return nil, fmt.Errorf("%w: dispatch running template capture: %v",
-			templatepkg.ErrTemplateSourceUnavailable, dispatchErr)
-	}
-	if completionErr != nil {
-		return nil, completionErr
-	}
-	return nil, fmt.Errorf("%w: writer checkpoint was not committed",
-		templatepkg.ErrTemplateSourceUnavailable)
+	return dispatchErr
 }
 
 func validateNomadTemplateCaptureCheckpoint(
@@ -181,7 +203,7 @@ func validateNomadTemplateCaptureCheckpoint(
 		proof.BindingVersion != candidate.BindingVersion ||
 		proof.BindingDigest != hex.EncodeToString(candidate.BindingDigest) ||
 		proof.ExpectedSourceGenerationID != candidate.SourceGenerationID {
-		return fmt.Errorf("node checkpoint belongs to another template capture")
+		return fmt.Errorf("node checkpoint belongs to another running rootfs capture")
 	}
 	return nil
 }

--- a/manager/pkg/sandboxstore/generation.go
+++ b/manager/pkg/sandboxstore/generation.go
@@ -919,6 +919,12 @@ func initialRootFSGenerationID(filesystemID, artifactDigest string, formatGenera
 	return "rootfs-generation-" + hex.EncodeToString(sum[:])
 }
 
+func restoredRootFSGenerationID(filesystemID, snapshotGenerationID string, writerEpoch int64) string {
+	sum := sha256.Sum256([]byte(fmt.Sprintf("sandbox0-rootfs-restore-v1\x00%s\x00%s\x00%d",
+		filesystemID, snapshotGenerationID, writerEpoch)))
+	return "rootfs-generation-" + hex.EncodeToString(sum[:])
+}
+
 func initialRootFSGenerationMatches(
 	filesystem *RootFSFilesystem,
 	generation *RootFSGeneration,

--- a/manager/pkg/sandboxstore/generation_integration_test.go
+++ b/manager/pkg/sandboxstore/generation_integration_test.go
@@ -1131,6 +1131,37 @@ func TestBlockRootFSSnapshotRestoreCopyAndRollback(t *testing.T) {
 	require.Equal(t, artifact.ArtifactDigest, snapshot.BaseArtifactDigest)
 	require.Equal(t, artifact.SourceOCIDigest, snapshot.SourceOCIDigest)
 
+	claimRecord := rootFSTestSandboxRecord("sandbox-snapshot-initial-claim", sourceRecord.TeamID)
+	_, err = store.ReserveSandboxClaim(ctx, &ReserveSandboxClaimRequest{
+		Record: claimRecord, OperationID: "operation-snapshot-initial-claim", LeaseTTL: 15 * time.Second,
+	})
+	require.NoError(t, err)
+	_, err = store.RestoreRootFSFromSnapshot(ctx, &RestoreRootFSFromSnapshotRequest{
+		SandboxID: claimRecord.ID, SnapshotID: snapshot.ID, TeamID: claimRecord.TeamID,
+		OperationID: "operation-snapshot-initial-claim/initial-restore",
+	})
+	require.ErrorIs(t, err, ErrRootFSFilesystemConflict)
+	claimedCopy, err := store.RestoreRootFSFromSnapshot(ctx, &RestoreRootFSFromSnapshotRequest{
+		SandboxID: claimRecord.ID, SnapshotID: snapshot.ID, TeamID: claimRecord.TeamID,
+		OperationID:             "operation-snapshot-initial-claim/initial-restore",
+		InitialClaimOperationID: "operation-snapshot-initial-claim",
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, initial.ID, claimedCopy.HeadGenerationID)
+	require.Equal(t, filesystem.ID, claimedCopy.SourceFilesystemID)
+	claimedGeneration, err := store.GetRootFSGeneration(ctx, claimedCopy.HeadGenerationID)
+	require.NoError(t, err)
+	require.Equal(t, claimedCopy.ID, claimedGeneration.FilesystemID)
+	require.Equal(t, initial.ID, claimedGeneration.ParentGenerationID)
+	require.True(t, rootFSGenerationRestoreContentEqual(initial, claimedGeneration))
+	retriedClaimedCopy, err := store.RestoreRootFSFromSnapshot(ctx, &RestoreRootFSFromSnapshotRequest{
+		SandboxID: claimRecord.ID, SnapshotID: snapshot.ID, TeamID: claimRecord.TeamID,
+		OperationID:             "operation-snapshot-initial-claim/initial-restore",
+		InitialClaimOperationID: "operation-snapshot-initial-claim",
+	})
+	require.NoError(t, err)
+	require.Equal(t, claimedCopy.HeadGenerationID, retriedClaimedCopy.HeadGenerationID)
+
 	second := putTestDurableRootFSGeneration(t, ctx, pool, filesystem, initial, "snapshot-second", 1)
 	secondSnapshot, err := store.CreateRootFSSnapshot(ctx, &CreateRootFSSnapshotRequest{
 		SandboxID: sourceRecord.ID, SnapshotID: "snapshot-block-second",
@@ -1141,9 +1172,14 @@ func TestBlockRootFSSnapshotRestoreCopyAndRollback(t *testing.T) {
 		SandboxID: lateCopyRecord.ID, SnapshotID: secondSnapshot.ID, TeamID: lateCopyRecord.TeamID,
 	})
 	require.NoError(t, err)
-	require.Equal(t, second.ID, lateCopy.HeadGenerationID)
+	require.NotEqual(t, second.ID, lateCopy.HeadGenerationID)
 	require.Equal(t, second.WriterEpoch, lateCopy.WriterEpoch,
-		"a copied filesystem must issue epochs newer than its shared generation")
+		"a new copied filesystem preserves the captured epoch")
+	lateGeneration, err := store.GetRootFSGeneration(ctx, lateCopy.HeadGenerationID)
+	require.NoError(t, err)
+	require.Equal(t, lateCopy.ID, lateGeneration.FilesystemID)
+	require.Equal(t, second.ID, lateGeneration.ParentGenerationID)
+	require.True(t, rootFSGenerationRestoreContentEqual(second, lateGeneration))
 	restored, err := store.RestoreRootFSFromSnapshot(ctx, &RestoreRootFSFromSnapshotRequest{
 		SandboxID: sourceRecord.ID, SnapshotID: snapshot.ID, TeamID: sourceRecord.TeamID,
 		OperationID: "restore-block-initial", RollbackExpiresAt: time.Now().Add(time.Hour),
@@ -1167,8 +1203,39 @@ func TestBlockRootFSSnapshotRestoreCopyAndRollback(t *testing.T) {
 		SandboxID: copyRecord.ID, SnapshotID: snapshot.ID, TeamID: copyRecord.TeamID,
 	})
 	require.NoError(t, err)
-	require.Equal(t, initial.ID, copied.HeadGenerationID)
+	require.NotEqual(t, initial.ID, copied.HeadGenerationID)
 	require.Equal(t, filesystem.ID, copied.SourceFilesystemID)
+	copiedGeneration, err := store.GetRootFSGeneration(ctx, copied.HeadGenerationID)
+	require.NoError(t, err)
+	require.Equal(t, copied.ID, copiedGeneration.FilesystemID)
+	require.Equal(t, initial.ID, copiedGeneration.ParentGenerationID)
+	require.True(t, rootFSGenerationRestoreContentEqual(initial, copiedGeneration))
+	replacedCopy, err := store.RestoreRootFSFromSnapshot(ctx, &RestoreRootFSFromSnapshotRequest{
+		SandboxID: copyRecord.ID, SnapshotID: secondSnapshot.ID, TeamID: copyRecord.TeamID,
+		OperationID: "restore-copy-to-second", RollbackExpiresAt: time.Now().Add(time.Hour),
+	})
+	require.NoError(t, err)
+	require.Equal(t, copied.WriterEpoch+1, replacedCopy.WriterEpoch)
+	require.NotEqual(t, copied.HeadGenerationID, replacedCopy.HeadGenerationID)
+	replacedGeneration, err := store.GetRootFSGeneration(ctx, replacedCopy.HeadGenerationID)
+	require.NoError(t, err)
+	require.Equal(t, replacedCopy.ID, replacedGeneration.FilesystemID)
+	require.Equal(t, second.ID, replacedGeneration.ParentGenerationID)
+	require.True(t, rootFSGenerationRestoreContentEqual(second, replacedGeneration))
+	retriedReplacement, err := store.RestoreRootFSFromSnapshot(ctx, &RestoreRootFSFromSnapshotRequest{
+		SandboxID: copyRecord.ID, SnapshotID: secondSnapshot.ID, TeamID: copyRecord.TeamID,
+		OperationID: "restore-copy-to-second", RollbackExpiresAt: time.Now().Add(time.Hour),
+	})
+	require.NoError(t, err)
+	require.Equal(t, replacedCopy.HeadGenerationID, retriedReplacement.HeadGenerationID)
+	require.Equal(t, replacedCopy.WriterEpoch, retriedReplacement.WriterEpoch)
+	rolledBackCopy, err := store.RollbackRootFSHead(ctx, &RollbackRootFSHeadRequest{
+		SandboxID: copyRecord.ID, OperationID: "restore-copy-to-second", TeamID: copyRecord.TeamID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, copied.HeadGenerationID, rolledBackCopy.HeadGenerationID)
+	require.Equal(t, replacedCopy.WriterEpoch, rolledBackCopy.WriterEpoch,
+		"rollback must not rewind the target writer epoch")
 
 	loadedSnapshot, err := store.GetRootFSSnapshot(ctx, snapshot.ID, sourceRecord.TeamID)
 	require.NoError(t, err)

--- a/manager/pkg/sandboxstore/generation_test.go
+++ b/manager/pkg/sandboxstore/generation_test.go
@@ -156,6 +156,14 @@ func TestInitialRootFSGenerationIDSeparatesFilesystems(t *testing.T) {
 	require.Equal(t, first, initialRootFSGenerationID("filesystem-a", artifact, 1))
 }
 
+func TestRestoredRootFSGenerationIDSeparatesFilesystemGenerationAndEpoch(t *testing.T) {
+	first := restoredRootFSGenerationID("filesystem-a", "generation-a", 1)
+	require.Equal(t, first, restoredRootFSGenerationID("filesystem-a", "generation-a", 1))
+	require.NotEqual(t, first, restoredRootFSGenerationID("filesystem-b", "generation-a", 1))
+	require.NotEqual(t, first, restoredRootFSGenerationID("filesystem-a", "generation-b", 1))
+	require.NotEqual(t, first, restoredRootFSGenerationID("filesystem-a", "generation-a", 2))
+}
+
 func readyRootFSBaseArtifactTestRequest() *PutReadyRootFSBaseArtifactRequest {
 	rootDigest := digest.FromString("base-block-root").String()
 	descriptor, err := rootfsblock.EncodeDescriptor(rootfsblock.Descriptor{

--- a/manager/pkg/sandboxstore/migration_integration_test.go
+++ b/manager/pkg/sandboxstore/migration_integration_test.go
@@ -259,6 +259,10 @@ func assertFinalNomadBlockCOWSchema(t *testing.T, ctx context.Context, pool *pgx
 		"sandbox_lifecycle_txns.recovery_claim_token",
 		"sandbox_lifecycle_txns.recovery_claimed_until",
 		"sandbox_lifecycle_txns.recovery_last_error",
+		"rootfs_running_template_captures.capture_kind",
+		"rootfs_running_template_captures.snapshot_name",
+		"rootfs_running_template_captures.snapshot_description",
+		"rootfs_running_template_captures.snapshot_expires_at",
 	} {
 		parts := strings.Split(identity, ".")
 		var exists bool
@@ -282,6 +286,21 @@ func assertFinalNomadBlockCOWSchema(t *testing.T, ctx context.Context, pool *pgx
 		`, table).Scan(&exists))
 		require.True(t, exists, "required table manager.%s is missing", table)
 	}
+
+	var runningCaptureMetadataTrigger bool
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_trigger trigger
+			JOIN pg_class relation ON relation.oid = trigger.tgrelid
+			JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+			WHERE namespace.nspname = 'manager'
+			  AND relation.relname = 'rootfs_snapshots'
+			  AND trigger.tgname = 'apply_running_rootfs_capture_snapshot_metadata'
+			  AND NOT trigger.tgisinternal
+		)
+	`).Scan(&runningCaptureMetadataTrigger))
+	require.True(t, runningCaptureMetadataTrigger, "running capture snapshot metadata trigger is missing")
 
 	var artifactIndex string
 	require.NoError(t, pool.QueryRow(ctx, `

--- a/manager/pkg/sandboxstore/migrations/00051_running_rootfs_snapshot_metadata.sql
+++ b/manager/pkg/sandboxstore/migrations/00051_running_rootfs_snapshot_metadata.sql
@@ -1,0 +1,62 @@
+-- +goose Up
+
+-- The original exact-writer capture intent was introduced for template
+-- builds. Public named snapshots use the same durable checkpoint authority,
+-- so retain their immutable metadata on the existing intent instead of
+-- creating a second running-capture state machine.
+ALTER TABLE manager.rootfs_running_template_captures
+    ADD COLUMN capture_kind text NOT NULL DEFAULT 'template',
+    ADD COLUMN snapshot_name text NOT NULL DEFAULT 'Template RootFS capture',
+    ADD COLUMN snapshot_description text NOT NULL DEFAULT 'Internal immutable live-writer checkpoint retained by a template.',
+    ADD COLUMN snapshot_expires_at timestamp with time zone,
+    ADD CONSTRAINT rootfs_running_template_captures_kind_check
+        CHECK (capture_kind IN ('template', 'snapshot'));
+
+-- During a rolling manager upgrade, an older RootFS authority replica can
+-- receive the node callback and still supply the legacy template metadata.
+-- Keep the durable capture intent authoritative regardless of callback
+-- replica version.
+-- +goose StatementBegin
+CREATE FUNCTION manager.apply_running_rootfs_capture_snapshot_metadata()
+RETURNS trigger AS $$
+DECLARE
+    capture_name text;
+    capture_description text;
+    capture_expires_at timestamp with time zone;
+BEGIN
+    SELECT snapshot_name, snapshot_description, snapshot_expires_at
+    INTO capture_name, capture_description, capture_expires_at
+    FROM manager.rootfs_running_template_captures
+    WHERE snapshot_id = NEW.snapshot_id
+      AND team_id = NEW.team_id
+      AND source_sandbox_id = NEW.source_sandbox_id
+      AND target_filesystem_id = NEW.filesystem_id
+      AND checkpoint_generation_id = NEW.head_generation_id;
+
+    IF FOUND THEN
+        NEW.name := capture_name;
+        NEW.description := capture_description;
+        NEW.expires_at := capture_expires_at;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER apply_running_rootfs_capture_snapshot_metadata
+    BEFORE INSERT ON manager.rootfs_snapshots
+    FOR EACH ROW
+    EXECUTE FUNCTION manager.apply_running_rootfs_capture_snapshot_metadata();
+
+-- +goose Down
+
+DROP TRIGGER apply_running_rootfs_capture_snapshot_metadata
+    ON manager.rootfs_snapshots;
+DROP FUNCTION manager.apply_running_rootfs_capture_snapshot_metadata();
+
+ALTER TABLE manager.rootfs_running_template_captures
+    DROP CONSTRAINT rootfs_running_template_captures_kind_check,
+    DROP COLUMN snapshot_expires_at,
+    DROP COLUMN snapshot_description,
+    DROP COLUMN snapshot_name,
+    DROP COLUMN capture_kind;

--- a/manager/pkg/sandboxstore/nomad_template_capture.go
+++ b/manager/pkg/sandboxstore/nomad_template_capture.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -21,6 +22,9 @@ var (
 const (
 	nomadTemplateCaptureStatePending   = "pending"
 	nomadTemplateCaptureStatePublished = "published"
+
+	NomadRunningRootFSCaptureKindTemplate = "template"
+	NomadRunningRootFSCaptureKindSnapshot = "snapshot"
 )
 
 // NomadTemplateCaptureRequest identifies one deterministic internal snapshot
@@ -30,6 +34,19 @@ type NomadTemplateCaptureRequest struct {
 	SourceSandboxID string
 	TeamID          string
 	SnapshotID      string
+}
+
+// NomadRunningRootFSCaptureRequest identifies one deterministic immutable
+// checkpoint and the public or internal snapshot metadata published with it.
+type NomadRunningRootFSCaptureRequest struct {
+	OperationID     string
+	SourceSandboxID string
+	TeamID          string
+	SnapshotID      string
+	CaptureKind     string
+	Name            string
+	Description     string
+	ExpiresAt       time.Time
 }
 
 // NomadTemplateCaptureCandidate authorizes a node checkpoint or returns its
@@ -49,6 +66,11 @@ type NomadTemplateCaptureCandidate struct {
 	SourceWriterEpoch   int64
 	BindingVersion      int
 	BindingDigest       []byte
+	TeamID              string
+	CaptureKind         string
+	Name                string
+	Description         string
+	ExpiresAt           time.Time
 }
 
 type nomadTemplateCaptureIntent struct {
@@ -69,6 +91,10 @@ type nomadTemplateCaptureIntent struct {
 	CheckpointSequence   *int64
 	DescriptorDigest     *string
 	ProofDigest          []byte
+	CaptureKind          string
+	Name                 string
+	Description          string
+	ExpiresAt            time.Time
 }
 
 // NomadTemplateCaptureFilesystemID derives the immutable unbound filesystem
@@ -90,6 +116,24 @@ func NomadTemplateCaptureGenerationID(operationID, snapshotID string) string {
 func (s *PGSandboxStore) RequestNomadRunningTemplateCapture(
 	ctx context.Context,
 	request *NomadTemplateCaptureRequest,
+) (*NomadTemplateCaptureCandidate, error) {
+	if request == nil {
+		return nil, fmt.Errorf("nomad template capture request is required")
+	}
+	return s.RequestNomadRunningRootFSCapture(ctx, &NomadRunningRootFSCaptureRequest{
+		OperationID: request.OperationID, SourceSandboxID: request.SourceSandboxID,
+		TeamID: request.TeamID, SnapshotID: request.SnapshotID,
+		CaptureKind: NomadRunningRootFSCaptureKindTemplate,
+		Name:        "Template RootFS capture",
+		Description: "Internal immutable live-writer checkpoint retained by a template.",
+	})
+}
+
+// RequestNomadRunningRootFSCapture reserves one exact source lifecycle and
+// returns the authoritative writer/node identity for checkpoint dispatch.
+func (s *PGSandboxStore) RequestNomadRunningRootFSCapture(
+	ctx context.Context,
+	request *NomadRunningRootFSCaptureRequest,
 ) (*NomadTemplateCaptureCandidate, error) {
 	normalized, requestDigest, targetFilesystemID, targetGenerationID, err :=
 		normalizeNomadTemplateCaptureRequest(request)
@@ -172,12 +216,15 @@ func (s *PGSandboxStore) RequestNomadRunningTemplateCapture(
 			source_filesystem_id, source_grant_id, source_writer_epoch,
 			source_generation_id, target_filesystem_id, checkpoint_generation_id,
 			request_digest, binding_version, binding_digest, state,
+			capture_kind, snapshot_name, snapshot_description, snapshot_expires_at,
 			created_at, updated_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NOW(), NOW())
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
+			$15, $16, $17, $18, NOW(), NOW())
 	`, normalized.OperationID, normalized.SnapshotID, normalized.TeamID, source.ID,
 		writer.filesystem.ID, writer.grant.ID, writer.grant.WriterEpoch, writer.generation.ID,
 		targetFilesystemID, targetGenerationID, requestDigest,
-		writer.grant.BindingVersion, writer.grant.BindingDigest, nomadTemplateCaptureStatePending); err != nil {
+		writer.grant.BindingVersion, writer.grant.BindingDigest, nomadTemplateCaptureStatePending,
+		normalized.CaptureKind, normalized.Name, normalized.Description, nullableTime(normalized.ExpiresAt)); err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
 			return nil, fmt.Errorf("%w: capture identity is already reserved", ErrNomadTemplateCaptureConflict)
@@ -192,6 +239,8 @@ func (s *PGSandboxStore) RequestNomadRunningTemplateCapture(
 		CheckpointGeneration: targetGenerationID, RequestDigest: append([]byte(nil), requestDigest...),
 		BindingVersion: writer.grant.BindingVersion,
 		BindingDigest:  append([]byte(nil), writer.grant.BindingDigest...), State: nomadTemplateCaptureStatePending,
+		CaptureKind: normalized.CaptureKind, Name: normalized.Name,
+		Description: normalized.Description, ExpiresAt: normalized.ExpiresAt,
 	}
 	candidate := nomadTemplateCaptureCandidate(source, writer, intent)
 	if err := tx.Commit(ctx); err != nil {
@@ -200,9 +249,152 @@ func (s *PGSandboxStore) RequestNomadRunningTemplateCapture(
 	return candidate, nil
 }
 
+// ContinueNomadRunningRootFSCapture reconstructs a pending checkpoint from
+// PostgreSQL so the controller can finish it after an API response or manager
+// process is lost.
+func (s *PGSandboxStore) ContinueNomadRunningRootFSCapture(
+	ctx context.Context,
+	sourceSandboxID string,
+) (*NomadTemplateCaptureCandidate, error) {
+	sourceSandboxID = strings.TrimSpace(sourceSandboxID)
+	if sourceSandboxID == "" {
+		return nil, fmt.Errorf("source_sandbox_id is required")
+	}
+	if s == nil || s.pool == nil {
+		return nil, fmt.Errorf("sandbox store is not configured")
+	}
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("begin Nomad running capture continuation tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	source, err := lockNomadSandboxClaimRecord(ctx, tx, sourceSandboxID)
+	if err != nil {
+		if errors.Is(err, ErrSandboxRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	lifecycle, err := getActiveLifecycleTxn(ctx, tx, sourceSandboxID)
+	if err != nil {
+		return nil, fmt.Errorf("load active Nomad running capture lifecycle: %w", err)
+	}
+	if lifecycle == nil || lifecycle.Kind != SandboxLifecycleKindSnapshot {
+		if err := tx.Commit(ctx); err != nil {
+			return nil, fmt.Errorf("commit absent Nomad running capture continuation: %w", err)
+		}
+		return nil, nil
+	}
+	intent, err := getNomadTemplateCaptureIntentForUpdate(ctx, tx, lifecycle.ID)
+	if err != nil {
+		return nil, err
+	}
+	if intent == nil {
+		return nil, fmt.Errorf("%w: running capture intent is missing", ErrNomadTemplateCaptureConflict)
+	}
+	candidate, err := lockPendingNomadTemplateCapture(ctx, tx, source, intent)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit Nomad running capture continuation: %w", err)
+	}
+	return candidate, nil
+}
+
+// AbortStaleNomadRunningRootFSCapture releases a pending capture only after
+// its exact live writer identity has changed. Publication and abort serialize
+// on the source row, so a committed checkpoint always wins the race.
+func (s *PGSandboxStore) AbortStaleNomadRunningRootFSCapture(
+	ctx context.Context,
+	operationID, sourceSandboxID, reason string,
+) (bool, error) {
+	operationID = strings.TrimSpace(operationID)
+	sourceSandboxID = strings.TrimSpace(sourceSandboxID)
+	reason = strings.TrimSpace(reason)
+	if operationID == "" || sourceSandboxID == "" || reason == "" {
+		return false, fmt.Errorf("operation, source sandbox, and abort reason are required")
+	}
+	if s == nil || s.pool == nil {
+		return false, fmt.Errorf("sandbox store is not configured")
+	}
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return false, fmt.Errorf("begin stale Nomad running capture abort tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	source, err := lockNomadSandboxClaimRecord(ctx, tx, sourceSandboxID)
+	if err != nil {
+		return false, err
+	}
+	intent, err := getNomadTemplateCaptureIntentForUpdate(ctx, tx, operationID)
+	if err != nil {
+		return false, err
+	}
+	if intent == nil || intent.State == nomadTemplateCaptureStatePublished {
+		if err := tx.Commit(ctx); err != nil {
+			return false, fmt.Errorf("commit terminal Nomad running capture abort: %w", err)
+		}
+		return false, nil
+	}
+	if intent.SourceSandboxID != sourceSandboxID {
+		return false, fmt.Errorf("%w: capture source identity changed", ErrNomadTemplateCaptureConflict)
+	}
+	lifecycle, err := scanLifecycleTxn(tx.QueryRow(ctx, lifecycleTxnSelectSQL()+`
+		WHERE txn_id = $1 AND sandbox_id = $2 FOR UPDATE
+	`, operationID, sourceSandboxID))
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return false, fmt.Errorf("lock stale Nomad running capture lifecycle: %w", err)
+	}
+	if lifecycle == nil || lifecycle.Kind != SandboxLifecycleKindSnapshot ||
+		lifecycle.Phase != SandboxLifecyclePhasePublishing ||
+		lifecycle.TargetSandboxID != intent.TargetFilesystemID ||
+		lifecycle.TargetGenerationID != intent.CheckpointGeneration ||
+		!bytes.Equal(lifecycle.TargetRecordDigest, intent.RequestDigest) {
+		return false, fmt.Errorf("%w: pending capture lifecycle changed", ErrNomadTemplateCaptureConflict)
+	}
+	writer, writerErr := lockExactNomadLiveWriter(ctx, tx, source)
+	if writerErr == nil && lifecycle.FromGeneration == source.RuntimeGeneration &&
+		lifecycle.FromRuntimeNamespace == source.RuntimeNamespace && lifecycle.FromRuntimeID == source.RuntimeID &&
+		writer.filesystem.ID == intent.SourceFilesystemID && writer.generation.ID == intent.SourceGenerationID &&
+		writer.grant.ID == intent.SourceGrantID && writer.grant.WriterEpoch == intent.SourceWriterEpoch &&
+		writer.grant.BindingVersion == intent.BindingVersion && bytes.Equal(writer.grant.BindingDigest, intent.BindingDigest) {
+		if err := tx.Commit(ctx); err != nil {
+			return false, fmt.Errorf("commit recoverable Nomad running capture check: %w", err)
+		}
+		return false, nil
+	}
+	tag, err := tx.Exec(ctx, `
+		UPDATE manager.sandbox_lifecycle_txns
+		SET phase = $2, error = $3, aborted_at = NOW(), updated_at = NOW()
+		WHERE txn_id = $1 AND sandbox_id = $4 AND phase = $5
+	`, operationID, SandboxLifecyclePhaseAborted, reason, sourceSandboxID,
+		SandboxLifecyclePhasePublishing)
+	if err != nil {
+		return false, fmt.Errorf("abort stale Nomad running capture lifecycle: %w", err)
+	}
+	if tag.RowsAffected() != 1 {
+		return false, fmt.Errorf("%w: stale capture lifecycle changed", ErrNomadTemplateCaptureConflict)
+	}
+	tag, err = tx.Exec(ctx, `
+		DELETE FROM manager.rootfs_running_template_captures
+		WHERE operation_id = $1 AND state = $2
+	`, operationID, nomadTemplateCaptureStatePending)
+	if err != nil {
+		return false, fmt.Errorf("delete stale Nomad running capture intent: %w", err)
+	}
+	if tag.RowsAffected() != 1 {
+		return false, fmt.Errorf("%w: stale capture intent changed", ErrNomadTemplateCaptureConflict)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return false, fmt.Errorf("commit stale Nomad running capture abort: %w", err)
+	}
+	return true, nil
+}
+
 func normalizeNomadTemplateCaptureRequest(
-	request *NomadTemplateCaptureRequest,
-) (*NomadTemplateCaptureRequest, []byte, string, string, error) {
+	request *NomadRunningRootFSCaptureRequest,
+) (*NomadRunningRootFSCaptureRequest, []byte, string, string, error) {
 	if request == nil {
 		return nil, nil, "", "", fmt.Errorf("nomad template capture request is required")
 	}
@@ -211,6 +403,15 @@ func normalizeNomadTemplateCaptureRequest(
 	normalized.SourceSandboxID = strings.TrimSpace(request.SourceSandboxID)
 	normalized.TeamID = strings.TrimSpace(request.TeamID)
 	normalized.SnapshotID = strings.TrimSpace(request.SnapshotID)
+	normalized.CaptureKind = strings.TrimSpace(request.CaptureKind)
+	normalized.Name = strings.TrimSpace(request.Name)
+	normalized.Description = strings.TrimSpace(request.Description)
+	if !normalized.ExpiresAt.IsZero() {
+		// PostgreSQL timestamps have microsecond precision. Normalize before the
+		// intent comparison so an idempotent retry cannot conflict only because
+		// the original HTTP timestamp carried nanoseconds.
+		normalized.ExpiresAt = normalized.ExpiresAt.UTC().Truncate(time.Microsecond)
+	}
 	for name, value := range map[string]string{
 		"operation_id": normalized.OperationID, "source_sandbox_id": normalized.SourceSandboxID,
 		"team_id": normalized.TeamID, "snapshot_id": normalized.SnapshotID,
@@ -218,6 +419,10 @@ func normalizeNomadTemplateCaptureRequest(
 		if value == "" || strings.TrimSpace(value) != value || len(value) > 512 {
 			return nil, nil, "", "", fmt.Errorf("%s must be canonical and at most 512 bytes", name)
 		}
+	}
+	if normalized.CaptureKind != NomadRunningRootFSCaptureKindTemplate &&
+		normalized.CaptureKind != NomadRunningRootFSCaptureKindSnapshot {
+		return nil, nil, "", "", fmt.Errorf("capture_kind must be template or snapshot")
 	}
 	targetFilesystemID := NomadTemplateCaptureFilesystemID(normalized.OperationID, normalized.SnapshotID)
 	targetGenerationID := NomadTemplateCaptureGenerationID(normalized.OperationID, normalized.SnapshotID)
@@ -235,12 +440,14 @@ func getNomadTemplateCaptureIntentForUpdate(
 	operationID string,
 ) (*nomadTemplateCaptureIntent, error) {
 	var intent nomadTemplateCaptureIntent
+	var expiresAt *time.Time
 	err := tx.QueryRow(ctx, `
 		SELECT operation_id, snapshot_id, team_id, source_sandbox_id,
 			source_filesystem_id, source_grant_id, source_writer_epoch,
 			source_generation_id, target_filesystem_id, checkpoint_generation_id,
 			request_digest, binding_version, binding_digest, state,
-			checkpoint_sequence, checkpoint_descriptor_digest, checkpoint_proof_digest
+			checkpoint_sequence, checkpoint_descriptor_digest, checkpoint_proof_digest,
+			capture_kind, snapshot_name, snapshot_description, snapshot_expires_at
 		FROM manager.rootfs_running_template_captures
 		WHERE operation_id = $1
 		FOR UPDATE
@@ -250,6 +457,7 @@ func getNomadTemplateCaptureIntentForUpdate(
 		&intent.SourceGenerationID, &intent.TargetFilesystemID, &intent.CheckpointGeneration,
 		&intent.RequestDigest, &intent.BindingVersion, &intent.BindingDigest, &intent.State,
 		&intent.CheckpointSequence, &intent.DescriptorDigest, &intent.ProofDigest,
+		&intent.CaptureKind, &intent.Name, &intent.Description, &expiresAt,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
@@ -257,12 +465,13 @@ func getNomadTemplateCaptureIntentForUpdate(
 	if err != nil {
 		return nil, fmt.Errorf("load Nomad template capture intent: %w", err)
 	}
+	intent.ExpiresAt = derefTime(expiresAt)
 	return &intent, nil
 }
 
 func nomadTemplateCaptureIntentMatches(
 	intent *nomadTemplateCaptureIntent,
-	request *NomadTemplateCaptureRequest,
+	request *NomadRunningRootFSCaptureRequest,
 	requestDigest []byte,
 	targetFilesystemID, targetGenerationID string,
 ) bool {
@@ -270,7 +479,9 @@ func nomadTemplateCaptureIntentMatches(
 		intent.SnapshotID == request.SnapshotID && intent.TeamID == request.TeamID &&
 		intent.SourceSandboxID == request.SourceSandboxID &&
 		intent.TargetFilesystemID == targetFilesystemID &&
-		intent.CheckpointGeneration == targetGenerationID && bytes.Equal(intent.RequestDigest, requestDigest)
+		intent.CheckpointGeneration == targetGenerationID && bytes.Equal(intent.RequestDigest, requestDigest) &&
+		intent.CaptureKind == request.CaptureKind && intent.Name == request.Name &&
+		intent.Description == request.Description && intent.ExpiresAt.Equal(request.ExpiresAt)
 }
 
 func lockPendingNomadTemplateCapture(
@@ -311,6 +522,8 @@ func nomadTemplateCaptureCandidate(
 		SourceGenerationID: writer.generation.ID, SourceWriterGrantID: writer.grant.ID,
 		SourceWriterEpoch: writer.grant.WriterEpoch, BindingVersion: writer.grant.BindingVersion,
 		BindingDigest: append([]byte(nil), writer.grant.BindingDigest...),
+		TeamID:        intent.TeamID, CaptureKind: intent.CaptureKind, Name: intent.Name,
+		Description: intent.Description, ExpiresAt: intent.ExpiresAt,
 	}
 }
 
@@ -344,13 +557,16 @@ func loadCompletedNomadTemplateCapture(
 	}
 	if snapshot.FilesystemID != intent.TargetFilesystemID ||
 		snapshot.HeadGenerationID != intent.CheckpointGeneration ||
-		snapshot.SourceSandboxID != intent.SourceSandboxID {
+		snapshot.SourceSandboxID != intent.SourceSandboxID || snapshot.Name != intent.Name ||
+		snapshot.Description != intent.Description || !snapshot.ExpiresAt.Equal(intent.ExpiresAt) {
 		return nil, fmt.Errorf("%w: published snapshot identity changed", ErrNomadTemplateCaptureConflict)
 	}
 	return &NomadTemplateCaptureCandidate{
 		OperationID: intent.OperationID, SnapshotID: intent.SnapshotID,
 		TargetFilesystemID: intent.TargetFilesystemID, TargetGenerationID: intent.CheckpointGeneration,
 		Completed: true, Snapshot: snapshot, Source: source,
+		TeamID: intent.TeamID, CaptureKind: intent.CaptureKind, Name: intent.Name,
+		Description: intent.Description, ExpiresAt: intent.ExpiresAt,
 	}, nil
 }
 

--- a/manager/pkg/sandboxstore/nomad_template_capture_integration_test.go
+++ b/manager/pkg/sandboxstore/nomad_template_capture_integration_test.go
@@ -144,6 +144,166 @@ func TestNomadRunningTemplateCaptureCancellationWinsPublicationRaceIntegration(t
 	require.Nil(t, filesystem)
 }
 
+func TestNomadRunningRootFSSnapshotPublishesMetadataAndReleasesIntegration(t *testing.T) {
+	fixture := newNomadPauseStoreFixture(t, "running-snapshot")
+	source, err := fixture.store.GetSandbox(fixture.ctx, fixture.sandboxID)
+	require.NoError(t, err)
+	expiresAt := time.Now().UTC().Add(24*time.Hour + 789*time.Nanosecond)
+	request := &NomadRunningRootFSCaptureRequest{
+		OperationID: "running-snapshot-operation", SourceSandboxID: source.ID,
+		TeamID: source.TeamID, SnapshotID: "rootfs-snapshot-running-operation",
+		CaptureKind: NomadRunningRootFSCaptureKindSnapshot,
+		Name:        "release checkpoint", Description: "before migration", ExpiresAt: expiresAt,
+	}
+	candidate, err := fixture.store.RequestNomadRunningRootFSCapture(fixture.ctx, request)
+	require.NoError(t, err)
+	require.False(t, candidate.Completed)
+	require.Equal(t, request.Name, candidate.Name)
+	require.Equal(t, request.Description, candidate.Description)
+	require.True(t, candidate.ExpiresAt.Equal(expiresAt.UTC().Truncate(time.Microsecond)))
+
+	continued, err := fixture.store.ContinueNomadRunningRootFSCapture(fixture.ctx, source.ID)
+	require.NoError(t, err)
+	require.Equal(t, candidate.OperationID, continued.OperationID)
+	require.Equal(t, candidate.SourceWriterGrantID, continued.SourceWriterGrantID)
+
+	changed := *request
+	changed.Name = "changed metadata"
+	_, err = fixture.store.RequestNomadRunningRootFSCapture(fixture.ctx, &changed)
+	require.ErrorIs(t, err, ErrNomadTemplateCaptureConflict)
+
+	publication := nomadTemplateCaptureCheckpointRequest(t, fixture, source, candidate)
+	_, err = fixture.store.ForkRunningRootFSFilesystem(fixture.ctx, publication)
+	require.NoError(t, err)
+	completed, err := fixture.store.RequestNomadRunningRootFSCapture(fixture.ctx, request)
+	require.NoError(t, err)
+	require.True(t, completed.Completed)
+	require.NotNil(t, completed.Snapshot)
+	require.Equal(t, request.Name, completed.Snapshot.Name)
+	require.Equal(t, request.Description, completed.Snapshot.Description)
+	require.True(t, completed.Snapshot.ExpiresAt.Equal(candidate.ExpiresAt))
+
+	// An old manager replica can receive the callback during a rolling
+	// upgrade. Its legacy INSERT supplies template metadata; the migration
+	// trigger must still publish the authoritative public snapshot metadata.
+	_, err = fixture.store.pool.Exec(fixture.ctx, `
+		DELETE FROM manager.rootfs_snapshots WHERE snapshot_id = $1
+	`, request.SnapshotID)
+	require.NoError(t, err)
+	_, err = fixture.store.pool.Exec(fixture.ctx, `
+		INSERT INTO manager.rootfs_snapshots (
+			snapshot_id, filesystem_id, team_id, source_sandbox_id,
+			head_generation_id, name, description, created_at, expires_at
+		) VALUES ($1, $2, $3, $4, $5,
+			'Template RootFS capture',
+			'Internal immutable live-writer checkpoint retained by a template.',
+			NOW(), NULL)
+	`, request.SnapshotID, candidate.TargetFilesystemID, request.TeamID,
+		source.ID, candidate.TargetGenerationID)
+	require.NoError(t, err)
+	rollingSnapshot, err := fixture.store.GetRootFSSnapshot(
+		fixture.ctx, request.SnapshotID, request.TeamID,
+	)
+	require.NoError(t, err)
+	require.Equal(t, request.Name, rollingSnapshot.Name)
+	require.Equal(t, request.Description, rollingSnapshot.Description)
+	require.True(t, rollingSnapshot.ExpiresAt.Equal(candidate.ExpiresAt))
+
+	loadedSource, err := fixture.store.GetSandbox(fixture.ctx, source.ID)
+	require.NoError(t, err)
+	require.Equal(t, SandboxDesiredStateActive, loadedSource.DesiredState)
+	require.Equal(t, source.RuntimeID, loadedSource.RuntimeID)
+
+	require.NoError(t, fixture.store.DeleteRootFSSnapshot(
+		fixture.ctx, request.SnapshotID, request.TeamID,
+	))
+	var cancelReason string
+	require.NoError(t, fixture.store.pool.QueryRow(fixture.ctx, `
+		SELECT cancel_reason FROM manager.rootfs_running_template_captures
+		WHERE operation_id = $1
+	`, request.OperationID).Scan(&cancelReason))
+	require.Equal(t, "snapshot deleted", cancelReason)
+	deleted, err := fixture.store.DeleteReleasedNomadRunningRootFSCaptures(
+		fixture.ctx, request.TeamID, 10,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, deleted)
+}
+
+func TestNomadRunningRootFSSnapshotExpirationReleasesCaptureIntegration(t *testing.T) {
+	fixture := newNomadPauseStoreFixture(t, "running-snapshot-expiry")
+	source, err := fixture.store.GetSandbox(fixture.ctx, fixture.sandboxID)
+	require.NoError(t, err)
+	request := &NomadRunningRootFSCaptureRequest{
+		OperationID: "running-snapshot-expiry-operation", SourceSandboxID: source.ID,
+		TeamID: source.TeamID, SnapshotID: "rootfs-snapshot-expiry-operation",
+		CaptureKind: NomadRunningRootFSCaptureKindSnapshot,
+		Name:        "short checkpoint", ExpiresAt: time.Now().UTC().Add(-time.Minute),
+	}
+	candidate, err := fixture.store.RequestNomadRunningRootFSCapture(fixture.ctx, request)
+	require.NoError(t, err)
+	publication := nomadTemplateCaptureCheckpointRequest(t, fixture, source, candidate)
+	_, err = fixture.store.ForkRunningRootFSFilesystem(fixture.ctx, publication)
+	require.NoError(t, err)
+
+	deleted, err := fixture.store.DeleteExpiredRootFSSnapshots(fixture.ctx, request.TeamID, 10)
+	require.NoError(t, err)
+	require.Equal(t, 1, deleted)
+	var cancelReason string
+	require.NoError(t, fixture.store.pool.QueryRow(fixture.ctx, `
+		SELECT cancel_reason FROM manager.rootfs_running_template_captures
+		WHERE operation_id = $1
+	`, request.OperationID).Scan(&cancelReason))
+	require.Equal(t, "snapshot expired", cancelReason)
+	deleted, err = fixture.store.DeleteReleasedNomadRunningRootFSCaptures(
+		fixture.ctx, request.TeamID, 10,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, deleted)
+}
+
+func TestAbortStaleNomadRunningRootFSCaptureRequiresLostWriterIntegration(t *testing.T) {
+	fixture := newNomadPauseStoreFixture(t, "running-snapshot-abort")
+	source, err := fixture.store.GetSandbox(fixture.ctx, fixture.sandboxID)
+	require.NoError(t, err)
+	request := &NomadRunningRootFSCaptureRequest{
+		OperationID: "running-snapshot-abort-operation", SourceSandboxID: source.ID,
+		TeamID: source.TeamID, SnapshotID: "rootfs-snapshot-abort-operation",
+		CaptureKind: NomadRunningRootFSCaptureKindSnapshot, Name: "checkpoint",
+	}
+	candidate, err := fixture.store.RequestNomadRunningRootFSCapture(fixture.ctx, request)
+	require.NoError(t, err)
+	publication := nomadTemplateCaptureCheckpointRequest(t, fixture, source, candidate)
+
+	aborted, err := fixture.store.AbortStaleNomadRunningRootFSCapture(
+		fixture.ctx, request.OperationID, source.ID, "lost exact writer",
+	)
+	require.NoError(t, err)
+	require.False(t, aborted, "a still-bound exact writer remains recoverable")
+
+	_, err = fixture.pool.Exec(fixture.ctx, `
+		UPDATE manager.sandboxes SET runtime_id = 'replacement-allocation'
+		WHERE sandbox_id = $1
+	`, source.ID)
+	require.NoError(t, err)
+	aborted, err = fixture.store.AbortStaleNomadRunningRootFSCapture(
+		fixture.ctx, request.OperationID, source.ID, "lost exact writer",
+	)
+	require.NoError(t, err)
+	require.True(t, aborted)
+	active, err := fixture.store.GetActiveLifecycleTxn(fixture.ctx, source.ID)
+	require.NoError(t, err)
+	require.Nil(t, active)
+	var phase string
+	require.NoError(t, fixture.store.pool.QueryRow(fixture.ctx, `
+		SELECT phase FROM manager.sandbox_lifecycle_txns WHERE txn_id = $1
+	`, request.OperationID).Scan(&phase))
+	require.Equal(t, SandboxLifecyclePhaseAborted, phase)
+
+	_, err = fixture.store.ForkRunningRootFSFilesystem(fixture.ctx, publication)
+	require.Error(t, err, "a late writer callback must lose after the abort commit")
+}
+
 func nomadTemplateCaptureCheckpointRequest(
 	t *testing.T,
 	fixture *nomadPauseStoreFixture,

--- a/manager/pkg/sandboxstore/rootfs.go
+++ b/manager/pkg/sandboxstore/rootfs.go
@@ -72,11 +72,12 @@ type ForkRootFSFilesystemRequest struct {
 }
 
 type RestoreRootFSFromSnapshotRequest struct {
-	SandboxID         string
-	SnapshotID        string
-	TeamID            string
-	OperationID       string
-	RollbackExpiresAt time.Time
+	SandboxID               string
+	SnapshotID              string
+	TeamID                  string
+	OperationID             string
+	InitialClaimOperationID string
+	RollbackExpiresAt       time.Time
 }
 
 // RootFSHeadRollback retains the old immutable generation for a bounded
@@ -509,8 +510,8 @@ func (t sandboxStoreTx) RestoreRootFSFromSnapshot(ctx context.Context, req *Rest
 	return filesystem, err
 }
 
-func restoreRootFSFromSnapshot(ctx context.Context, db rootFSStoreDB, req *RestoreRootFSFromSnapshotRequest) (*RootFSFilesystem, error) {
-	if db == nil || req == nil {
+func restoreRootFSFromSnapshot(ctx context.Context, tx pgx.Tx, req *RestoreRootFSFromSnapshotRequest) (*RootFSFilesystem, error) {
+	if tx == nil || req == nil {
 		return nil, nil
 	}
 	sandboxID := strings.TrimSpace(req.SandboxID)
@@ -518,11 +519,23 @@ func restoreRootFSFromSnapshot(ctx context.Context, db rootFSStoreDB, req *Resto
 	if sandboxID == "" || snapshotID == "" {
 		return nil, fmt.Errorf("sandbox_id and snapshot_id are required")
 	}
-	filesystem, err := scanRootFSFilesystem(db.QueryRow(ctx, `
+	teamID := strings.TrimSpace(req.TeamID)
+	initialClaimOperationID := strings.TrimSpace(req.InitialClaimOperationID)
+	var targetFilesystemID, targetTeamID, snapshotFilesystemID, previousGenerationID string
+	var targetWriterEpoch int64
+	var targetExists bool
+	var snapshotGeneration RootFSGeneration
+	var snapshotParentGenerationID *string
+	err := tx.QueryRow(ctx, `
 		WITH snapshot AS (
-			SELECT snapshot.snapshot_id, snapshot.filesystem_id, snapshot.team_id,
-				snapshot.head_generation_id, generation.base_artifact_digest,
-				generation.format_generation, generation.writer_epoch
+			SELECT snapshot.filesystem_id AS snapshot_filesystem_id,
+				snapshot.team_id AS snapshot_team_id,
+				generation.generation_id, generation.filesystem_id,
+				generation.parent_generation_id, generation.source_oci_digest,
+				generation.base_artifact_digest, generation.base_block_root,
+				generation.current_block_head, generation.writer_epoch,
+				generation.format_generation, generation.durability_state,
+				generation.locator_version, generation.descriptor, generation.created_at
 			FROM manager.rootfs_snapshots snapshot
 			JOIN manager.rootfs_generations generation
 				ON generation.generation_id = snapshot.head_generation_id
@@ -534,8 +547,22 @@ func restoreRootFSFromSnapshot(ctx context.Context, db rootFSStoreDB, req *Resto
 		target AS (
 			SELECT sandbox_id, team_id
 			FROM manager.sandboxes
-			WHERE sandbox_id = $1 AND desired_state = 'paused' AND deleted_at IS NULL
+			WHERE sandbox_id = $1 AND deleted_at IS NULL
 				AND ($3 = '' OR team_id = $3)
+				AND (
+					desired_state = 'paused'
+					OR (
+						$4 <> '' AND desired_state = 'active' AND runtime_id = ''
+						AND EXISTS (
+							SELECT 1
+							FROM manager.sandbox_runtime_claims claim
+							WHERE claim.sandbox_id = $1
+								AND claim.operation_id = $4
+								AND claim.phase = 'claiming'
+								AND claim.lease_expires_at > NOW()
+						)
+					)
+				)
 		),
 		binding AS (
 			SELECT filesystem_id FROM manager.sandbox_rootfs_bindings WHERE sandbox_id = $1
@@ -544,53 +571,162 @@ func restoreRootFSFromSnapshot(ctx context.Context, db rootFSStoreDB, req *Resto
 				SELECT 1 FROM manager.sandbox_rootfs_bindings WHERE sandbox_id = $1
 			)
 			LIMIT 1
-		),
-		previous AS (
-			SELECT filesystem.filesystem_id, filesystem.head_generation_id
-			FROM binding
-			JOIN manager.rootfs_filesystems filesystem
-				ON filesystem.filesystem_id = binding.filesystem_id
-		),
-		restored AS (
-			INSERT INTO manager.rootfs_filesystems (
-				filesystem_id, team_id, source_filesystem_id, head_generation_id,
-				writer_epoch, base_artifact_digest, format_generation,
-				created_at, updated_at
+		)
+		SELECT snapshot.generation_id, snapshot.filesystem_id,
+			snapshot.parent_generation_id, snapshot.source_oci_digest,
+			snapshot.base_artifact_digest, snapshot.base_block_root,
+			snapshot.current_block_head, snapshot.writer_epoch,
+			snapshot.format_generation, snapshot.durability_state,
+			snapshot.locator_version, snapshot.descriptor, snapshot.created_at,
+			binding.filesystem_id, target.team_id, snapshot.snapshot_filesystem_id,
+			COALESCE(filesystem.writer_epoch, snapshot.writer_epoch),
+			COALESCE(filesystem.head_generation_id, ''),
+			filesystem.filesystem_id IS NOT NULL
+		FROM snapshot CROSS JOIN target CROSS JOIN binding
+		LEFT JOIN manager.rootfs_filesystems filesystem
+			ON filesystem.filesystem_id = binding.filesystem_id
+		WHERE snapshot.snapshot_team_id = target.team_id
+			AND (filesystem.filesystem_id IS NULL OR filesystem.team_id = target.team_id)
+			AND NOT EXISTS (
+				SELECT 1 FROM manager.rootfs_writer_grants writer
+				WHERE writer.filesystem_id = binding.filesystem_id
+					AND writer.state IN ('issued', 'consumed', 'retiring')
 			)
-			SELECT binding.filesystem_id, target.team_id, snapshot.filesystem_id,
-				snapshot.head_generation_id, snapshot.writer_epoch,
-				snapshot.base_artifact_digest, snapshot.format_generation,
-				NOW(), NOW()
-			FROM snapshot CROSS JOIN target CROSS JOIN binding
-			WHERE snapshot.team_id = target.team_id
+			AND NOT EXISTS (
+				SELECT 1 FROM manager.sandbox_lifecycle_txns lifecycle
+				WHERE lifecycle.sandbox_id = target.sandbox_id
+					AND lifecycle.phase NOT IN ('committed', 'aborted')
+			)
+	`, sandboxID, snapshotID, teamID, initialClaimOperationID).Scan(
+		&snapshotGeneration.ID, &snapshotGeneration.FilesystemID,
+		&snapshotParentGenerationID, &snapshotGeneration.SourceOCIDigest,
+		&snapshotGeneration.BaseArtifactDigest, &snapshotGeneration.BaseBlockRoot,
+		&snapshotGeneration.CurrentBlockHead, &snapshotGeneration.WriterEpoch,
+		&snapshotGeneration.FormatGeneration, &snapshotGeneration.DurabilityState,
+		&snapshotGeneration.LocatorVersion, &snapshotGeneration.Descriptor,
+		&snapshotGeneration.CreatedAt,
+		&targetFilesystemID, &targetTeamID, &snapshotFilesystemID,
+		&targetWriterEpoch, &previousGenerationID, &targetExists,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("restore rootfs filesystem from snapshot: %w", err)
+	}
+	if snapshotParentGenerationID != nil {
+		snapshotGeneration.ParentGenerationID = *snapshotParentGenerationID
+	}
+	snapshotGeneration.Descriptor = append([]byte(nil), snapshotGeneration.Descriptor...)
+
+	selectedGeneration := &snapshotGeneration
+	cloneGeneration := targetFilesystemID != snapshotFilesystemID
+	if cloneGeneration && previousGenerationID != "" {
+		previousGeneration, loadErr := scanRootFSGeneration(tx.QueryRow(ctx, rootFSGenerationSelectSQL()+`
+			WHERE generation_id = $1
+		`, previousGenerationID))
+		if loadErr != nil {
+			return nil, fmt.Errorf("load restore target rootfs generation: %w", loadErr)
+		}
+		if previousGeneration.FilesystemID == targetFilesystemID &&
+			rootFSGenerationRestoreContentEqual(previousGeneration, &snapshotGeneration) {
+			selectedGeneration = previousGeneration
+			cloneGeneration = false
+		}
+	}
+
+	newWriterEpoch := targetWriterEpoch
+	if cloneGeneration {
+		if targetExists && previousGenerationID != "" {
+			if targetWriterEpoch == int64(^uint64(0)>>1) {
+				return nil, fmt.Errorf("%w: target writer epoch is exhausted", ErrRootFSFilesystemConflict)
+			}
+			newWriterEpoch++
+		}
+		selectedGeneration = &RootFSGeneration{
+			ID:           restoredRootFSGenerationID(targetFilesystemID, snapshotGeneration.ID, newWriterEpoch),
+			FilesystemID: targetFilesystemID, ParentGenerationID: snapshotGeneration.ID,
+			SourceOCIDigest:    snapshotGeneration.SourceOCIDigest,
+			BaseArtifactDigest: snapshotGeneration.BaseArtifactDigest,
+			BaseBlockRoot:      snapshotGeneration.BaseBlockRoot, CurrentBlockHead: snapshotGeneration.CurrentBlockHead,
+			WriterEpoch: newWriterEpoch, FormatGeneration: snapshotGeneration.FormatGeneration,
+			DurabilityState: snapshotGeneration.DurabilityState, LocatorVersion: snapshotGeneration.LocatorVersion,
+			Descriptor: append([]byte(nil), snapshotGeneration.Descriptor...),
+		}
+	}
+
+	sourceFilesystemID := snapshotFilesystemID
+	if sourceFilesystemID == targetFilesystemID {
+		sourceFilesystemID = ""
+	}
+	var ensuredFilesystemID string
+	err = tx.QueryRow(ctx, `
+		INSERT INTO manager.rootfs_filesystems (
+			filesystem_id, team_id, source_filesystem_id, head_generation_id,
+			writer_epoch, base_artifact_digest, format_generation, created_at, updated_at
+		) VALUES ($1, $2, NULLIF($3, ''), NULL, $4, $5, $6, NOW(), NOW())
+		ON CONFLICT (filesystem_id) DO UPDATE SET
+			source_filesystem_id = COALESCE(
+				manager.rootfs_filesystems.source_filesystem_id,
+				EXCLUDED.source_filesystem_id
+			),
+			writer_epoch = EXCLUDED.writer_epoch,
+			base_artifact_digest = EXCLUDED.base_artifact_digest,
+			format_generation = EXCLUDED.format_generation,
+			updated_at = NOW()
+		WHERE manager.rootfs_filesystems.team_id = EXCLUDED.team_id
+			AND manager.rootfs_filesystems.writer_epoch = $7
+			AND COALESCE(manager.rootfs_filesystems.head_generation_id, '') = $8
+		RETURNING filesystem_id
+	`, targetFilesystemID, targetTeamID, sourceFilesystemID, newWriterEpoch,
+		snapshotGeneration.BaseArtifactDigest, snapshotGeneration.FormatGeneration,
+		targetWriterEpoch, previousGenerationID).Scan(&ensuredFilesystemID)
+	if err != nil {
+		return nil, fmt.Errorf("prepare rootfs snapshot restore target: %w", err)
+	}
+	if ensuredFilesystemID != targetFilesystemID {
+		return nil, fmt.Errorf("%w: restore target filesystem changed", ErrRootFSFilesystemConflict)
+	}
+
+	if cloneGeneration {
+		if err := insertPreparedRootFSGeneration(ctx, tx, selectedGeneration); err != nil {
+			return nil, fmt.Errorf("clone rootfs snapshot generation: %w", err)
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO manager.rootfs_generation_materialization_objects (
+				generation_id, locator_version, object_key, created_at
+			)
+			SELECT $1, locator_version, object_key, NOW()
+			FROM manager.rootfs_generation_materialization_objects
+			WHERE generation_id = $2
+			ON CONFLICT (generation_id, locator_version, object_key) DO NOTHING
+		`, selectedGeneration.ID, snapshotGeneration.ID); err != nil {
+			return nil, fmt.Errorf("clone rootfs snapshot materialization objects: %w", err)
+		}
+	}
+
+	operationID := strings.TrimSpace(req.OperationID)
+	filesystem, err := scanRootFSFilesystem(tx.QueryRow(ctx, `
+		WITH restored AS (
+			UPDATE manager.rootfs_filesystems filesystem
+			SET head_generation_id = $2, updated_at = NOW()
+			WHERE filesystem.filesystem_id = $1 AND filesystem.team_id = $3
+				AND filesystem.writer_epoch = $4
+				AND COALESCE(filesystem.head_generation_id, '') = $5
 				AND NOT EXISTS (
 					SELECT 1 FROM manager.rootfs_writer_grants writer
-					WHERE writer.filesystem_id = binding.filesystem_id
+					WHERE writer.filesystem_id = filesystem.filesystem_id
 						AND writer.state IN ('issued', 'consumed', 'retiring')
 				)
 				AND NOT EXISTS (
 					SELECT 1 FROM manager.sandbox_lifecycle_txns lifecycle
-					WHERE lifecycle.sandbox_id = target.sandbox_id
+					WHERE lifecycle.sandbox_id = $6
 						AND lifecycle.phase NOT IN ('committed', 'aborted')
 				)
-			ON CONFLICT (filesystem_id) DO UPDATE SET
-				team_id = EXCLUDED.team_id,
-				source_filesystem_id = COALESCE(
-					manager.rootfs_filesystems.source_filesystem_id,
-					EXCLUDED.source_filesystem_id
-				),
-				head_generation_id = EXCLUDED.head_generation_id,
-				base_artifact_digest = EXCLUDED.base_artifact_digest,
-				format_generation = EXCLUDED.format_generation,
-				updated_at = NOW()
-			WHERE manager.rootfs_filesystems.team_id = EXCLUDED.team_id
 			RETURNING *
 		),
 		bound AS (
 			INSERT INTO manager.sandbox_rootfs_bindings (
 				sandbox_id, filesystem_id, team_id, created_at, updated_at
 			)
-			SELECT $1, filesystem_id, team_id, NOW(), NOW() FROM restored
+			SELECT $6, filesystem_id, team_id, NOW(), NOW() FROM restored
 			ON CONFLICT (sandbox_id) DO UPDATE SET team_id = EXCLUDED.team_id
 			WHERE manager.sandbox_rootfs_bindings.filesystem_id = EXCLUDED.filesystem_id
 			RETURNING filesystem_id
@@ -600,12 +736,10 @@ func restoreRootFSFromSnapshot(ctx context.Context, db rootFSStoreDB, req *Resto
 				operation_id, filesystem_id, sandbox_id, team_id, operation_kind,
 				old_generation_id, new_generation_id, state, created_at, expires_at
 			)
-			SELECT $4, restored.filesystem_id, $1, restored.team_id, 'restore',
-				previous.head_generation_id, restored.head_generation_id,
-				'available', NOW(), $5
-			FROM restored JOIN previous USING (filesystem_id)
-			WHERE $4 <> '' AND previous.head_generation_id IS NOT NULL
-				AND previous.head_generation_id <> restored.head_generation_id
+			SELECT $7, restored.filesystem_id, $6, restored.team_id, 'restore',
+				$5, restored.head_generation_id, 'available', NOW(), $8
+			FROM restored
+			WHERE $7 <> '' AND $5 <> '' AND $5 <> restored.head_generation_id
 			ON CONFLICT (operation_id) DO UPDATE SET operation_id = EXCLUDED.operation_id
 			WHERE manager.rootfs_head_rollbacks.filesystem_id = EXCLUDED.filesystem_id
 				AND manager.rootfs_head_rollbacks.sandbox_id = EXCLUDED.sandbox_id
@@ -627,16 +761,23 @@ func restoreRootFSFromSnapshot(ctx context.Context, db rootFSStoreDB, req *Resto
 			ON generation.generation_id = restored.head_generation_id
 		JOIN manager.rootfs_base_artifacts artifact
 			ON artifact.artifact_digest = restored.base_artifact_digest
-		LEFT JOIN previous ON previous.filesystem_id = restored.filesystem_id
-		LEFT JOIN rollback_pin ON rollback_pin.operation_id = $4
-		WHERE $4 = '' OR previous.head_generation_id IS NULL
-			OR previous.head_generation_id = restored.head_generation_id
-			OR rollback_pin.operation_id = $4
-	`, sandboxID, snapshotID, strings.TrimSpace(req.TeamID), strings.TrimSpace(req.OperationID), nullableTime(req.RollbackExpiresAt)))
+		LEFT JOIN rollback_pin ON rollback_pin.operation_id = $7
+		WHERE $7 = '' OR $5 = '' OR $5 = restored.head_generation_id
+			OR rollback_pin.operation_id = $7
+	`, targetFilesystemID, selectedGeneration.ID, targetTeamID, newWriterEpoch,
+		previousGenerationID, sandboxID, operationID, nullableTime(req.RollbackExpiresAt)))
 	if err != nil {
-		return nil, fmt.Errorf("restore rootfs filesystem from snapshot: %w", err)
+		return nil, fmt.Errorf("publish rootfs snapshot restore: %w", err)
 	}
 	return filesystem, nil
+}
+
+func rootFSGenerationRestoreContentEqual(left, right *RootFSGeneration) bool {
+	return left != nil && right != nil && left.SourceOCIDigest == right.SourceOCIDigest &&
+		left.BaseArtifactDigest == right.BaseArtifactDigest && left.BaseBlockRoot == right.BaseBlockRoot &&
+		left.CurrentBlockHead == right.CurrentBlockHead && left.FormatGeneration == right.FormatGeneration &&
+		left.DurabilityState == right.DurabilityState && left.LocatorVersion == right.LocatorVersion &&
+		reflect.DeepEqual(left.Descriptor, right.Descriptor)
 }
 
 // RollbackRootFSHead atomically restores a retained generation. The sandbox

--- a/manager/pkg/sandboxstore/rootfs.go
+++ b/manager/pkg/sandboxstore/rootfs.go
@@ -340,7 +340,12 @@ func (s *PGSandboxStore) DeleteRootFSSnapshot(ctx context.Context, snapshotID, t
 	if s == nil || s.pool == nil {
 		return nil
 	}
-	tag, err := s.pool.Exec(ctx, `
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin rootfs snapshot deletion: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	tag, err := tx.Exec(ctx, `
 		DELETE FROM manager.rootfs_snapshots
 		WHERE snapshot_id = $1 AND ($2 = '' OR team_id = $2)
 	`, strings.TrimSpace(snapshotID), strings.TrimSpace(teamID))
@@ -349,6 +354,17 @@ func (s *PGSandboxStore) DeleteRootFSSnapshot(ctx context.Context, snapshotID, t
 	}
 	if tag.RowsAffected() == 0 {
 		return fmt.Errorf("%w: %s", ErrRootFSSnapshotNotFound, snapshotID)
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE manager.rootfs_running_template_captures
+		SET cancel_reason = 'snapshot deleted', updated_at = NOW()
+		WHERE snapshot_id = $1 AND ($2 = '' OR team_id = $2)
+			AND state = 'published' AND cancel_reason = ''
+	`, strings.TrimSpace(snapshotID), strings.TrimSpace(teamID)); err != nil {
+		return fmt.Errorf("release running rootfs snapshot capture: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit rootfs snapshot deletion: %w", err)
 	}
 	return nil
 }
@@ -728,7 +744,7 @@ func (s *PGSandboxStore) GarbageCollectRootFSFilesystemWithOptions(ctx context.C
 	if _, err := s.deleteTerminalRootFSHeadRollbacks(ctx, teamID, limit); err != nil {
 		return nil, err
 	}
-	deletedTemplateCaptures, err := s.DeleteReleasedNomadTemplateCaptures(ctx, teamID, limit)
+	deletedRunningCaptures, err := s.DeleteReleasedNomadRunningRootFSCaptures(ctx, teamID, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -741,7 +757,7 @@ func (s *PGSandboxStore) GarbageCollectRootFSFilesystemWithOptions(ctx context.C
 	result := &RootFSGarbageCollectionResult{
 		DeletedObjectKeys:  deletedObjectKeys,
 		ExpiredSnapshots:   expiredSnapshots,
-		DeletedFilesystems: deletedTemplateCaptures + deletedFilesystems,
+		DeletedFilesystems: deletedRunningCaptures + deletedFilesystems,
 	}
 	return result, deleteErr
 }
@@ -751,22 +767,33 @@ func (s *PGSandboxStore) DeleteExpiredRootFSSnapshots(ctx context.Context, teamI
 		return 0, nil
 	}
 	limit = normalizeRootFSObjectLimit(limit)
-	tag, err := s.pool.Exec(ctx, `
+	var deleted int
+	err := s.pool.QueryRow(ctx, `
 		WITH expired AS (
 			SELECT snapshot_id FROM manager.rootfs_snapshots
 			WHERE expires_at IS NOT NULL AND expires_at <= NOW()
 				AND ($1 = '' OR team_id = $1)
 			ORDER BY expires_at, snapshot_id
 			LIMIT $2 FOR UPDATE SKIP LOCKED
+		), deleted AS (
+			DELETE FROM manager.rootfs_snapshots snapshot
+			USING expired
+			WHERE snapshot.snapshot_id = expired.snapshot_id
+			RETURNING snapshot.snapshot_id
+		), released AS (
+			UPDATE manager.rootfs_running_template_captures capture
+			SET cancel_reason = 'snapshot expired', updated_at = NOW()
+			FROM deleted
+			WHERE capture.snapshot_id = deleted.snapshot_id
+				AND capture.state = 'published' AND capture.cancel_reason = ''
+			RETURNING capture.operation_id
 		)
-		DELETE FROM manager.rootfs_snapshots snapshot
-		USING expired
-		WHERE snapshot.snapshot_id = expired.snapshot_id
-	`, strings.TrimSpace(teamID), limit)
+		SELECT COUNT(*) FROM deleted
+	`, strings.TrimSpace(teamID), limit).Scan(&deleted)
 	if err != nil {
 		return 0, fmt.Errorf("delete expired rootfs snapshots: %w", err)
 	}
-	return int(tag.RowsAffected()), nil
+	return deleted, nil
 }
 
 func (s *PGSandboxStore) deleteTerminalRootFSHeadRollbacks(ctx context.Context, teamID string, limit int) (int, error) {

--- a/manager/pkg/sandboxstore/running_fork.go
+++ b/manager/pkg/sandboxstore/running_fork.go
@@ -137,7 +137,7 @@ func forkRunningRootFSFilesystem(
 		return nil, err
 	}
 	if intent != nil {
-		return captureRunningRootFSTemplate(ctx, tx, sourceSandbox, intent, req)
+		return captureRunningRootFS(ctx, tx, sourceSandbox, intent, req)
 	}
 	if retry, err := loadRunningRootFSForkRetry(ctx, tx, req); err != nil || retry != nil {
 		return retry, err

--- a/manager/pkg/sandboxstore/running_template_capture.go
+++ b/manager/pkg/sandboxstore/running_template_capture.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sandbox0-ai/sandbox0/pkg/rootfsblock"
 )
 
-func captureRunningRootFSTemplate(
+func captureRunningRootFS(
 	ctx context.Context,
 	tx pgx.Tx,
 	sourceSandbox *SandboxRecord,
@@ -26,22 +26,22 @@ func captureRunningRootFSTemplate(
 		intent.TargetFilesystemID != req.TargetSandboxID ||
 		intent.CheckpointGeneration != req.Generation.ID || req.Generation.FilesystemID != intent.TargetFilesystemID ||
 		intent.BindingVersion != req.BindingVersion || !bytes.Equal(intent.BindingDigest, req.BindingDigest) {
-		return nil, fmt.Errorf("%w: running template checkpoint identity changed", ErrRootFSFilesystemConflict)
+		return nil, fmt.Errorf("%w: running checkpoint identity changed", ErrRootFSFilesystemConflict)
 	}
 	if intent.State == nomadTemplateCaptureStatePublished {
 		return loadRunningRootFSTemplateCaptureRetry(ctx, tx, sourceSandbox, intent, req)
 	}
 	if intent.State != nomadTemplateCaptureStatePending || sourceSandbox.TeamID != intent.TeamID {
-		return nil, fmt.Errorf("%w: template capture intent is not pending", ErrRootFSFilesystemConflict)
+		return nil, fmt.Errorf("%w: running capture intent is not pending", ErrRootFSFilesystemConflict)
 	}
 	lifecycle, err := scanLifecycleTxn(tx.QueryRow(ctx, lifecycleTxnSelectSQL()+`
 		WHERE txn_id = $1 AND sandbox_id = $2 FOR UPDATE
 	`, intent.OperationID, sourceSandbox.ID))
 	if err != nil {
-		return nil, fmt.Errorf("lock running template capture lifecycle: %w", err)
+		return nil, fmt.Errorf("lock running capture lifecycle: %w", err)
 	}
 	if !nomadTemplateCaptureLifecycleMatches(lifecycle, sourceSandbox, intent, false) {
-		return nil, fmt.Errorf("%w: running template capture lifecycle changed", ErrRootFSFilesystemConflict)
+		return nil, fmt.Errorf("%w: running capture lifecycle changed", ErrRootFSFilesystemConflict)
 	}
 	writer, err := lockExactNomadLiveWriter(ctx, tx, sourceSandbox)
 	if err != nil {
@@ -51,7 +51,7 @@ func captureRunningRootFSTemplate(
 		writer.grant.ID != intent.SourceGrantID || writer.grant.WriterEpoch != intent.SourceWriterEpoch ||
 		writer.grant.BindingVersion != intent.BindingVersion ||
 		!bytes.Equal(writer.grant.BindingDigest, intent.BindingDigest) {
-		return nil, fmt.Errorf("%w: source writer changed before template publication", ErrRootFSWriterGrantConflict)
+		return nil, fmt.Errorf("%w: source writer changed before capture publication", ErrRootFSWriterGrantConflict)
 	}
 	checkpoint := req.Generation
 	if req.CheckpointProof.SourceFilesystemID != writer.filesystem.ID ||
@@ -63,11 +63,11 @@ func captureRunningRootFSTemplate(
 	}
 	sourceDescriptor, err := rootfsblock.DecodeDescriptor(writer.generation.Descriptor)
 	if err != nil {
-		return nil, fmt.Errorf("decode template capture source generation: %w", err)
+		return nil, fmt.Errorf("decode running capture source generation: %w", err)
 	}
 	checkpointDescriptor, err := rootfsblock.DecodeDescriptor(checkpoint.Descriptor)
 	if err != nil {
-		return nil, fmt.Errorf("decode template capture checkpoint generation: %w", err)
+		return nil, fmt.Errorf("decode running capture checkpoint generation: %w", err)
 	}
 	if checkpointDescriptor.LogicalSizeBytes != sourceDescriptor.LogicalSizeBytes ||
 		checkpointDescriptor.BlockSizeBytes != sourceDescriptor.BlockSizeBytes {
@@ -84,10 +84,10 @@ func captureRunningRootFSTemplate(
 	`, intent.TargetFilesystemID, intent.TeamID, writer.filesystem.ID, intent.SourceWriterEpoch,
 		writer.filesystem.BaseArtifactDigest, writer.filesystem.FormatGeneration)
 	if err != nil {
-		return nil, fmt.Errorf("create template capture filesystem: %w", err)
+		return nil, fmt.Errorf("create running capture filesystem: %w", err)
 	}
 	if tag.RowsAffected() != 1 {
-		return nil, fmt.Errorf("%w: template capture filesystem already exists", ErrRootFSFilesystemConflict)
+		return nil, fmt.Errorf("%w: running capture filesystem already exists", ErrRootFSFilesystemConflict)
 	}
 	if err := insertPreparedRootFSGeneration(ctx, tx, checkpoint); err != nil {
 		return nil, err
@@ -98,22 +98,20 @@ func captureRunningRootFSTemplate(
 		WHERE filesystem_id = $1 AND head_generation_id IS NULL AND writer_epoch = $3
 	`, intent.TargetFilesystemID, intent.CheckpointGeneration, intent.SourceWriterEpoch)
 	if err != nil {
-		return nil, fmt.Errorf("install template capture checkpoint: %w", err)
+		return nil, fmt.Errorf("install running capture checkpoint: %w", err)
 	}
 	if tag.RowsAffected() != 1 {
-		return nil, fmt.Errorf("%w: template capture filesystem changed", ErrRootFSFilesystemConflict)
+		return nil, fmt.Errorf("%w: running capture filesystem changed", ErrRootFSFilesystemConflict)
 	}
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO manager.rootfs_snapshots (
 			snapshot_id, filesystem_id, team_id, source_sandbox_id,
 			head_generation_id, name, description, created_at, expires_at
-		) VALUES ($1, $2, $3, $4, $5,
-			'Template RootFS capture',
-			'Internal immutable live-writer checkpoint retained by a template.',
-			NOW(), NULL)
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), $8)
 	`, intent.SnapshotID, intent.TargetFilesystemID, intent.TeamID,
-		intent.SourceSandboxID, intent.CheckpointGeneration); err != nil {
-		return nil, fmt.Errorf("create running template snapshot: %w", err)
+		intent.SourceSandboxID, intent.CheckpointGeneration,
+		intent.Name, intent.Description, nullableTime(intent.ExpiresAt)); err != nil {
+		return nil, fmt.Errorf("create running snapshot: %w", err)
 	}
 	proofDigest := append([]byte(nil), req.CheckpointProofDigest...)
 	tag, err = tx.Exec(ctx, `
@@ -129,10 +127,10 @@ func captureRunningRootFSTemplate(
 		int64(req.CheckpointProof.CheckpointSequence), req.CheckpointProof.CheckpointDescriptorDigest,
 		proofDigest, nomadTemplateCaptureStatePending)
 	if err != nil {
-		return nil, fmt.Errorf("publish running template capture intent: %w", err)
+		return nil, fmt.Errorf("publish running capture intent: %w", err)
 	}
 	if tag.RowsAffected() != 1 {
-		return nil, fmt.Errorf("%w: template capture intent changed", ErrRootFSFilesystemConflict)
+		return nil, fmt.Errorf("%w: running capture intent changed", ErrRootFSFilesystemConflict)
 	}
 	if err := (sandboxStoreTx{tx: tx}).CommitLifecycleTxn(
 		ctx, intent.OperationID, intent.CheckpointGeneration,

--- a/manager/pkg/sandboxstore/template_capture_gc.go
+++ b/manager/pkg/sandboxstore/template_capture_gc.go
@@ -8,11 +8,19 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-// DeleteReleasedNomadTemplateCaptures removes unbound capture filesystems only
-// after their template snapshot and every derived sandbox filesystem are gone.
-// This keeps template deletion asynchronous without leaking generation or
-// materialization metadata.
+// DeleteReleasedNomadTemplateCaptures is the compatibility name for running
+// capture GC introduced with template builds.
 func (s *PGSandboxStore) DeleteReleasedNomadTemplateCaptures(
+	ctx context.Context,
+	teamID string,
+	limit int,
+) (int, error) {
+	return s.DeleteReleasedNomadRunningRootFSCaptures(ctx, teamID, limit)
+}
+
+// DeleteReleasedNomadRunningRootFSCaptures removes an unbound checkpoint
+// filesystem only after its snapshot and every derived filesystem are gone.
+func (s *PGSandboxStore) DeleteReleasedNomadRunningRootFSCaptures(
 	ctx context.Context,
 	teamID string,
 	limit int,
@@ -28,7 +36,7 @@ func (s *PGSandboxStore) DeleteReleasedNomadTemplateCaptures(
 	}
 	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
-		return 0, fmt.Errorf("begin released template capture GC tx: %w", err)
+		return 0, fmt.Errorf("begin released running rootfs capture GC tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 	rows, err := tx.Query(ctx, `
@@ -89,7 +97,7 @@ func (s *PGSandboxStore) DeleteReleasedNomadTemplateCaptures(
 		FOR UPDATE OF c, f, generation SKIP LOCKED
 	`, strings.TrimSpace(teamID), limit)
 	if err != nil {
-		return 0, fmt.Errorf("list released template captures: %w", err)
+		return 0, fmt.Errorf("list released running rootfs captures: %w", err)
 	}
 	type candidate struct{ operationID, filesystemID, teamID string }
 	var candidates []candidate
@@ -116,7 +124,7 @@ func (s *PGSandboxStore) DeleteReleasedNomadTemplateCaptures(
 			ORDER BY object_key
 		`, item.filesystemID)
 		if err != nil {
-			return 0, fmt.Errorf("list released template capture objects: %w", err)
+			return 0, fmt.Errorf("list released running rootfs capture objects: %w", err)
 		}
 		var objectKeys []string
 		for objectRows.Next() {
@@ -136,12 +144,12 @@ func (s *PGSandboxStore) DeleteReleasedNomadTemplateCaptures(
 			UPDATE manager.rootfs_filesystems SET head_generation_id = NULL, updated_at = NOW()
 			WHERE filesystem_id = $1
 		`, item.filesystemID); err != nil {
-			return 0, fmt.Errorf("clear released template capture head: %w", err)
+			return 0, fmt.Errorf("clear released running rootfs capture head: %w", err)
 		}
 		if _, err := tx.Exec(ctx, `
 			DELETE FROM manager.rootfs_generations WHERE filesystem_id = $1
 		`, item.filesystemID); err != nil {
-			return 0, fmt.Errorf("delete released template capture generations: %w", err)
+			return 0, fmt.Errorf("delete released running rootfs capture generations: %w", err)
 		}
 		for _, objectKey := range objectKeys {
 			if _, err := releaseUnreferencedRootFSMaterializationObject(ctx, tx, objectKey, item.teamID); err != nil {
@@ -151,16 +159,16 @@ func (s *PGSandboxStore) DeleteReleasedNomadTemplateCaptures(
 		if _, err := tx.Exec(ctx, `
 			DELETE FROM manager.rootfs_running_template_captures WHERE operation_id = $1
 		`, item.operationID); err != nil {
-			return 0, fmt.Errorf("delete released template capture audit: %w", err)
+			return 0, fmt.Errorf("delete released running rootfs capture audit: %w", err)
 		}
 		if _, err := tx.Exec(ctx, `
 			DELETE FROM manager.rootfs_filesystems WHERE filesystem_id = $1
 		`, item.filesystemID); err != nil {
-			return 0, fmt.Errorf("delete released template capture filesystem: %w", err)
+			return 0, fmt.Errorf("delete released running rootfs capture filesystem: %w", err)
 		}
 	}
 	if err := tx.Commit(ctx); err != nil {
-		return 0, fmt.Errorf("commit released template capture GC: %w", err)
+		return 0, fmt.Errorf("commit released running rootfs capture GC: %w", err)
 	}
 	return len(candidates), nil
 }

--- a/manager/pkg/service/nomad_sandbox_rootfs.go
+++ b/manager/pkg/service/nomad_sandbox_rootfs.go
@@ -21,18 +21,18 @@ type NomadSandboxRootFSStore interface {
 	WithSandboxLock(context.Context, string, func(context.Context, sandboxstore.SandboxStoreTx, *sandboxstore.SandboxRecord) error) error
 }
 
-// NomadSandboxRootFSService exposes snapshots only for stable paused
-// block-COW heads. Running checkpoints remain owned by explicit lifecycle
-// orchestration.
+// NomadSandboxRootFSService pins stable paused heads directly and delegates
+// active writers to the exact-writer checkpoint authority.
 type NomadSandboxRootFSService struct {
-	store NomadSandboxRootFSStore
-	now   func() time.Time
+	store              NomadSandboxRootFSStore
+	runningSnapshotter SandboxRunningRootFSSnapshotter
+	now                func() time.Time
 }
 
-// NewNomadSandboxRootFSService creates a PostgreSQL-only RootFS product
-// service.
+// NewNomadSandboxRootFSService creates the public RootFS product service.
 func NewNomadSandboxRootFSService(
 	store NomadSandboxRootFSStore,
+	runningSnapshotter SandboxRunningRootFSSnapshotter,
 	now func() time.Time,
 ) (*NomadSandboxRootFSService, error) {
 	if store == nil {
@@ -41,10 +41,13 @@ func NewNomadSandboxRootFSService(
 	if now == nil {
 		now = time.Now
 	}
-	return &NomadSandboxRootFSService{store: store, now: now}, nil
+	return &NomadSandboxRootFSService{
+		store: store, runningSnapshotter: runningSnapshotter, now: now,
+	}, nil
 }
 
-// CreateSandboxRootFSSnapshot pins the current paused durable generation.
+// CreateSandboxRootFSSnapshot pins a paused durable head or checkpoints the
+// exact active writer while leaving the source runtime running.
 func (s *NomadSandboxRootFSService) CreateSandboxRootFSSnapshot(
 	ctx context.Context,
 	sandboxID, teamID string,
@@ -64,13 +67,35 @@ func (s *NomadSandboxRootFSService) CreateSandboxRootFSSnapshot(
 	if !request.ExpiresAt.IsZero() && !request.ExpiresAt.After(s.now().UTC()) {
 		return nil, ErrRootFSSnapshotExpired
 	}
+	record, err := s.store.GetSandbox(ctx, sandboxID)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateRootFSSourceSandboxRecord(record, sandboxID, teamID, s.now().UTC()); err != nil {
+		return nil, err
+	}
+	if record.DesiredState == sandboxstore.SandboxDesiredStateActive {
+		if s.runningSnapshotter == nil {
+			return nil, ErrSandboxCheckpointRequiresCtld
+		}
+		if strings.TrimSpace(request.OperationID) == "" {
+			return nil, fmt.Errorf("%w: signed operation identity is required", ErrSandboxLifecycleUnavailable)
+		}
+		snapshot, err := s.runningSnapshotter.CreateRunningSandboxRootFSSnapshot(
+			ctx, sandboxID, teamID, request,
+		)
+		if err != nil {
+			return nil, err
+		}
+		return sandboxRootFSSnapshotFromStore(snapshot), nil
+	}
 	if err := s.requirePausedBlockSandbox(ctx, sandboxID, teamID); err != nil {
 		return nil, err
 	}
 
 	var snapshot *sandboxstore.RootFSSnapshot
 	snapshotID := generateRootFSSnapshotID()
-	err := s.store.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx sandboxstore.SandboxStoreTx, record *sandboxstore.SandboxRecord) error {
+	err = s.store.WithSandboxLock(ctx, sandboxID, func(lockCtx context.Context, tx sandboxstore.SandboxStoreTx, record *sandboxstore.SandboxRecord) error {
 		if err := validateNomadRootFSSandboxRecord(record, sandboxID, teamID, true); err != nil {
 			return err
 		}

--- a/manager/pkg/service/nomad_sandbox_rootfs_test.go
+++ b/manager/pkg/service/nomad_sandbox_rootfs_test.go
@@ -14,7 +14,7 @@ import (
 func TestNomadSandboxRootFSServiceManagesPausedBlockSnapshots(t *testing.T) {
 	now := time.Date(2026, time.August, 21, 5, 0, 0, 0, time.UTC)
 	store := newNomadRootFSTestStore(now)
-	service, err := NewNomadSandboxRootFSService(store, func() time.Time { return now })
+	service, err := NewNomadSandboxRootFSService(store, nil, func() time.Time { return now })
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,11 +60,11 @@ func TestNomadSandboxRootFSServiceManagesPausedBlockSnapshots(t *testing.T) {
 
 func TestNomadSandboxRootFSServiceFailsClosed(t *testing.T) {
 	now := time.Date(2026, time.August, 21, 5, 0, 0, 0, time.UTC)
-	if _, err := NewNomadSandboxRootFSService(nil, nil); err == nil {
+	if _, err := NewNomadSandboxRootFSService(nil, nil, nil); err == nil {
 		t.Fatal("nil rootfs store was accepted")
 	}
 	store := newNomadRootFSTestStore(now)
-	service, err := NewNomadSandboxRootFSService(store, func() time.Time { return now })
+	service, err := NewNomadSandboxRootFSService(store, nil, func() time.Time { return now })
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestNomadSandboxRootFSServiceFailsClosed(t *testing.T) {
 		t.Fatalf("expired snapshot error = %v", err)
 	}
 	store.records["sandbox-a"].DesiredState = sandboxstore.SandboxDesiredStateActive
-	if _, err := service.CreateSandboxRootFSSnapshot(context.Background(), "sandbox-a", "team-a", nil); !errors.Is(err, ErrSandboxRootFSRequiresPausedSandbox) {
+	if _, err := service.CreateSandboxRootFSSnapshot(context.Background(), "sandbox-a", "team-a", nil); !errors.Is(err, ErrSandboxCheckpointRequiresCtld) {
 		t.Fatalf("active snapshot error = %v", err)
 	}
 	store.records["sandbox-a"].DesiredState = sandboxstore.SandboxDesiredStatePaused
@@ -99,6 +99,48 @@ func TestNomadSandboxRootFSServiceFailsClosed(t *testing.T) {
 	if _, err := service.RestoreSandboxRootFS(context.Background(), "sandbox-b", "team-a", &RestoreSandboxRootFSRequest{SnapshotID: "snapshot-a"}); !errors.Is(err, ErrSandboxRootFSRequiresPausedSandbox) {
 		t.Fatalf("active restore error = %v", err)
 	}
+}
+
+func TestNomadSandboxRootFSServiceDelegatesActiveSnapshotToExactWriter(t *testing.T) {
+	now := time.Date(2026, time.August, 21, 5, 0, 0, 0, time.UTC)
+	store := newNomadRootFSTestStore(now)
+	store.records["sandbox-a"].DesiredState = sandboxstore.SandboxDesiredStateActive
+	snapshotter := &recordingRunningRootFSSnapshotter{snapshot: &sandboxstore.RootFSSnapshot{
+		ID: "rootfs-snapshot-running", FilesystemID: "capture-filesystem", TeamID: "team-a",
+		SourceSandboxID: "sandbox-a", HeadGenerationID: "capture-generation",
+		Name: "checkpoint", Description: "while active", CreatedAt: now,
+	}}
+	rootFS, err := NewNomadSandboxRootFSService(store, snapshotter, func() time.Time { return now })
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := &CreateSandboxRootFSSnapshotRequest{
+		Name: "checkpoint", Description: "while active", OperationID: "operation-signed",
+	}
+	snapshot, err := rootFS.CreateSandboxRootFSSnapshot(t.Context(), "sandbox-a", "team-a", request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.ID != snapshotter.snapshot.ID || len(snapshotter.requests) != 1 ||
+		snapshotter.requests[0].OperationID != "operation-signed" {
+		t.Fatalf("snapshot=%+v requests=%+v", snapshot, snapshotter.requests)
+	}
+}
+
+type recordingRunningRootFSSnapshotter struct {
+	snapshot *sandboxstore.RootFSSnapshot
+	requests []*CreateSandboxRootFSSnapshotRequest
+}
+
+func (r *recordingRunningRootFSSnapshotter) CreateRunningSandboxRootFSSnapshot(
+	_ context.Context,
+	_, _ string,
+	request *CreateSandboxRootFSSnapshotRequest,
+) (*sandboxstore.RootFSSnapshot, error) {
+	copyRequest := *request
+	r.requests = append(r.requests, &copyRequest)
+	copySnapshot := *r.snapshot
+	return &copySnapshot, nil
 }
 
 type nomadRootFSTestStore struct {

--- a/manager/pkg/service/runtime_rootfs_types.go
+++ b/manager/pkg/service/runtime_rootfs_types.go
@@ -32,6 +32,14 @@ type CreateSandboxRootFSSnapshotRequest struct {
 	Name        string    `json:"name,omitempty"`
 	Description string    `json:"description,omitempty"`
 	ExpiresAt   time.Time `json:"expires_at,omitempty"`
+	OperationID string    `json:"-"`
+	StartedAt   time.Time `json:"-"`
+}
+
+// SandboxRunningRootFSSnapshotter publishes an immutable checkpoint from the
+// exact live writer without replacing or pausing the source runtime.
+type SandboxRunningRootFSSnapshotter interface {
+	CreateRunningSandboxRootFSSnapshot(context.Context, string, string, *CreateSandboxRootFSSnapshotRequest) (*sandboxstore.RootFSSnapshot, error)
 }
 
 type SandboxRootFSSnapshot struct {

--- a/manager/pkg/service/runtime_types.go
+++ b/manager/pkg/service/runtime_types.go
@@ -94,6 +94,10 @@ type SandboxForkReconciler interface {
 	CompleteSandboxFork(context.Context, string) error
 }
 
+type SandboxRootFSSnapshotReconciler interface {
+	CompleteSandboxRootFSSnapshot(context.Context, string) error
+}
+
 type SandboxRootFSRebaser interface {
 	RebaseSandboxRootFS(context.Context, string, string, *RebaseSandboxRootFSRequest) (*RebaseSandboxRootFSResponse, error)
 }

--- a/manager/pkg/service/sandbox_rootfs_controller.go
+++ b/manager/pkg/service/sandbox_rootfs_controller.go
@@ -24,10 +24,11 @@ type sandboxRootFSWorkItem struct {
 	sandboxID string
 }
 
-// SandboxRootFSController retries durable fork, rebase publication, and
-// rebase acknowledgement independently of API requests and Nomad plugins.
+// SandboxRootFSController retries durable snapshot, fork, rebase publication,
+// and rebase acknowledgement independently of API requests and Nomad plugins.
 type SandboxRootFSController struct {
 	store          sandboxRootFSLifecycleStore
+	snapshot       SandboxRootFSSnapshotReconciler
 	fork           SandboxForkReconciler
 	rebase         SandboxRootFSRebaseReconciler
 	logger         *zap.Logger
@@ -38,6 +39,7 @@ type SandboxRootFSController struct {
 
 func NewSandboxRootFSController(
 	store sandboxRootFSLifecycleStore,
+	snapshot SandboxRootFSSnapshotReconciler,
 	fork SandboxForkReconciler,
 	rebase SandboxRootFSRebaseReconciler,
 	logger *zap.Logger,
@@ -46,10 +48,14 @@ func NewSandboxRootFSController(
 		logger = zap.NewNop()
 	}
 	return &SandboxRootFSController{
-		store: store, fork: fork, rebase: rebase, logger: logger,
+		store: store, snapshot: snapshot, fork: fork, rebase: rebase, logger: logger,
 		queue:          newRetryQueue[sandboxRootFSWorkItem](),
 		resyncInterval: defaultSandboxRootFSResyncPeriod, scanLimit: defaultSandboxRootFSScanLimit,
 	}
+}
+
+func (c *SandboxRootFSController) EnqueueSandboxSnapshot(sandboxID string) {
+	c.enqueue(sandboxstore.SandboxLifecycleKindSnapshot, sandboxID)
 }
 
 func (c *SandboxRootFSController) EnqueueSandboxFork(sandboxID string) {
@@ -107,6 +113,20 @@ func (c *SandboxRootFSController) enqueuePending(ctx context.Context) {
 	if c == nil || c.store == nil {
 		return
 	}
+	if c.snapshot != nil {
+		txns, err := c.store.ListActiveLifecycleTxns(
+			ctx, sandboxstore.SandboxLifecycleKindSnapshot, c.scanLimit,
+		)
+		if err != nil {
+			c.logger.Warn("Failed to list active snapshot lifecycle transactions", zap.Error(err))
+		} else {
+			for _, txn := range txns {
+				if txn != nil {
+					c.EnqueueSandboxSnapshot(txn.SandboxID)
+				}
+			}
+		}
+	}
 	if c.fork != nil {
 		txns, err := c.store.ListActiveLifecycleTxns(
 			ctx, sandboxstore.SandboxLifecycleKindFork, c.scanLimit,
@@ -148,6 +168,10 @@ func (c *SandboxRootFSController) processNextWorkItem(ctx context.Context) bool 
 	defer c.queue.Done(item)
 	var err error
 	switch item.kind {
+	case sandboxstore.SandboxLifecycleKindSnapshot:
+		if c.snapshot != nil {
+			err = c.snapshot.CompleteSandboxRootFSSnapshot(ctx, item.sandboxID)
+		}
 	case sandboxstore.SandboxLifecycleKindFork:
 		if c.fork != nil {
 			err = c.fork.CompleteSandboxFork(ctx, item.sandboxID)

--- a/manager/pkg/service/sandbox_rootfs_controller_test.go
+++ b/manager/pkg/service/sandbox_rootfs_controller_test.go
@@ -11,16 +11,20 @@ import (
 )
 
 type staticRootFSLifecycleStore struct {
-	forks   []*sandboxstore.SandboxLifecycleTxn
-	rebases []*sandboxstore.SandboxLifecycleTxn
-	err     error
+	snapshots []*sandboxstore.SandboxLifecycleTxn
+	forks     []*sandboxstore.SandboxLifecycleTxn
+	rebases   []*sandboxstore.SandboxLifecycleTxn
+	err       error
 }
 
 func (s staticRootFSLifecycleStore) ListActiveLifecycleTxns(
-	context.Context,
-	string,
-	int,
+	_ context.Context,
+	kind string,
+	_ int,
 ) ([]*sandboxstore.SandboxLifecycleTxn, error) {
+	if kind == sandboxstore.SandboxLifecycleKindSnapshot {
+		return s.snapshots, s.err
+	}
 	return s.forks, s.err
 }
 
@@ -34,6 +38,16 @@ func (s staticRootFSLifecycleStore) ListPendingNomadPausedRebases(
 type recordingForkReconciler struct {
 	completed []string
 	err       error
+}
+
+type recordingSnapshotReconciler struct {
+	completed []string
+	err       error
+}
+
+func (r *recordingSnapshotReconciler) CompleteSandboxRootFSSnapshot(_ context.Context, sandboxID string) error {
+	r.completed = append(r.completed, sandboxID)
+	return r.err
 }
 
 func (r *recordingForkReconciler) CompleteSandboxFork(_ context.Context, sandboxID string) error {
@@ -54,21 +68,26 @@ func (r *recordingRebaseReconciler) CompleteSandboxRootFSRebase(
 	return r.err
 }
 
-func TestSandboxRootFSControllerRecoversForksAndRebasesThroughSelectedBackend(t *testing.T) {
-	store := staticRootFSLifecycleStore{forks: []*sandboxstore.SandboxLifecycleTxn{
+func TestSandboxRootFSControllerRecoversSnapshotsForksAndRebasesThroughSelectedBackend(t *testing.T) {
+	store := staticRootFSLifecycleStore{snapshots: []*sandboxstore.SandboxLifecycleTxn{
+		{SandboxID: "snapshot-source", Kind: sandboxstore.SandboxLifecycleKindSnapshot},
+	}, forks: []*sandboxstore.SandboxLifecycleTxn{
 		{SandboxID: "fork-source-a", Kind: sandboxstore.SandboxLifecycleKindFork},
 		{SandboxID: "fork-source-b", Kind: sandboxstore.SandboxLifecycleKindFork},
 	}, rebases: []*sandboxstore.SandboxLifecycleTxn{
 		{SandboxID: "rebase-source", Kind: sandboxstore.SandboxLifecycleKindRebase},
 	}}
+	snapshot := &recordingSnapshotReconciler{}
 	fork := &recordingForkReconciler{}
 	rebase := &recordingRebaseReconciler{}
-	controller := NewSandboxRootFSController(store, fork, rebase, zap.NewNop())
+	controller := NewSandboxRootFSController(store, snapshot, fork, rebase, zap.NewNop())
 	t.Cleanup(controller.queue.ShutDown)
 
 	controller.enqueuePending(t.Context())
 	require.True(t, controller.processNextWorkItem(t.Context()))
 	require.True(t, controller.processNextWorkItem(t.Context()))
+	require.True(t, controller.processNextWorkItem(t.Context()))
+	require.Equal(t, []string{"snapshot-source"}, snapshot.completed)
 	require.True(t, controller.processNextWorkItem(t.Context()))
 	require.ElementsMatch(t, []string{"fork-source-a", "fork-source-b"}, fork.completed)
 	require.Equal(t, []string{"rebase-source"}, rebase.completed)
@@ -76,7 +95,7 @@ func TestSandboxRootFSControllerRecoversForksAndRebasesThroughSelectedBackend(t 
 
 func TestSandboxRootFSControllerRateLimitsFailedRecovery(t *testing.T) {
 	backend := &recordingForkReconciler{err: errors.New("node channel unavailable")}
-	controller := NewSandboxRootFSController(staticRootFSLifecycleStore{}, backend, nil, zap.NewNop())
+	controller := NewSandboxRootFSController(staticRootFSLifecycleStore{}, nil, backend, nil, zap.NewNop())
 	t.Cleanup(controller.queue.ShutDown)
 	controller.EnqueueSandboxFork("fork-source")
 


### PR DESCRIPTION
## Summary

- route running-source snapshot creation through the existing exact-writer checkpoint authority while leaving the source runtime and durable head unchanged
- persist public snapshot metadata on the durable running-capture intent, recover pending publications after manager/API loss, and abort only after the exact writer identity is irrecoverably stale
- release capture-owned filesystems after snapshot deletion or expiration and preserve metadata correctness across rolling manager upgrades
- document Nomad/gVisor checkpoint and recovery semantics

## Validation

- go test ./...
- go vet ./manager/...
- go test -race ./manager/pkg/service ./manager/pkg/http ./manager/pkg/nomadclaim ./manager/pkg/sandboxstore
- full manager/pkg/sandboxstore integration suite against a real PostgreSQL instance with integration tags
- fresh-schema and terminal-cutover migration tests
- simulated callback from a pre-upgrade manager replica

The persistent remote helper currently deploys the retired kind/operator path, so it was intentionally not used as evidence for this Nomad-only exact-writer change. PR CI remains the e2e gate.