### PR TITLE
fix(rootfs): recover missing terminal detach proof

### DIFF
--- a/pkg/nomadruntime/runtime.go
+++ b/pkg/nomadruntime/runtime.go
@@ -678,7 +678,7 @@ func (r *rootfsRuntime) CrashFence(
 	}
 	r.stopRenewal(request.Parent)
 	if err := r.authority.VerifyTerminalWriterGrant(ctx, request); err == nil {
-		if err := r.finalizeVerifiedTerminal(request); err != nil {
+		if err := r.finalizeVerifiedTerminal(ctx, request); err != nil {
 			return rootfshandoff.CrashFenceProof{}, fmt.Errorf("finalize verified terminal RootFS session: %w", err)
 		}
 		return rootfshandoff.CrashFenceProof{}, nil
@@ -727,12 +727,16 @@ func (r *rootfsRuntime) CrashFence(
 	return proof, nil
 }
 
-func (r *rootfsRuntime) finalizeVerifiedTerminal(request rootfshandoff.StageRequest) error {
+func (r *rootfsRuntime) finalizeVerifiedTerminal(
+	ctx context.Context,
+	request rootfshandoff.StageRequest,
+) error {
 	sessions, err := r.sessions.RecoverySessions()
 	if err != nil {
 		return fmt.Errorf("inspect terminal RootFS session ownership: %w", err)
 	}
 	keepProof := false
+	var matched *rootfssession.RecoverySession
 	for _, session := range sessions {
 		if session.Stage.Parent != request.Parent {
 			continue
@@ -741,14 +745,36 @@ func (r *rootfsRuntime) finalizeVerifiedTerminal(request rootfshandoff.StageRequ
 			session.Stage.Identity.WriterEpoch != request.Identity.WriterEpoch {
 			return fmt.Errorf("terminal RootFS session belongs to another writer: %w", errdefs.ErrFailedPrecondition)
 		}
+		candidate := session
+		matched = &candidate
 		keepProof = session.ExternalCrash
 		break
 	}
-	if err := r.sessions.ReclaimTerminalArtifacts(request.Parent, request.Identity); err != nil {
-		if errdefs.IsNotFound(err) {
+	reclaimErr := r.sessions.ReclaimTerminalArtifacts(request.Parent, request.Identity)
+	if errdefs.IsFailedPrecondition(reclaimErr) && matched != nil {
+		// A regional terminal CAS can win after physical teardown but before an
+		// older node journal persisted its local detach proof. Rebuild that proof
+		// from exact host absence instead of retrying the proof-less tombstone
+		// forever. External mode is required because regional truth already owns
+		// the terminal decision and any unpublished local seal must be discarded.
+		if err := r.sessions.Release(ctx, request.Identity); err != nil {
+			return fmt.Errorf("finish regionally verified RootFS release: %w", err)
+		}
+		operationID := matched.CrashOperationID
+		if operationID == "" {
+			operationID = crashOperationID(request)
+		}
+		if _, err := r.sessions.CrashFenceExternal(request, operationID); err != nil {
+			return fmt.Errorf("rebuild regionally verified RootFS detach proof: %w", err)
+		}
+		keepProof = true
+		reclaimErr = r.sessions.ReclaimTerminalArtifacts(request.Parent, request.Identity)
+	}
+	if reclaimErr != nil {
+		if errdefs.IsNotFound(reclaimErr) {
 			return nil
 		}
-		return err
+		return reclaimErr
 	}
 	if keepProof {
 		return nil
@@ -770,7 +796,7 @@ func (r *rootfsRuntime) ReclaimVerifiedTerminal(
 	if err := r.authority.VerifyTerminalWriterGrant(ctx, request); err != nil {
 		return fmt.Errorf("verify terminal writer grant: %w", err)
 	}
-	return r.finalizeVerifiedTerminal(request)
+	return r.finalizeVerifiedTerminal(ctx, request)
 }
 
 // ReclaimExternallyRetired removes large node-local artifacts once the

--- a/pkg/rootfssession/manager_test.go
+++ b/pkg/rootfssession/manager_test.go
@@ -459,6 +459,39 @@ func TestManagerExternalCrashFenceReplacesUnpublishedLocalRetirement(t *testing.
 	require.Len(t, recovery, 1, "restart must rebuild the due-proof recovery index")
 }
 
+func TestManagerExternalCrashFenceRepairsLegacyPlannedTombstoneWithoutDetachProof(t *testing.T) {
+	manager, _, request := newTestManager(t, "external-repairs-missing-proof")
+	_, err := manager.Ensure(t.Context(), request)
+	require.NoError(t, err)
+	require.NoError(t, manager.BeginRetire(request.Parent, request.Identity, "local-planned-operation"))
+	require.NoError(t, manager.ReleaseParent(t.Context(), request.Parent, request.Identity))
+
+	stored, err := manager.load(request.Parent)
+	require.NoError(t, err)
+	require.Equal(t, stateTombstoned, stored.State)
+	require.NotEmpty(t, stored.DetachProof)
+	stored.DetachProof = ""
+	require.NoError(t, manager.save(stored))
+	require.ErrorIs(
+		t, manager.ReclaimTerminalArtifacts(request.Parent, request.Identity), errdefs.ErrFailedPrecondition,
+	)
+
+	observation, err := manager.CrashFenceExternal(
+		request.WithoutWriterGrantToken(), "regional-terminal-recovery",
+	)
+	require.NoError(t, err)
+	require.NoError(t, observation.Validate())
+	require.NoError(t, manager.ReclaimTerminalArtifacts(request.Parent, request.Identity))
+
+	recovered, err := manager.load(request.Parent)
+	require.NoError(t, err)
+	require.Empty(t, recovered.RetireOperationID)
+	require.NotNil(t, recovered.CrashFence)
+	require.True(t, recovered.CrashFence.External)
+	require.NotNil(t, recovered.CrashFence.Result)
+	require.True(t, recovered.BranchRemoved)
+}
+
 func TestManagerForgetsRegionallyVerifiedPlannedTerminal(t *testing.T) {
 	manager, _, request := newTestManager(t, "forget-planned")
 	_, err := manager.Ensure(t.Context(), request)


### PR DESCRIPTION
When regional writer retirement was already terminal but an older node journal had reached a local tombstone without persisting its detach proof, terminal reconciliation called artifact reclaim forever and failed once per second.\n\nAfter regional terminal verification, this change completes any interrupted local release, reconstructs an external crash-fence proof from exact host absence, and retries artifact reclaim. It preserves the compact external proof for the existing retention window.\n\nValidation:\n- go test ./pkg/rootfssession ./pkg/nomadruntime\n- git diff --check