### PR TITLE
Fix runtime slot terminal retry recovery

### DIFF
--- a/manager/pkg/runtimeslotwriter/controller.go
+++ b/manager/pkg/runtimeslotwriter/controller.go
@@ -35,6 +35,10 @@ type sandboxRuntimeSlotReader interface {
 	GetRuntimeSlot(context.Context, string) (*sandboxstore.RuntimeSlot, error)
 }
 
+type sandboxCrashLifecycleStarter interface {
+	BeginOrRestartRootFSWriterCrashLifecycleTxn(context.Context, *sandboxstore.SandboxLifecycleTxn) error
+}
+
 // Controller fences renewal and terminally abandons unsealed writers while
 // preserving the last durable RootFS generation.
 type Controller struct {
@@ -297,13 +301,17 @@ func (c *Controller) ensureCrashLifecycle(
 		default:
 			return errors.New("sandbox runtime does not match the runtime slot writer")
 		}
-		return tx.BeginLifecycleTxn(lockCtx, &sandboxstore.SandboxLifecycleTxn{
+		lifecycle := &sandboxstore.SandboxLifecycleTxn{
 			ID: request.OperationID, SandboxID: grant.SandboxID,
 			Kind: sandboxstore.SandboxLifecycleKindPause, Phase: sandboxstore.SandboxLifecyclePhasePublishing,
 			Source: sandboxstore.SandboxLifecycleSourceCrash, Cancelable: false,
 			FromGeneration: runtimeGeneration, FromRuntimeNamespace: fromRuntimeNamespace,
 			FromRuntimeID: fromRuntimeID, ExpectedGenerationID: grant.InitialGenerationID,
-		})
+		}
+		if starter, ok := tx.(sandboxCrashLifecycleStarter); ok {
+			return starter.BeginOrRestartRootFSWriterCrashLifecycleTxn(lockCtx, lifecycle)
+		}
+		return tx.BeginLifecycleTxn(lockCtx, lifecycle)
 	})
 	if err != nil {
 		return fmt.Errorf("prepare runtime slot writer crash lifecycle: %w", err)

--- a/manager/pkg/runtimeslotwriter/controller_test.go
+++ b/manager/pkg/runtimeslotwriter/controller_test.go
@@ -22,6 +22,7 @@ type fakeStore struct {
 	abortCalls    int
 	cancelCalls   int
 	beginCalls    int
+	restartCalls  int
 	completeCalls int
 	cancelLost    bool
 	beginLost     bool
@@ -127,6 +128,19 @@ func (f fakeTx) BeginLifecycleTxn(_ context.Context, txn *sandboxstore.SandboxLi
 	}
 	f.store.lifecycle = cloneLifecycle(txn)
 	return nil
+}
+
+func (f fakeTx) BeginOrRestartRootFSWriterCrashLifecycleTxn(
+	ctx context.Context,
+	txn *sandboxstore.SandboxLifecycleTxn,
+) error {
+	if f.store.lifecycle != nil && f.store.lifecycle.ID == txn.ID &&
+		f.store.lifecycle.Phase == sandboxstore.SandboxLifecyclePhaseAborted {
+		f.store.restartCalls++
+		f.store.lifecycle = cloneLifecycle(txn)
+		return nil
+	}
+	return f.BeginLifecycleTxn(ctx, txn)
 }
 
 func (f fakeTx) CompleteRootFSWriterCrashAbandon(
@@ -388,6 +402,32 @@ func TestControllerFencesConsumedWriterBeforeInitialGenerationPublishes(t *testi
 		store.lifecycle.FromRuntimeNamespace != store.grant.RuntimeNamespace ||
 		store.lifecycle.FromRuntimeID != store.grant.RuntimeIncarnationID {
 		t.Fatalf("fence = %+v lifecycle = %+v", fence, store.lifecycle)
+	}
+}
+
+func TestControllerRestartsExactAbortedCrashLifecycle(t *testing.T) {
+	store, controller, request := newFixture(t, sandboxstore.RootFSWriterGrantStateConsumed)
+	store.lifecycle = &sandboxstore.SandboxLifecycleTxn{
+		ID: request.OperationID, SandboxID: store.record.ID,
+		Kind: sandboxstore.SandboxLifecycleKindPause, Phase: sandboxstore.SandboxLifecyclePhaseAborted,
+		Source: sandboxstore.SandboxLifecycleSourceCrash, Cancelable: false,
+		FromGeneration:       store.record.RuntimeGeneration,
+		FromRuntimeNamespace: store.grant.RuntimeNamespace,
+		FromRuntimeID:        store.grant.RuntimeIncarnationID,
+		ExpectedGenerationID: store.grant.InitialGenerationID,
+		Error:                "earlier terminal reconciliation failed",
+	}
+
+	fence, err := controller.Fence(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Fence() error = %v", err)
+	}
+	if len(fence.ProofDigest) != 32 || store.restartCalls != 1 || store.lifecycle == nil ||
+		store.lifecycle.ID != request.OperationID ||
+		store.lifecycle.Phase != sandboxstore.SandboxLifecyclePhasePublishing ||
+		store.lifecycle.Error != "" || store.grant.State != sandboxstore.RootFSWriterGrantStateRetiring {
+		t.Fatalf("fence = %+v restart calls = %d lifecycle = %+v grant = %+v",
+			fence, store.restartCalls, store.lifecycle, store.grant)
 	}
 }
 

--- a/manager/pkg/sandboxstore/store.go
+++ b/manager/pkg/sandboxstore/store.go
@@ -1,6 +1,7 @@
 package sandboxstore
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1100,6 +1101,108 @@ func (t sandboxStoreTx) BeginLifecycleTxn(ctx context.Context, txn *SandboxLifec
 	txn.Phase = phase
 	txn.Source = source
 	return nil
+}
+
+// BeginOrRestartRootFSWriterCrashLifecycleTxn recovers the deterministic
+// runtime-slot writer operation when an earlier pre-fence attempt left the
+// same lifecycle ID aborted but the exact writer grant remained live. A
+// successfully completed crash-abandon is never reopened.
+func (t sandboxStoreTx) BeginOrRestartRootFSWriterCrashLifecycleTxn(
+	ctx context.Context,
+	txn *SandboxLifecycleTxn,
+) error {
+	if txn == nil || strings.TrimSpace(txn.ID) == "" || strings.TrimSpace(txn.SandboxID) == "" ||
+		txn.Kind != SandboxLifecycleKindPause ||
+		!rootFSWriterCrashAbandonSource(txn.Source) || txn.Cancelable ||
+		txn.Phase != SandboxLifecyclePhasePublishing || txn.FromGeneration <= 0 || txn.ToGeneration != 0 ||
+		strings.TrimSpace(txn.FromRuntimeNamespace) == "" || strings.TrimSpace(txn.FromRuntimeID) == "" ||
+		strings.TrimSpace(txn.ToRuntimeNamespace) != "" || strings.TrimSpace(txn.ToRuntimeID) != "" ||
+		strings.TrimSpace(txn.TargetSandboxID) != "" || strings.TrimSpace(txn.TargetGenerationID) != "" ||
+		len(txn.TargetRecordDigest) != 0 || strings.TrimSpace(txn.SourceBaseArtifactDigest) != "" ||
+		strings.TrimSpace(txn.TargetBaseArtifactDigest) != "" || !txn.RollbackExpiresAt.IsZero() ||
+		strings.TrimSpace(txn.WorkerClusterID) != "" || strings.TrimSpace(txn.WorkerNodeID) != "" ||
+		strings.TrimSpace(txn.WorkerNodeUID) != "" || len(txn.WorkerProofDigest) != 0 ||
+		!txn.WorkerAcknowledgedAt.IsZero() || strings.TrimSpace(txn.ExpectedGenerationID) == "" ||
+		strings.TrimSpace(txn.PreparedGenerationID) != "" {
+		return fmt.Errorf("restartable RootFS writer crash lifecycle is invalid")
+	}
+	existing, err := scanLifecycleTxn(t.tx.QueryRow(ctx, lifecycleTxnSelectSQL()+`
+		WHERE txn_id = $1
+		FOR UPDATE
+	`, txn.ID))
+	if err != nil {
+		return fmt.Errorf("lock restartable RootFS writer crash lifecycle: %w", err)
+	}
+	if existing == nil {
+		return t.BeginLifecycleTxn(ctx, txn)
+	}
+	if !restartableRootFSWriterCrashLifecycleMatches(existing, txn) {
+		return fmt.Errorf("RootFS writer crash lifecycle %s is not restartable", txn.ID)
+	}
+	if err := cancelPendingNomadSandboxNetworkMutationForSandbox(
+		ctx, t.tx, txn.SandboxID, "sandbox lifecycle preempted network update",
+	); err != nil {
+		return err
+	}
+	var epoch int64
+	if err := t.tx.QueryRow(ctx, `
+		UPDATE manager.sandboxes
+		SET lifecycle_epoch = lifecycle_epoch + 1,
+			updated_at = NOW()
+		WHERE sandbox_id = $1
+		RETURNING lifecycle_epoch
+	`, txn.SandboxID).Scan(&epoch); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("%w: %s", ErrSandboxRecordNotFound, txn.SandboxID)
+		}
+		return fmt.Errorf("advance restarted lifecycle epoch: %w", err)
+	}
+	tag, err := t.tx.Exec(ctx, `
+		UPDATE manager.sandbox_lifecycle_txns
+		SET phase = $2,
+			epoch = $3,
+			error = '',
+			cancel_reason = '',
+			cancel_requested_at = NULL,
+			committed_at = NULL,
+			aborted_at = NULL,
+			updated_at = NOW()
+		WHERE txn_id = $1
+			AND phase = $4
+			AND epoch = $5
+	`, txn.ID, SandboxLifecyclePhasePublishing, epoch,
+		SandboxLifecyclePhaseAborted, existing.Epoch)
+	if err != nil {
+		return fmt.Errorf("restart RootFS writer crash lifecycle: %w", err)
+	}
+	if tag.RowsAffected() != 1 {
+		return fmt.Errorf("RootFS writer crash lifecycle %s changed before restart", txn.ID)
+	}
+	txn.Epoch = epoch
+	return nil
+}
+
+func restartableRootFSWriterCrashLifecycleMatches(existing, requested *SandboxLifecycleTxn) bool {
+	return existing != nil && requested != nil &&
+		existing.ID == requested.ID && existing.SandboxID == requested.SandboxID &&
+		existing.Kind == requested.Kind && existing.Source == requested.Source &&
+		!existing.Cancelable && !requested.Cancelable &&
+		existing.Phase == SandboxLifecyclePhaseAborted && existing.CancelRequestedAt.IsZero() &&
+		existing.Error != RootFSWriterCrashAbandonReason &&
+		existing.FromGeneration == requested.FromGeneration && existing.ToGeneration == requested.ToGeneration &&
+		existing.FromRuntimeNamespace == requested.FromRuntimeNamespace && existing.FromRuntimeID == requested.FromRuntimeID &&
+		existing.ToRuntimeNamespace == requested.ToRuntimeNamespace && existing.ToRuntimeID == requested.ToRuntimeID &&
+		existing.TargetSandboxID == requested.TargetSandboxID && existing.TargetGenerationID == requested.TargetGenerationID &&
+		bytes.Equal(existing.TargetRecordDigest, requested.TargetRecordDigest) &&
+		existing.SourceBaseArtifactDigest == requested.SourceBaseArtifactDigest &&
+		existing.TargetBaseArtifactDigest == requested.TargetBaseArtifactDigest &&
+		existing.RollbackExpiresAt.Equal(requested.RollbackExpiresAt) &&
+		existing.WorkerClusterID == requested.WorkerClusterID && existing.WorkerNodeID == requested.WorkerNodeID &&
+		existing.WorkerNodeUID == requested.WorkerNodeUID &&
+		bytes.Equal(existing.WorkerProofDigest, requested.WorkerProofDigest) &&
+		existing.WorkerAcknowledgedAt.Equal(requested.WorkerAcknowledgedAt) &&
+		existing.ExpectedGenerationID == requested.ExpectedGenerationID &&
+		existing.PreparedGenerationID == "" && requested.PreparedGenerationID == ""
 }
 
 func (t sandboxStoreTx) SetLifecycleTxnRuntime(ctx context.Context, txnID, runtimeNamespace, runtimeID string) error {

--- a/manager/pkg/sandboxstore/writer_grant.go
+++ b/manager/pkg/sandboxstore/writer_grant.go
@@ -1704,6 +1704,14 @@ func lockRootFSWriterCrashRuntime(
 			return match, fmt.Errorf("verify failed Nomad claim cleanup: %w", err)
 		}
 	}
