### PR TITLE
fix(ctld): fence unroutable network incarnations

### DIFF
--- a/ctld/internal/ctld/networking/daemon.go
+++ b/ctld/internal/ctld/networking/daemon.go
@@ -45,8 +45,8 @@ type Daemon struct {
 	conntrackCloser          runtimeResource
 	meteringCloser           runtimeResource
 	meteringDone             <-chan struct{}
-	runtimeSlotRegistry      *slotnetwork.Registry
-	runtimeSlotControl       *slotnetwork.ControlServer
+	runtimeSlotRegistry      runtimeSlotRegistryCloser
+	runtimeSlotControl       runtimeSlotControlCloser
 	ready                    atomic.Bool
 }
 
@@ -58,6 +58,14 @@ type Options struct {
 
 type runtimeResource interface {
 	Close()
+}
+
+type runtimeSlotRegistryCloser interface {
+	Close() error
+}
+
+type runtimeSlotControlCloser interface {
+	Shutdown(context.Context) error
 }
 
 type sqlRuntimeResource struct {
@@ -559,11 +567,14 @@ func (d *Daemon) closeRuntimeSlotNetworkControl(ctx context.Context) error {
 	d.runtimeSlotControl = nil
 	d.runtimeMu.Unlock()
 	var result error
-	if registry != nil {
-		result = registry.Close()
-	}
+	// Stop accepting and drain control requests before closing the registry
+	// they use. Closing in the opposite order exposes a transient 503 to an
+	// otherwise valid in-flight manager request during ctld HA handoff.
 	if control != nil {
-		result = errors.Join(result, control.Shutdown(ctx))
+		result = control.Shutdown(ctx)
+	}
+	if registry != nil {
+		result = errors.Join(result, registry.Close())
 	}
 	return result
 }

--- a/ctld/internal/ctld/networking/daemon_lifecycle_test.go
+++ b/ctld/internal/ctld/networking/daemon_lifecycle_test.go
@@ -14,6 +14,24 @@ type orderedRuntimeResource struct {
 	events chan<- string
 }
 
+type orderedRuntimeSlotRegistry struct {
+	events chan<- string
+}
+
+func (r *orderedRuntimeSlotRegistry) Close() error {
+	r.events <- "registry"
+	return nil
+}
+
+type orderedRuntimeSlotControl struct {
+	events chan<- string
+}
+
+func (c *orderedRuntimeSlotControl) Shutdown(context.Context) error {
+	c.events <- "control"
+	return nil
+}
+
 func (r *orderedRuntimeResource) Close() {
 	r.events <- r.name
 }
@@ -46,6 +64,27 @@ func TestShutdownClosesRuntimeResourcesAfterMeteringLoopStops(t *testing.T) {
 
 	want := []string{"flush", "metering", "conntrack"}
 	for _, expected := range want {
+		select {
+		case got := <-events:
+			if got != expected {
+				t.Fatalf("event = %q, want %q", got, expected)
+			}
+		default:
+			t.Fatalf("missing event %q", expected)
+		}
+	}
+}
+
+func TestShutdownDrainsRuntimeSlotControlBeforeClosingRegistry(t *testing.T) {
+	events := make(chan string, 2)
+	d := &Daemon{
+		runtimeSlotRegistry: &orderedRuntimeSlotRegistry{events: events},
+		runtimeSlotControl:  &orderedRuntimeSlotControl{events: events},
+	}
+	if err := d.closeRuntimeSlotNetworkControl(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range []string{"control", "registry"} {
 		select {
 		case got := <-events:
 			if got != expected {

--- a/ctld/internal/ctld/networking/slotnetwork/inspector_linux.go
+++ b/ctld/internal/ctld/networking/slotnetwork/inspector_linux.go
@@ -88,7 +88,11 @@ func selectRoutableIPv4(addresses map[string]struct{}) (string, error) {
 	}
 	sort.Strings(values)
 	if len(values) == 0 {
-		return "", fmt.Errorf("network namespace does not have a routable IPv4 address yet: %w", errdefs.ErrUnavailable)
+		return "", fmt.Errorf(
+			"network namespace does not have a routable IPv4 address yet: %w: %w",
+			errExactNamespaceUnroutable,
+			errdefs.ErrUnavailable,
+		)
 	}
 	if len(values) != 1 {
 		return "", fmt.Errorf("network namespace must have exactly one routable IPv4 address, got %v: %w", values, errdefs.ErrFailedPrecondition)

--- a/ctld/internal/ctld/networking/slotnetwork/inspector_linux_test.go
+++ b/ctld/internal/ctld/networking/slotnetwork/inspector_linux_test.go
@@ -19,7 +19,7 @@ func TestNamespaceInspectorClassifiesMissingExactIncarnation(t *testing.T) {
 }
 
 func TestSelectRoutableIPv4ClassifiesNetworkReadiness(t *testing.T) {
-	if _, err := selectRoutableIPv4(nil); !errdefs.IsUnavailable(err) {
+	if _, err := selectRoutableIPv4(nil); !errdefs.IsUnavailable(err) || !errors.Is(err, errExactNamespaceUnroutable) {
 		t.Fatalf("missing address error = %v", err)
 	}
 	if _, err := selectRoutableIPv4(map[string]struct{}{

--- a/ctld/internal/ctld/networking/slotnetwork/registry.go
+++ b/ctld/internal/ctld/networking/slotnetwork/registry.go
@@ -46,7 +46,8 @@ var (
 	metadataBucket   = []byte("metadata-v1")
 	generationKey    = []byte("generation")
 
-	errExactNamespaceAbsent = errors.New("exact runtime slot network namespace is absent")
+	errExactNamespaceAbsent     = errors.New("exact runtime slot network namespace is absent")
+	errExactNamespaceUnroutable = errors.New("exact runtime slot network namespace has no routable IPv4 address")
 )
 
 // Config constrains durable state and namespace inspection for one node-local
@@ -714,8 +715,9 @@ func recordMatchesCleanup(record registryRecord, request protocol.NodeCleanupCon
 
 // Snapshot returns the exact physically present warm and claimed desired set
 // and the revision that an external redirect reconciliation may acknowledge.
-// A disappeared namespace is fenced in memory so an orphaned durable record
-// cannot collide with an IP that Nomad has reassigned to a newer allocation.
+// A disappeared or no-longer-routable namespace is fenced in memory so an
+// orphaned durable record cannot collide with an IP that Nomad has reassigned
+// to a newer allocation.
 func (r *Registry) Snapshot() ([]*model.SandboxInfo, uint64, error) {
 	if r == nil {
 		return nil, 0, fmt.Errorf("runtime slot network registry is unavailable: %w", errdefs.ErrUnavailable)
@@ -790,7 +792,11 @@ func (r *Registry) fenceAbsentNamespaces() error {
 			filepath.Join(r.config.NetNSRoot, registration.NetNSRelativePath),
 			registration.NetNSIdentity,
 		)
-		if errors.Is(err, errExactNamespaceAbsent) {
+		// A registered namespace only enters the journal after it has exactly one
+		// routable IPv4 address. If that address is now gone while its recorded IP
+		// collides with another incarnation, it cannot still own the recorded
+		// source IP and must not poison the node-wide desired-state snapshot.
+		if errors.Is(err, errExactNamespaceAbsent) || errors.Is(err, errExactNamespaceUnroutable) {
 			absent = append(absent, candidate)
 			continue
 		}

--- a/ctld/internal/ctld/networking/slotnetwork/registry_test.go
+++ b/ctld/internal/ctld/networking/slotnetwork/registry_test.go
@@ -261,6 +261,81 @@ func TestRegistryFencesAbsentNamespaceBeforeSourceIPReuse(t *testing.T) {
 	}
 }
 
+func TestRegistryFencesUnroutableNamespaceBeforeSourceIPReuse(t *testing.T) {
+	directory := t.TempDir()
+	netnsRoot := filepath.Join(directory, "netns")
+	if err := ensureDirectory(netnsRoot); err != nil {
+		t.Fatal(err)
+	}
+	inspector := &fakeNamespaceInspector{podIP: "192.0.2.8"}
+	registry := newTestRegistry(t, filepath.Join(directory, "network.db"), netnsRoot, inspector, time.Hour)
+	defer registry.Close()
+	autoAcknowledge(registry)
+	first := testRegistrationRequest()
+	if err := registry.Register(t.Context(), first); err != nil {
+		t.Fatal(err)
+	}
+	second := first
+	second.SlotID = "slot-2"
+	second.AllocationID = "allocation-2"
+	second.NetNSRelativePath = "allocation-2"
+	second.NetNSIdentity = "netns-v1:1:3"
+	if err := registry.Register(t.Context(), second); err != nil {
+		t.Fatal(err)
+	}
+	before := registry.Stats().Revision
+	inspector.mu.Lock()
+	inspector.errors = []error{
+		fmt.Errorf("address removed: %w: %w", errExactNamespaceUnroutable, errdefs.ErrUnavailable),
+		nil,
+	}
+	inspector.mu.Unlock()
+	sandboxes, revision, err := registry.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sandboxes) != 1 || sandboxes[0].Name != second.SlotID || sandboxes[0].SourceIP != "192.0.2.8" {
+		t.Fatalf("snapshot after source IP reuse = %+v", sandboxes)
+	}
+	stats := registry.Stats()
+	if revision <= before || stats.Revision != revision || stats.Orphaned != 1 || stats.Warm != 1 {
+		t.Fatalf("registry stats after fencing = %+v, revision %d", stats, revision)
+	}
+}
+
+func TestRegistryKeepsUnknownInspectionFailureFailClosed(t *testing.T) {
+	directory := t.TempDir()
+	netnsRoot := filepath.Join(directory, "netns")
+	if err := ensureDirectory(netnsRoot); err != nil {
+		t.Fatal(err)
+	}
+	inspector := &fakeNamespaceInspector{podIP: "192.0.2.8"}
+	registry := newTestRegistry(t, filepath.Join(directory, "network.db"), netnsRoot, inspector, time.Hour)
+	defer registry.Close()
+	autoAcknowledge(registry)
+	first := testRegistrationRequest()
+	if err := registry.Register(t.Context(), first); err != nil {
+		t.Fatal(err)
+	}
+	second := first
+	second.SlotID = "slot-2"
+	second.AllocationID = "allocation-2"
+	second.NetNSRelativePath = "allocation-2"
+	second.NetNSIdentity = "netns-v1:1:3"
+	if err := registry.Register(t.Context(), second); err != nil {
+		t.Fatal(err)
+	}
+	inspector.mu.Lock()
+	inspector.errors = []error{fmt.Errorf("netlink unavailable: %w", errdefs.ErrUnavailable)}
+	inspector.mu.Unlock()
+	if _, _, err := registry.Snapshot(); !errdefs.IsUnavailable(err) {
+		t.Fatalf("unknown inspection failure = %v", err)
+	}
+	if stats := registry.Stats(); stats.Orphaned != 0 || stats.Warm != 2 {
+		t.Fatalf("registry stats after unknown inspection failure = %+v", stats)
+	}
+}
+
 func TestRegistryRejectsChangedAndLegacyPolicyRequests(t *testing.T) {
 	directory := t.TempDir()
 	netnsRoot := filepath.Join(directory, "netns")


### PR DESCRIPTION
## Summary
- fence a previously registered runtime-slot network incarnation when it has lost its routable IPv4 address and collides with a newer allocation
- preserve fail-closed behavior for unknown namespace inspection failures
- drain the ctld control listener before closing its registry during HA handoff

## Production evidence
A stale failed-claim namespace retained a runsc process after CNI teardown. Its durable source IP had been reassigned, and every ctld startup failed its first network sync with:

```
revalidate runtime slot network namespace ...: network namespace does not have a routable IPv4 address yet: unavailable
```

That prevented ctld readiness and caused the A/B services to restart every 45 seconds. New claims then hit the shutdown window and received `runtime slot network registry is closed`.

## Safety
- records are fenced only in an actual source-IP collision
- a no-address record cannot own or receive traffic for its recorded source IP
- unrelated inspection failures still stop snapshot publication
- claim timeout remains unchanged at 10 seconds

## Tests
- `go test ./...`
- `go test -race ./ctld/internal/ctld/networking/slotnetwork ./ctld/internal/ctld/networking`
