### PR TITLE
fix(rootfs): recover restarted planned retire mounts

### DIFF
--- a/pkg/rootfssession/manager.go
+++ b/pkg/rootfssession/manager.go
@@ -1862,11 +1862,18 @@ func (m *Manager) releaseLocked(ctx context.Context, current record) error {
 		}
 	}
 	var releaseErr error
-	if err := m.runtime.UnmountOverlay(current.MergedRoot, plannedRetire); err != nil {
+	// A planned retirement owned by this process must flush the mounted
+	// filesystem before it publishes a new durable head. After a process
+	// restart there is no live NBD userspace owner left to service syncfs on
+	// the crash-surviving mount; attempting that barrier returns EIO and keeps
+	// the node runtime in a permanent restart loop. The branch journal remains
+	// the recovery boundary in that case and is flushed again by Checkpoint.
+	requireFilesystemSync := plannedRetire && live != nil
+	if err := m.runtime.UnmountOverlay(current.MergedRoot, requireFilesystemSync); err != nil {
 		releaseErr = errors.Join(releaseErr, fmt.Errorf("unmount OverlayFS: %w", err))
 	}
 	if releaseErr == nil {
-		if err := m.runtime.UnmountXFS(current.XFSRoot, plannedRetire); err != nil {
+		if err := m.runtime.UnmountXFS(current.XFSRoot, requireFilesystemSync); err != nil {
 			releaseErr = errors.Join(releaseErr, fmt.Errorf("unmount XFS: %w", err))
 		}
 	}

--- a/pkg/rootfssession/manager_test.go
+++ b/pkg/rootfssession/manager_test.go
@@ -1418,6 +1418,8 @@ func TestManagerPlannedRetireRecoversBranchAfterProcessRestart(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, second.Close()) })
 	require.NoError(t, second.ReleaseParent(t.Context(), request.Parent, request.Identity))
+	require.Equal(t, []bool{false, false}, runtime.unmountSyncSnapshot(),
+		"restart recovery must not sync mounts whose NBD userspace owner disappeared")
 	result, err := second.RetireResult(request.Parent, request.Identity, "retire-restart")
 	require.NoError(t, err)
 	require.Equal(t, rootfsblock.DurabilityComposite, result.DurabilityState)


### PR DESCRIPTION
## Summary

- keep filesystem sync barriers for live planned retirements
- skip an impossible syncfs barrier when startup recovery owns no live NBD userspace session
- checkpoint the recovered block-COW journal before publishing the durable head

## Production evidence

The ali-ue1 fixed worker is drained with zero nonterminal allocations. Both ctld instances restart-loop while reconciling a planned retirement because opening the crash-surviving OverlayFS mount returns EIO after the old NBD userspace owner disappeared. This prevents the ctld runtime socket and all warm carriers from becoming healthy.

## Verification

- `go test ./pkg/rootfssession -run "TestManager(PlannedRetireRecoversBranchAfterProcessRestart|PlannedRetireSealsCompositeGenerationAfterWriterRevocation|PlannedRetireRetriesMaterializationAfterRestart|ReleaseRecoversAfterTerminalDeviceCloseError)$" -count=1`
- `go test ./pkg/rootfssession ./pkg/nomadruntime -count=1`