+	if !match.failedClaimCleanup && failedClaimCandidate && runtimeGeneration == 0 &&
+		lifecycle.FromGeneration == 1 && match.renewalRevoked {
+		// Older initial claims left the sandbox generation unpublished while
+		// their exact slot was already fenced. The slot identity is sufficient
+		// authority to finish that interrupted terminal operation even if the
+		// logical claim worker no longer exposes cleanup_pending.
+		match.failedClaimCleanup = true
+	}
 	if !match.active && !match.terminating && !precommitResume &&
 		!match.failedClaimCleanup && !match.failedClaimDeletion {
 		return match, fmt.Errorf("%w: sandbox runtime no longer matches crash lifecycle txn %s",

--- a/manager/pkg/sandboxstore/writer_grant_integration_test.go
+++ b/manager/pkg/sandboxstore/writer_grant_integration_test.go
@@ -179,6 +179,69 @@ func TestRootFSWriterCrashAbandonCompletesWithRecoveryLifecycleAfterBeginOwnerAb
 	require.Equal(t, RootFSWriterCrashAbandonReason, lifecycleError)
 }
 
+func TestRootFSWriterCrashAbandonRestartsExactAbortedLifecycle(t *testing.T) {
+	fixture := newRootFSWriterCrashAbandonFixture(t, SandboxLifecycleSourceCrash, true)
+	ctx := context.Background()
+	var originalEpoch int64
+	require.NoError(t, fixture.pool.QueryRow(ctx, `
+		SELECT epoch FROM manager.sandbox_lifecycle_txns WHERE txn_id = $1
+	`, fixture.request.LifecycleTxnID).Scan(&originalEpoch))
+	require.NoError(t, fixture.store.WithSandboxLock(ctx, fixture.sandboxID, func(
+		lockCtx context.Context,
+		tx SandboxStoreTx,
+		_ *SandboxRecord,
+	) error {
+		return tx.AbortLifecycleTxn(lockCtx, fixture.request.LifecycleTxnID,
+			"earlier terminal reconciliation failed")
+	}))
+
+	var restarted *SandboxLifecycleTxn
+	require.NoError(t, fixture.store.WithSandboxLock(ctx, fixture.sandboxID, func(
+		lockCtx context.Context,
+		tx SandboxStoreTx,
+		_ *SandboxRecord,
+	) error {
+		restarted = &SandboxLifecycleTxn{
+			ID: fixture.request.LifecycleTxnID, SandboxID: fixture.sandboxID,
+			Kind: SandboxLifecycleKindPause, Phase: SandboxLifecyclePhasePublishing,
+			Source: SandboxLifecycleSourceCrash, Cancelable: false,
+			FromGeneration:       fixture.runtimeGeneration,
+			FromRuntimeNamespace: "sandbox0", FromRuntimeID: "sandbox-crash-abandon-pod",
+			ExpectedGenerationID: fixture.initial.ID,
+		}
+		restarter, ok := tx.(interface {
+			BeginOrRestartRootFSWriterCrashLifecycleTxn(context.Context, *SandboxLifecycleTxn) error
+		})
+		require.True(t, ok)
+		return restarter.BeginOrRestartRootFSWriterCrashLifecycleTxn(lockCtx, restarted)
+	}))
+	require.Greater(t, restarted.Epoch, originalEpoch)
+
+	stored, err := fixture.store.GetLifecycleTxn(ctx, fixture.request.LifecycleTxnID)
+	require.NoError(t, err)
+	require.Equal(t, SandboxLifecyclePhasePublishing, stored.Phase)
+	require.Empty(t, stored.Error)
+	require.True(t, stored.AbortedAt.IsZero())
+	require.Equal(t, restarted.Epoch, stored.Epoch)
+
+	_, err = fixture.store.BeginRootFSWriterCrashAbandon(ctx, fixture.beginRequest)
+	require.NoError(t, err)
+	require.NoError(t, fixture.complete(t))
+	grant, err := fixture.store.GetRootFSWriterGrant(ctx, fixture.issued.Grant.ID)
+	require.NoError(t, err)
+	require.Equal(t, RootFSWriterGrantStateRetired, grant.State)
+	err = fixture.store.WithSandboxLock(ctx, fixture.sandboxID, func(
+		lockCtx context.Context,
+		tx SandboxStoreTx,
+		_ *SandboxRecord,
+	) error {
+		return tx.(interface {
+			BeginOrRestartRootFSWriterCrashLifecycleTxn(context.Context, *SandboxLifecycleTxn) error
+		}).BeginOrRestartRootFSWriterCrashLifecycleTxn(lockCtx, restarted)
+	})
+	require.Error(t, err)
+}
+
 func TestRootFSWriterCrashAbandonCompletesAcceptedPrecommitResumePod(t *testing.T) {
 	fixture := newRootFSWriterCrashAbandonFixture(t, SandboxLifecycleSourceLost, true)
 	ctx := context.Background()
@@ -552,6 +615,14 @@ func TestRootFSWriterCrashAbandonCompletesAbandonedInitialNomadClaimIntegration(
 		})
 	})
 	require.NoError(t, err)
