### PR TITLE
Retire unpublished initial claim writers

### DIFF
--- a/manager/pkg/runtimeslotwriter/controller.go
+++ b/manager/pkg/runtimeslotwriter/controller.go
@@ -266,18 +266,14 @@ func (c *Controller) ensureCrashLifecycle(
 		regularRuntime := record != nil && record.DeletedAt.IsZero() && record.RuntimeGeneration == runtimeGeneration &&
 			(record.DesiredState == sandboxstore.SandboxDesiredStateActive ||
 				record.DesiredState == sandboxstore.SandboxDesiredStateTerminating)
-		if !regularRuntime && !precommitResume {
-			return errors.New("sandbox runtime does not match the runtime slot writer")
-		}
-		fromRuntimeNamespace, fromRuntimeID := grant.RuntimeNamespace, grant.RuntimeIncarnationID
-		if regularRuntime {
-			fromRuntimeNamespace = record.RuntimeNamespace
-			fromRuntimeID = record.RuntimeID
-		}
-		if fromRuntimeNamespace != grant.RuntimeNamespace || fromRuntimeID != grant.RuntimeIncarnationID {
-			if fromRuntimeNamespace != "" || fromRuntimeID != "" {
-				return errors.New("sandbox runtime does not match the runtime slot writer")
-			}
+		failedInitialClaim := false
+		failedInitialClaimCandidate := record != nil && record.DeletedAt.IsZero() &&
+			(record.DesiredState == sandboxstore.SandboxDesiredStateActive ||
+				record.DesiredState == sandboxstore.SandboxDesiredStateTerminating) &&
+			record.RuntimeNamespace == "" && record.RuntimeID == "" &&
+			(record.RuntimeGeneration == runtimeGeneration ||
+				record.RuntimeGeneration == 0 && runtimeGeneration == 1)
+		if failedInitialClaimCandidate {
 			claimReader, ok := tx.(sandboxRuntimeClaimReader)
 			if !ok {
 				return errors.New("sandbox transaction cannot inspect Nomad claim cleanup")
@@ -286,11 +282,20 @@ func (c *Controller) ensureCrashLifecycle(
 			if err != nil {
 				return err
 			}
-			if claim == nil || claim.Phase != sandboxstore.SandboxRuntimeClaimPhaseCleanupPending {
-				return errors.New("sandbox runtime does not match the runtime slot writer")
-			}
-			fromRuntimeNamespace = grant.RuntimeNamespace
-			fromRuntimeID = grant.RuntimeIncarnationID
+			failedInitialClaim = claim != nil && claim.Phase == sandboxstore.SandboxRuntimeClaimPhaseCleanupPending
+		}
+		fromRuntimeNamespace, fromRuntimeID := grant.RuntimeNamespace, grant.RuntimeIncarnationID
+		switch {
+		case regularRuntime && record.RuntimeNamespace == grant.RuntimeNamespace &&
+			record.RuntimeID == grant.RuntimeIncarnationID:
+			fromRuntimeNamespace = record.RuntimeNamespace
+			fromRuntimeID = record.RuntimeID
+		case failedInitialClaim, precommitResume:
+			// A first claim publishes generation 1 only after command readiness.
+			// Cleanup must therefore accept the durable generation-0 identity
+			// while fencing the exact generation-1 writer bound to its slot.
+		default:
+			return errors.New("sandbox runtime does not match the runtime slot writer")
 		}
 		return tx.BeginLifecycleTxn(lockCtx, &sandboxstore.SandboxLifecycleTxn{
 			ID: request.OperationID, SandboxID: grant.SandboxID,

--- a/manager/pkg/runtimeslotwriter/controller_test.go
+++ b/manager/pkg/runtimeslotwriter/controller_test.go
@@ -368,6 +368,45 @@ func TestControllerFencesConsumedWriterForAbandonedInitialClaim(t *testing.T) {
 	}
 }
 
+func TestControllerFencesConsumedWriterBeforeInitialGenerationPublishes(t *testing.T) {
+	store, controller, request := newFixture(t, sandboxstore.RootFSWriterGrantStateConsumed)
+	store.grant.RuntimeGeneration = "1"
+	store.record.DesiredState = sandboxstore.SandboxDesiredStateTerminating
+	store.record.RuntimeGeneration = 0
+	store.record.RuntimeNamespace = ""
+	store.record.RuntimeID = ""
+	store.claim = &sandboxstore.SandboxRuntimeClaim{
+		SandboxID: store.record.ID, OperationID: "claim-operation-1",
+		Phase: sandboxstore.SandboxRuntimeClaimPhaseCleanupPending,
+	}
+	fence, err := controller.Fence(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Fence() error = %v", err)
+	}
+	if len(fence.ProofDigest) != 32 || store.lifecycle == nil ||
+		store.lifecycle.FromGeneration != 1 ||
+		store.lifecycle.FromRuntimeNamespace != store.grant.RuntimeNamespace ||
+		store.lifecycle.FromRuntimeID != store.grant.RuntimeIncarnationID {
+		t.Fatalf("fence = %+v lifecycle = %+v", fence, store.lifecycle)
+	}
+}
+
+func TestControllerRejectsGenerationGapForFailedInitialClaim(t *testing.T) {
+	store, controller, request := newFixture(t, sandboxstore.RootFSWriterGrantStateConsumed)
+	store.record.DesiredState = sandboxstore.SandboxDesiredStateTerminating
+	store.record.RuntimeGeneration = 0
+	store.record.RuntimeNamespace = ""
+	store.record.RuntimeID = ""
+	store.claim = &sandboxstore.SandboxRuntimeClaim{
+		SandboxID: store.record.ID, OperationID: "claim-operation-1",
+		Phase: sandboxstore.SandboxRuntimeClaimPhaseCleanupPending,
+	}
+	_, err := controller.Fence(context.Background(), request)
+	if err == nil || store.lifecycle != nil || store.beginCalls != 0 {
+		t.Fatalf("Fence() = %v, lifecycle = %+v, begin calls = %d", err, store.lifecycle, store.beginCalls)
+	}
+}
+
 func TestControllerRejectsUnfencedInitialClaimWithoutRuntimeBinding(t *testing.T) {
 	store, controller, request := newFixture(t, sandboxstore.RootFSWriterGrantStateConsumed)
 	store.record.RuntimeNamespace = ""

--- a/manager/pkg/sandboxstore/writer_grant.go
+++ b/manager/pkg/sandboxstore/writer_grant.go
@@ -1684,7 +1684,8 @@ func lockRootFSWriterCrashRuntime(
 		currentRuntimeNamespace == "" && currentRuntimeID == "" && runtimeGeneration == lifecycle.FromGeneration
 	failedClaimCandidate := !deletedAt.Valid &&
 		(desiredState == SandboxDesiredStateActive || desiredState == SandboxDesiredStateTerminating) &&
-		currentRuntimeNamespace == "" && currentRuntimeID == "" && runtimeGeneration == lifecycle.FromGeneration &&
+		currentRuntimeNamespace == "" && currentRuntimeID == "" &&
+		(runtimeGeneration == lifecycle.FromGeneration || runtimeGeneration == 0 && lifecycle.FromGeneration == 1) &&
 		lifecycle.FromRuntimeNamespace == record.RuntimeNamespace && lifecycle.FromRuntimeID == record.RuntimeIncarnationID
 	if failedClaimCandidate {
 		if err := db.QueryRow(ctx, `

--- a/manager/pkg/sandboxstore/writer_grant_integration_test.go
+++ b/manager/pkg/sandboxstore/writer_grant_integration_test.go
@@ -493,10 +493,6 @@ func TestRootFSWriterCrashAbandonCompletesAbandonedInitialNomadClaimIntegration(
 	store := NewPGSandboxStore(pool)
 	record, filesystem, generation, registration := sandboxRuntimeClaimReadySlotFixture(t, store, "failed-writer")
 	record.RuntimeGeneration = 1
-	_, err := pool.Exec(ctx, `
-		UPDATE manager.sandboxes SET runtime_generation = $2 WHERE sandbox_id = $1
-	`, record.ID, record.RuntimeGeneration)
-	require.NoError(t, err)
 
 	acquire := sandboxRuntimeSlotAcquireRequest(record, filesystem, generation, registration, "failed-writer")
 	claimed, err := store.AcquireRuntimeSlot(ctx, acquire)
@@ -589,6 +585,7 @@ func TestRootFSWriterCrashAbandonCompletesAbandonedInitialNomadClaimIntegration(
 	stored, err := store.GetSandbox(ctx, record.ID)
 	require.NoError(t, err)
 	require.Equal(t, SandboxDesiredStateActive, stored.DesiredState)
+	require.Zero(t, stored.RuntimeGeneration)
 	require.Empty(t, stored.RuntimeNamespace)
 	require.Empty(t, stored.RuntimeID)
 	var claimPhase, lifecyclePhase string


### PR DESCRIPTION
## Summary\n- allow terminal reconciliation to fence an exact generation-1 writer while the failed initial sandbox record is still generation 0\n- preserve strict rejection for arbitrary generation gaps and require cleanup_pending claim authority\n- teach crash-abandon completion the same pre-publish generation boundary\n\n## Production evidence\n- ali-ue1 has two legacy generation-0 terminal slots rejected as sandbox/runtime mismatches\n- one owns the node dirty-tail retirement reserve, blocking five additional exact cleanup operations\n- diagnostic runs: 33599625499 and 33601408373\n\n## Validation\n- go test ./...\n- TEST_DATABASE_URL=<temporary PostgreSQL> go test ./manager/pkg/sandboxstore -count=1