+	// Reproduce an older failed initial claim whose logical worker no longer
+	// advertises cleanup_pending even though its exact runtime slot is fenced.
+	_, err = pool.Exec(ctx, `
+		UPDATE manager.sandbox_runtime_claims
+		SET phase = $2, cleanup_started_at = NULL, last_error = ''
+		WHERE sandbox_id = $1
+	`, record.ID, SandboxRuntimeClaimPhaseReady)
+	require.NoError(t, err)
 	begin := &BeginRootFSWriterCrashAbandonRequest{
 		GrantID: issued.Grant.ID, WriterEpoch: issued.Grant.WriterEpoch,
 		OperationID: lifecycleID, BindingVersion: RootFSWriterBindingVersion,
@@ -559,6 +630,12 @@ func TestRootFSWriterCrashAbandonCompletesAbandonedInitialNomadClaimIntegration(
 		ExpectedOldGenerationID: generation.ID,
 	}
 	_, err = store.BeginRootFSWriterCrashAbandon(ctx, begin)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		UPDATE manager.sandbox_runtime_claims
+		SET phase = $2, cleanup_started_at = NOW()
+		WHERE sandbox_id = $1
+	`, record.ID, SandboxRuntimeClaimPhaseCleanupPending)
 	require.NoError(t, err)
 	proof := sha256.Sum256([]byte("failed-initial-claim-node-cleanup-proof"))
 	err = store.WithSandboxLock(ctx, record.ID, func(


### PR DESCRIPTION
## Summary
- restart an exact aborted deterministic crash lifecycle instead of colliding with its primary key
- allow fenced generation 0 to writer generation 1 initial claims to finish terminal cleanup after the logical claim leaves cleanup_pending
- preserve strict runtime slot, writer grant, lifecycle identity, and successful-terminal fencing

## Production evidence
- one ali-ue1 slot currently reaches a duplicate lifecycle transaction key on terminal retry
- another exact initial generation slot reaches a runtime mismatch after its slot has already been fenced

## Tests
- go test ./...
- go test -race ./manager/pkg/runtimeslotwriter -count=1
- TEST_DATABASE_URL=<temporary PostgreSQL> go test ./manager/pkg/sandboxstore -count=1
- targeted real PostgreSQL regression tests for both production failure modes