### PR TITLE
fix(rootfs): reset restored session ownership

### DIFF
--- a/manager/pkg/nomadclaim/service.go
+++ b/manager/pkg/nomadclaim/service.go
@@ -503,10 +503,11 @@ func (s *Service) resumeNomadSandbox(
 			fmt.Errorf("stored runtime assignment changed during resume: %w", err))
 		return nil, nil, s.abortFailedNomadResume(ctx, candidate, resumeErr)
 	}
-	// Runtime generation zero is reserved for a paused fork target that has
-	// never owned a runtime. Its RootFS contains the source sandbox's procd
-	// session identity, which must be cleared exactly once on first resume.
-	plan.assignment.ResetCopiedSessionState = candidate.Record.RuntimeGeneration == 0
+	// A never-run fork or a restored cross-filesystem head contains another
+	// sandbox's procd session identity. Clear it on activation; a later pause
+	// publishes a same-filesystem generation and consumes the durable signal.
+	plan.assignment.ResetCopiedSessionState = candidate.ResetCopiedSessionState ||
+		candidate.Record.RuntimeGeneration == 0
 	if err := plan.assignment.Validate(); err != nil {
 		resumeErr := apierror.NewConflict("sandbox", sandboxID,
 			fmt.Errorf("stored runtime assignment changed during resume: %w", err))

--- a/manager/pkg/nomadclaim/service_test.go
+++ b/manager/pkg/nomadclaim/service_test.go
@@ -1450,6 +1450,24 @@ func TestServiceResetsCopiedSessionStateOnFirstForkResume(t *testing.T) {
 	}
 }
 
+func TestServiceResetsCopiedSessionStateAfterRestoreIntoUsedSandbox(t *testing.T) {
+	fixture := newClaimServiceFixture(t)
+	sandboxID := preparePausedNomadResume(t, fixture)
+	fixture.store.resumeCandidate.ResetCopiedSessionState = true
+
+	response, err := fixture.service.ResumeSandboxAndWait(context.Background(), sandboxID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.SandboxID != sandboxID || len(fixture.planner.requests) != 1 {
+		t.Fatalf("resume response=%+v planner=%+v", response, fixture.planner.requests)
+	}
+	planned := fixture.planner.requests[0]
+	if planned.Runtime.RuntimeGeneration != 2 || !planned.Runtime.ResetCopiedSessionState {
+		t.Fatalf("restored sandbox resume assignment = %+v", planned.Runtime)
+	}
+}
+
 func TestServiceProjectsResumedAndAlreadyActiveNomadRuntime(t *testing.T) {
 	fixture := newClaimServiceFixture(t)
 	sandboxID := preparePausedNomadResume(t, fixture)

--- a/manager/pkg/sandboxstore/composite_materialization.go
+++ b/manager/pkg/sandboxstore/composite_materialization.go
@@ -82,7 +82,8 @@ func (s *PGSandboxStore) ListCompositeRootFSGenerations(ctx context.Context, lim
 			generation.base_artifact_digest, generation.base_block_root,
 			generation.current_block_head, generation.writer_epoch,
 			generation.format_generation, generation.durability_state,
-			generation.locator_version, generation.descriptor, generation.created_at,
+			generation.locator_version, generation.descriptor,
+			generation.reset_copied_session_state, generation.created_at,
 			filesystem.team_id
 		FROM manager.rootfs_generations generation
 		JOIN manager.rootfs_filesystems filesystem
@@ -115,7 +116,8 @@ func (s *PGSandboxStore) ListCompositeRootFSGenerations(ctx context.Context, lim
 			&generation.BaseBlockRoot, &generation.CurrentBlockHead,
 			&generation.WriterEpoch, &generation.FormatGeneration,
 			&generation.DurabilityState, &generation.LocatorVersion,
-			&generation.Descriptor, &generation.CreatedAt,
+			&generation.Descriptor, &generation.ResetCopiedSessionState,
+			&generation.CreatedAt,
 			&generation.MaterializationTeamID,
 		); err != nil {
 			return nil, fmt.Errorf("scan composite rootfs generation: %w", err)

--- a/manager/pkg/sandboxstore/generation.go
+++ b/manager/pkg/sandboxstore/generation.go
@@ -114,7 +114,11 @@ type RootFSGeneration struct {
 	DurabilityState    string
 	LocatorVersion     int64
 	Descriptor         []byte
-	CreatedAt          time.Time
+	// ResetCopiedSessionState is set only on an immutable generation cloned by
+	// cross-sandbox restore. The first successfully activated target runtime
+	// consumes it by publishing its own generation with the default false value.
+	ResetCopiedSessionState bool
+	CreatedAt               time.Time
 	// MaterializationPackLane and MaterializationTeamID are populated only by
 	// regional materialization scans. They prevent shared physical packs from
 	// crossing a tenant or format boundary.
@@ -619,7 +623,8 @@ func getInitialRootFSGenerationForSandbox(
 			g.generation_id, g.filesystem_id, g.parent_generation_id,
 			g.source_oci_digest, g.base_artifact_digest, g.base_block_root,
 			g.current_block_head, g.writer_epoch, g.format_generation,
-			g.durability_state, g.locator_version, g.descriptor, g.created_at
+			g.durability_state, g.locator_version, g.descriptor,
+			g.reset_copied_session_state, g.created_at
 		FROM manager.sandbox_rootfs_bindings b
 		JOIN manager.rootfs_filesystems f ON f.filesystem_id = b.filesystem_id
 		JOIN manager.rootfs_generations g ON g.generation_id = f.head_generation_id
@@ -775,7 +780,8 @@ func getRootFSFilesystemAndGenerationForUpdate(
 			g.generation_id, g.filesystem_id, g.parent_generation_id,
 			g.source_oci_digest, g.base_artifact_digest, g.base_block_root,
 			g.current_block_head, g.writer_epoch, g.format_generation,
-			g.durability_state, g.locator_version, g.descriptor, g.created_at
+			g.durability_state, g.locator_version, g.descriptor,
+			g.reset_copied_session_state, g.created_at
 		FROM manager.sandbox_rootfs_bindings binding
 		JOIN manager.rootfs_filesystems f ON f.filesystem_id = binding.filesystem_id
 		JOIN manager.rootfs_generations g ON g.generation_id = f.head_generation_id
@@ -883,13 +889,15 @@ func insertPreparedRootFSGeneration(ctx context.Context, tx pgx.Tx, generation *
 		INSERT INTO manager.rootfs_generations (
 			generation_id, filesystem_id, parent_generation_id, source_oci_digest,
 			base_artifact_digest, base_block_root, current_block_head, writer_epoch,
-			format_generation, durability_state, locator_version, descriptor, created_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, NOW())
+			format_generation, durability_state, locator_version, descriptor,
+			reset_copied_session_state, created_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW())
 		ON CONFLICT (generation_id) DO NOTHING
 	`, generation.ID, generation.FilesystemID, generation.ParentGenerationID,
 		generation.SourceOCIDigest, generation.BaseArtifactDigest, generation.BaseBlockRoot,
 		generation.CurrentBlockHead, generation.WriterEpoch, generation.FormatGeneration,
-		generation.DurabilityState, generation.LocatorVersion, generation.Descriptor); err != nil {
+		generation.DurabilityState, generation.LocatorVersion, generation.Descriptor,
+		generation.ResetCopiedSessionState); err != nil {
 		return fmt.Errorf("insert prepared rootfs generation: %w", err)
 	}
 	stored, err := scanRootFSGeneration(tx.QueryRow(ctx, rootFSGenerationSelectSQL()+`
@@ -910,7 +918,9 @@ func rootFSGenerationEqual(left, right *RootFSGeneration) bool {
 		left.BaseArtifactDigest == right.BaseArtifactDigest && left.BaseBlockRoot == right.BaseBlockRoot &&
 		left.CurrentBlockHead == right.CurrentBlockHead && left.WriterEpoch == right.WriterEpoch &&
 		left.FormatGeneration == right.FormatGeneration && left.DurabilityState == right.DurabilityState &&
-		left.LocatorVersion == right.LocatorVersion && bytes.Equal(left.Descriptor, right.Descriptor)
+		left.LocatorVersion == right.LocatorVersion &&
+		left.ResetCopiedSessionState == right.ResetCopiedSessionState &&
+		bytes.Equal(left.Descriptor, right.Descriptor)
 }
 
 func initialRootFSGenerationID(filesystemID, artifactDigest string, formatGeneration int) string {
@@ -942,7 +952,8 @@ func initialRootFSGenerationMatches(
 		generation.BaseArtifactDigest == artifact.ArtifactDigest &&
 		generation.BaseBlockRoot == artifact.BaseBlockRoot && generation.CurrentBlockHead == artifact.BaseBlockRoot &&
 		generation.WriterEpoch == 0 && generation.FormatGeneration == artifact.FormatGeneration &&
-		generation.DurabilityState == RootFSGenerationStateS3Materialized
+		generation.DurabilityState == RootFSGenerationStateS3Materialized &&
+		!generation.ResetCopiedSessionState
 }
 
 func rootFSBaseArtifactSelectSQL() string {
@@ -961,7 +972,8 @@ func rootFSGenerationSelectSQL() string {
 	return `
 		SELECT generation_id, filesystem_id, parent_generation_id, source_oci_digest,
 			base_artifact_digest, base_block_root, current_block_head, writer_epoch,
-			format_generation, durability_state, locator_version, descriptor, created_at
+			format_generation, durability_state, locator_version, descriptor,
+			reset_copied_session_state, created_at
 		FROM manager.rootfs_generations `
 }
 
@@ -988,7 +1000,7 @@ func scanRootFSGeneration(row sandboxRecordScanner) (*RootFSGeneration, error) {
 		&generation.SourceOCIDigest, &generation.BaseArtifactDigest, &generation.BaseBlockRoot,
 		&generation.CurrentBlockHead, &generation.WriterEpoch, &generation.FormatGeneration,
 		&generation.DurabilityState, &generation.LocatorVersion, &generation.Descriptor,
-		&generation.CreatedAt); err != nil {
+		&generation.ResetCopiedSessionState, &generation.CreatedAt); err != nil {
 		return nil, err
 	}
 	if parent != nil {
@@ -1012,7 +1024,7 @@ func scanRootFSFilesystemAndGeneration(row sandboxRecordScanner) (*RootFSFilesys
 		&generation.SourceOCIDigest, &generation.BaseArtifactDigest, &generation.BaseBlockRoot,
 		&generation.CurrentBlockHead, &generation.WriterEpoch, &generation.FormatGeneration,
 		&generation.DurabilityState, &generation.LocatorVersion, &generation.Descriptor,
-		&generation.CreatedAt,
+		&generation.ResetCopiedSessionState, &generation.CreatedAt,
 	); err != nil {
 		return nil, nil, err
 	}

--- a/manager/pkg/sandboxstore/generation_integration_test.go
+++ b/manager/pkg/sandboxstore/generation_integration_test.go
@@ -322,6 +322,7 @@ func TestForkRootFSFilesystemSharesBlockGenerationAndPublishesChildWriter(t *tes
 	require.Equal(t, source.ID, target.SourceFilesystemID)
 	require.Equal(t, initial.ID, target.HeadGenerationID)
 	require.Equal(t, int64(0), target.WriterEpoch)
+	requireNomadResumeHeadSessionReset(t, ctx, pool, "sandbox-fork-target", true)
 
 	var generationCount int
 	require.NoError(t, pool.QueryRow(ctx, `
@@ -404,6 +405,7 @@ func TestForkRootFSFilesystemSharesBlockGenerationAndPublishesChildWriter(t *tes
 	require.NoError(t, err)
 	require.Equal(t, target.ID, loadedChild.FilesystemID)
 	require.Equal(t, initial.ID, loadedChild.ParentGenerationID)
+	requireNomadResumeHeadSessionReset(t, ctx, pool, "sandbox-fork-target", false)
 	retired, err := store.GetRootFSWriterGrant(ctx, issue.GrantID)
 	require.NoError(t, err)
 	require.Equal(t, RootFSWriterGrantStateRetired, retired.State)
@@ -1234,6 +1236,7 @@ func TestBlockRootFSSnapshotRestoreCopyAndRollback(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, initial.ID, restored.HeadGenerationID)
 	require.Equal(t, int64(1), restored.WriterEpoch, "head restore must not rewind the writer epoch")
+	requireNomadResumeHeadSessionReset(t, ctx, pool, sourceRecord.ID, false)
 
 	rolledBack, err := store.RollbackRootFSHead(ctx, &RollbackRootFSHeadRequest{
 		SandboxID: sourceRecord.ID, OperationID: "restore-block-initial", TeamID: sourceRecord.TeamID,
@@ -1257,6 +1260,7 @@ func TestBlockRootFSSnapshotRestoreCopyAndRollback(t *testing.T) {
 	require.Equal(t, copied.ID, copiedGeneration.FilesystemID)
 	require.Equal(t, initial.ID, copiedGeneration.ParentGenerationID)
 	require.True(t, rootFSGenerationRestoreContentEqual(initial, copiedGeneration))
+	requireNomadResumeHeadSessionReset(t, ctx, pool, copyRecord.ID, true)
 	replacedCopy, err := store.RestoreRootFSFromSnapshot(ctx, &RestoreRootFSFromSnapshotRequest{
 		SandboxID: copyRecord.ID, SnapshotID: secondSnapshot.ID, TeamID: copyRecord.TeamID,
 		OperationID: "restore-copy-to-second", RollbackExpiresAt: time.Now().Add(time.Hour),
@@ -1269,6 +1273,7 @@ func TestBlockRootFSSnapshotRestoreCopyAndRollback(t *testing.T) {
 	require.Equal(t, replacedCopy.ID, replacedGeneration.FilesystemID)
 	require.Equal(t, second.ID, replacedGeneration.ParentGenerationID)
 	require.True(t, rootFSGenerationRestoreContentEqual(second, replacedGeneration))
+	requireNomadResumeHeadSessionReset(t, ctx, pool, copyRecord.ID, true)
 	retriedReplacement, err := store.RestoreRootFSFromSnapshot(ctx, &RestoreRootFSFromSnapshotRequest{
 		SandboxID: copyRecord.ID, SnapshotID: secondSnapshot.ID, TeamID: copyRecord.TeamID,
 		OperationID: "restore-copy-to-second", RollbackExpiresAt: time.Now().Add(time.Hour),
@@ -1283,11 +1288,28 @@ func TestBlockRootFSSnapshotRestoreCopyAndRollback(t *testing.T) {
 	require.Equal(t, copied.HeadGenerationID, rolledBackCopy.HeadGenerationID)
 	require.Equal(t, replacedCopy.WriterEpoch, rolledBackCopy.WriterEpoch,
 		"rollback must not rewind the target writer epoch")
+	requireNomadResumeHeadSessionReset(t, ctx, pool, copyRecord.ID, true)
 
 	loadedSnapshot, err := store.GetRootFSSnapshot(ctx, snapshot.ID, sourceRecord.TeamID)
 	require.NoError(t, err)
 	require.Equal(t, initial.ID, loadedSnapshot.HeadGenerationID,
 		"moving and rolling back the source head must not mutate the snapshot")
+}
+
+func requireNomadResumeHeadSessionReset(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	sandboxID string,
+	want bool,
+) {
+	t.Helper()
+	tx, err := pool.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(ctx) }()
+	_, _, resetCopiedSessionState, err := lockNomadSandboxResumeHead(ctx, tx, sandboxID)
+	require.NoError(t, err)
+	require.Equal(t, want, resetCopiedSessionState)
 }
 
 func TestBlockRootFSSnapshotRejectsActiveWriter(t *testing.T) {

--- a/manager/pkg/sandboxstore/migration_integration_test.go
+++ b/manager/pkg/sandboxstore/migration_integration_test.go
@@ -129,6 +129,8 @@ func prepareMixedRuntimeSchemaForCutover(t *testing.T, ctx context.Context, pool
 		ALTER TABLE manager.runtime_slots
 			DROP CONSTRAINT runtime_slots_resource_lease_claim,
 			DROP COLUMN resource_lease_id;
+		ALTER TABLE manager.rootfs_generations
+			DROP COLUMN reset_copied_session_state;
 		DROP TABLE manager.runtime_resource_leases;
 		DROP TABLE manager.runtime_node_capacities;
 
@@ -263,6 +265,7 @@ func assertFinalNomadBlockCOWSchema(t *testing.T, ctx context.Context, pool *pgx
 		"rootfs_running_template_captures.snapshot_name",
 		"rootfs_running_template_captures.snapshot_description",
 		"rootfs_running_template_captures.snapshot_expires_at",
+		"rootfs_generations.reset_copied_session_state",
 	} {
 		parts := strings.Split(identity, ".")
 		var exists bool

--- a/manager/pkg/sandboxstore/migrations/00001_nomad_block_cow_baseline.sql
+++ b/manager/pkg/sandboxstore/migrations/00001_nomad_block_cow_baseline.sql
@@ -176,6 +176,7 @@ CREATE TABLE manager.rootfs_generations (
     durability_state text NOT NULL,
     locator_version bigint NOT NULL,
     descriptor bytea NOT NULL,
+    reset_copied_session_state boolean DEFAULT false NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     CONSTRAINT rootfs_generations_check CHECK (((parent_generation_id IS NULL) OR (parent_generation_id <> generation_id))),
     CONSTRAINT rootfs_generations_descriptor_check CHECK ((octet_length(descriptor) <= 65536)),

--- a/manager/pkg/sandboxstore/migrations/00052_rootfs_generation_session_owner.sql
+++ b/manager/pkg/sandboxstore/migrations/00052_rootfs_generation_session_owner.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+
+-- A generation cloned by cross-sandbox restore still contains the source
+-- sandbox's procd session identity. Keep that immutable ownership transition
+-- with the RootFS head so resume retries and manager failover make the same
+-- activation decision. Generations published by a live target runtime retain
+-- the default false value and therefore consume the reset requirement.
+ALTER TABLE manager.rootfs_generations
+    ADD COLUMN IF NOT EXISTS reset_copied_session_state boolean NOT NULL DEFAULT false;
+
+-- +goose Down
+
+ALTER TABLE manager.rootfs_generations
+    DROP COLUMN IF EXISTS reset_copied_session_state;

--- a/manager/pkg/sandboxstore/nomad_resume.go
+++ b/manager/pkg/sandboxstore/nomad_resume.go
@@ -45,7 +45,12 @@ type NomadSandboxResumeCandidate struct {
 	RuntimeGeneration  int64
 	FilesystemID       string
 	SourceGenerationID string
-	Record             *SandboxRecord
+	// ResetCopiedSessionState is true when the exact paused RootFS head contains
+	// another sandbox's session identity and has not yet been activated and
+	// republished by this sandbox. procd must clear the copied identity before
+	// it can activate this runtime.
+	ResetCopiedSessionState bool
+	Record                  *SandboxRecord
 }
 
 // CompleteNomadSandboxResumeRequest commits only an exact command-ready slot
@@ -150,7 +155,7 @@ func (s *PGSandboxStore) RetryNomadSandboxResume(
 	if !record.HardExpiresAt.IsZero() && !record.HardExpiresAt.After(authorityNow) {
 		return nil, false, fmt.Errorf("%w: sandbox hard TTL has expired", ErrNomadSandboxResumeConflict)
 	}
-	filesystemID, sourceGenerationID, err := lockNomadSandboxResumeHead(ctx, tx, record.ID)
+	filesystemID, sourceGenerationID, resetCopiedSessionState, err := lockNomadSandboxResumeHead(ctx, tx, record.ID)
 	if err != nil {
 		return nil, false, err
 	}
@@ -163,7 +168,9 @@ func (s *PGSandboxStore) RetryNomadSandboxResume(
 	if err := tx.Commit(ctx); err != nil {
 		return nil, false, fmt.Errorf("commit Nomad sandbox resume retry: %w", err)
 	}
-	return nomadSandboxResumeCandidate(record, activeLifecycle, filesystemID, sourceGenerationID), true, nil
+	return nomadSandboxResumeCandidate(
+		record, activeLifecycle, filesystemID, sourceGenerationID, resetCopiedSessionState,
+	), true, nil
 }
 
 // RequestNomadSandboxResume reserves active-sandbox quota and creates the
@@ -239,7 +246,7 @@ func (s *PGSandboxStore) RequestNomadSandboxResume(
 		return nil, fmt.Errorf("%w: sandbox hard TTL has expired", ErrNomadSandboxResumeConflict)
 	}
 
-	filesystemID, sourceGenerationID, err := lockNomadSandboxResumeHead(ctx, tx, record.ID)
+	filesystemID, sourceGenerationID, resetCopiedSessionState, err := lockNomadSandboxResumeHead(ctx, tx, record.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +260,9 @@ func (s *PGSandboxStore) RequestNomadSandboxResume(
 		if err := tx.Commit(ctx); err != nil {
 			return nil, fmt.Errorf("commit Nomad sandbox resume retry: %w", err)
 		}
-		return nomadSandboxResumeCandidate(record, activeLifecycle, filesystemID, sourceGenerationID), nil
+		return nomadSandboxResumeCandidate(
+			record, activeLifecycle, filesystemID, sourceGenerationID, resetCopiedSessionState,
+		), nil
 	}
 	if err := ensureNomadResumePhysicalStateTerminal(ctx, tx, record.ID); err != nil {
 		return nil, err
@@ -276,7 +285,9 @@ func (s *PGSandboxStore) RequestNomadSandboxResume(
 	if err := tx.Commit(ctx); err != nil {
 		return nil, fmt.Errorf("commit Nomad sandbox resume request: %w", err)
 	}
-	return nomadSandboxResumeCandidate(record, lifecycle, filesystemID, sourceGenerationID), nil
+	return nomadSandboxResumeCandidate(
+		record, lifecycle, filesystemID, sourceGenerationID, resetCopiedSessionState,
+	), nil
 }
 
 // AbortNomadSandboxResume terminally closes only the exact uncommitted resume
@@ -337,7 +348,7 @@ func (s *PGSandboxStore) AbortNomadSandboxResume(
 		}
 		return false, nil
 	}
-	filesystemID, sourceGenerationID, err := lockNomadSandboxResumeHead(ctx, tx, record.ID)
+	filesystemID, sourceGenerationID, _, err := lockNomadSandboxResumeHead(ctx, tx, record.ID)
 	if err != nil {
 		return false, err
 	}
@@ -445,7 +456,7 @@ func (s *PGSandboxStore) CompleteNomadSandboxResume(
 	if !nomadResumeLifecycleMatches(lifecycle, record, normalized.OperationID, lifecycle.ExpectedGenerationID, false) {
 		return nil, fmt.Errorf("%w: active resume lifecycle changed", ErrNomadSandboxResumeConflict)
 	}
-	filesystemID, sourceGenerationID, err := lockNomadSandboxResumeHead(ctx, tx, record.ID)
+	filesystemID, sourceGenerationID, _, err := lockNomadSandboxResumeHead(ctx, tx, record.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -604,13 +615,18 @@ func validateCompletedRuntimeResourceLease(
 	return slot.ResourceLease.CPUMillicores, memoryMiB, nil
 }
 
-func lockNomadSandboxResumeHead(ctx context.Context, tx pgx.Tx, sandboxID string) (string, string, error) {
+func lockNomadSandboxResumeHead(ctx context.Context, tx pgx.Tx, sandboxID string) (string, string, bool, error) {
 	var filesystemID, generationID string
+	var resetCopiedSessionState bool
 	// A never-run fork points at its source's immutable generation until the
 	// child publishes its first generation, so the head need not be owned by
-	// the child's filesystem yet.
+	// the child's filesystem yet. Snapshot restore records the equivalent
+	// ownership transition explicitly on its cloned generation. A successful
+	// run followed by pause publishes a generation with the flag cleared.
 	err := tx.QueryRow(ctx, `
-		SELECT filesystem.filesystem_id, filesystem.head_generation_id
+		SELECT filesystem.filesystem_id, filesystem.head_generation_id,
+			generation.filesystem_id <> filesystem.filesystem_id OR
+				generation.reset_copied_session_state
 		FROM manager.sandbox_rootfs_bindings AS binding
 		JOIN manager.rootfs_filesystems AS filesystem
 			ON filesystem.filesystem_id = binding.filesystem_id
@@ -618,17 +634,17 @@ func lockNomadSandboxResumeHead(ctx context.Context, tx pgx.Tx, sandboxID string
 			ON generation.generation_id = filesystem.head_generation_id
 		WHERE binding.sandbox_id = $1
 		FOR SHARE OF binding, filesystem, generation
-	`, sandboxID).Scan(&filesystemID, &generationID)
+	`, sandboxID).Scan(&filesystemID, &generationID, &resetCopiedSessionState)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return "", "", fmt.Errorf("%w: paused sandbox RootFS head is missing", ErrNomadSandboxResumeNotReady)
+		return "", "", false, fmt.Errorf("%w: paused sandbox RootFS head is missing", ErrNomadSandboxResumeNotReady)
 	}
 	if err != nil {
-		return "", "", fmt.Errorf("lock Nomad resume RootFS head: %w", err)
+		return "", "", false, fmt.Errorf("lock Nomad resume RootFS head: %w", err)
 	}
 	if filesystemID == "" || generationID == "" {
-		return "", "", fmt.Errorf("%w: paused sandbox RootFS head is invalid", ErrNomadSandboxResumeNotReady)
+		return "", "", false, fmt.Errorf("%w: paused sandbox RootFS head is invalid", ErrNomadSandboxResumeNotReady)
 	}
-	return filesystemID, generationID, nil
+	return filesystemID, generationID, resetCopiedSessionState, nil
 }
 
 func ensureNomadResumePhysicalStateTerminal(ctx context.Context, tx pgx.Tx, sandboxID string) error {
@@ -692,11 +708,13 @@ func nomadSandboxResumeCandidate(
 	lifecycle *SandboxLifecycleTxn,
 	filesystemID string,
 	sourceGenerationID string,
+	resetCopiedSessionState bool,
 ) *NomadSandboxResumeCandidate {
 	return &NomadSandboxResumeCandidate{
 		SandboxID: record.ID, OperationID: lifecycle.ID, LifecyclePhase: lifecycle.Phase,
 		RuntimeGeneration: lifecycle.ToGeneration, FilesystemID: filesystemID,
-		SourceGenerationID: sourceGenerationID, Record: record,
+		SourceGenerationID: sourceGenerationID, ResetCopiedSessionState: resetCopiedSessionState,
+		Record: record,
 	}
 }
 

--- a/manager/pkg/sandboxstore/nomad_resume_integration_test.go
+++ b/manager/pkg/sandboxstore/nomad_resume_integration_test.go
@@ -281,6 +281,7 @@ func TestNomadSandboxResumeStartsNeverRunPausedForkIntegration(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(1), requested.RuntimeGeneration)
 	require.Equal(t, targetFilesystem.HeadGenerationID, requested.SourceGenerationID)
+	require.True(t, requested.ResetCopiedSessionState)
 
 	runtime := prepareNomadResumeRuntime(t, &childFixture, requested, "fork-child")
 	_, err = fixture.store.MarkRuntimeSlotCommandReady(fixture.ctx, &MarkRuntimeSlotCommandReadyRequest{
@@ -301,6 +302,53 @@ func TestNomadSandboxResumeStartsNeverRunPausedForkIntegration(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, SandboxDesiredStateActive, completed.DesiredState)
 	require.Equal(t, int64(1), completed.RuntimeGeneration)
+}
+
+func TestNomadSandboxResumeResetsSessionStateAfterCrossSandboxRestoreIntegration(t *testing.T) {
+	fixture := newNomadPauseStoreFixture(t, "resume-restored-child")
+	terminalizeNomadPauseFixture(t, fixture)
+
+	source := rootFSTestSandboxRecord("sandbox-nomad-resume-restore-source", "team-slot")
+	source.DesiredState = SandboxDesiredStatePaused
+	require.NoError(t, fixture.store.UpsertSandbox(fixture.ctx, source))
+	artifact, err := fixture.store.PutReadyRootFSBaseArtifact(fixture.ctx, readyRootFSBaseArtifactTestRequest())
+	require.NoError(t, err)
+	_, sourceGeneration, err := fixture.store.EnsureInitialRootFSGeneration(
+		fixture.ctx,
+		&EnsureInitialRootFSGenerationRequest{
+			SandboxID: source.ID, TeamID: source.TeamID,
+			SourceOCIRef: artifact.SourceOCIRef, SourceOCIDigest: artifact.SourceOCIDigest,
+			BaseArtifactDigest: artifact.ArtifactDigest,
+		},
+	)
+	require.NoError(t, err)
+	snapshot, err := fixture.store.CreateRootFSSnapshot(fixture.ctx, &CreateRootFSSnapshotRequest{
+		SandboxID: source.ID, SnapshotID: "snapshot-nomad-resume-restore-source",
+	})
+	require.NoError(t, err)
+	require.Equal(t, sourceGeneration.ID, snapshot.HeadGenerationID)
+
+	restored, err := fixture.store.RestoreRootFSFromSnapshot(fixture.ctx, &RestoreRootFSFromSnapshotRequest{
+		SandboxID: fixture.sandboxID, SnapshotID: snapshot.ID, TeamID: source.TeamID,
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, sourceGeneration.ID, restored.HeadGenerationID)
+
+	requested, err := fixture.store.RequestNomadSandboxResume(fixture.ctx, &RequestNomadSandboxResumeRequest{
+		SandboxID: fixture.sandboxID, ExpectedTeamID: source.TeamID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), requested.RuntimeGeneration)
+	require.Equal(t, restored.HeadGenerationID, requested.SourceGenerationID)
+	require.True(t, requested.ResetCopiedSessionState)
+
+	retry, found, err := fixture.store.RetryNomadSandboxResume(fixture.ctx, &RetryNomadSandboxResumeRequest{
+		SandboxID: fixture.sandboxID, ExpectedTeamID: source.TeamID,
+	})
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, requested.OperationID, retry.OperationID)
+	require.True(t, retry.ResetCopiedSessionState)
 }
 
 func TestNomadSandboxResumeFencesLateCommandReadyAfterAbortIntegration(t *testing.T) {

--- a/manager/pkg/sandboxstore/rootfs.go
+++ b/manager/pkg/sandboxstore/rootfs.go
@@ -535,7 +535,8 @@ func restoreRootFSFromSnapshot(ctx context.Context, tx pgx.Tx, req *RestoreRootF
 				generation.base_artifact_digest, generation.base_block_root,
 				generation.current_block_head, generation.writer_epoch,
 				generation.format_generation, generation.durability_state,
-				generation.locator_version, generation.descriptor, generation.created_at
+				generation.locator_version, generation.descriptor,
+				generation.reset_copied_session_state, generation.created_at
 			FROM manager.rootfs_snapshots snapshot
 			JOIN manager.rootfs_generations generation
 				ON generation.generation_id = snapshot.head_generation_id
@@ -577,7 +578,8 @@ func restoreRootFSFromSnapshot(ctx context.Context, tx pgx.Tx, req *RestoreRootF
 			snapshot.base_artifact_digest, snapshot.base_block_root,
 			snapshot.current_block_head, snapshot.writer_epoch,
 			snapshot.format_generation, snapshot.durability_state,
-			snapshot.locator_version, snapshot.descriptor, snapshot.created_at,
+			snapshot.locator_version, snapshot.descriptor,
+			snapshot.reset_copied_session_state, snapshot.created_at,
 			binding.filesystem_id, target.team_id, snapshot.snapshot_filesystem_id,
 			COALESCE(filesystem.writer_epoch, snapshot.writer_epoch),
 			COALESCE(filesystem.head_generation_id, ''),
@@ -604,7 +606,7 @@ func restoreRootFSFromSnapshot(ctx context.Context, tx pgx.Tx, req *RestoreRootF
 		&snapshotGeneration.CurrentBlockHead, &snapshotGeneration.WriterEpoch,
 		&snapshotGeneration.FormatGeneration, &snapshotGeneration.DurabilityState,
 		&snapshotGeneration.LocatorVersion, &snapshotGeneration.Descriptor,
-		&snapshotGeneration.CreatedAt,
+		&snapshotGeneration.ResetCopiedSessionState, &snapshotGeneration.CreatedAt,
 		&targetFilesystemID, &targetTeamID, &snapshotFilesystemID,
 		&targetWriterEpoch, &previousGenerationID, &targetExists,
 	)
@@ -626,6 +628,7 @@ func restoreRootFSFromSnapshot(ctx context.Context, tx pgx.Tx, req *RestoreRootF
 			return nil, fmt.Errorf("load restore target rootfs generation: %w", loadErr)
 		}
 		if previousGeneration.FilesystemID == targetFilesystemID &&
+			previousGeneration.ResetCopiedSessionState &&
 			rootFSGenerationRestoreContentEqual(previousGeneration, &snapshotGeneration) {
 			selectedGeneration = previousGeneration
 			cloneGeneration = false
@@ -648,7 +651,7 @@ func restoreRootFSFromSnapshot(ctx context.Context, tx pgx.Tx, req *RestoreRootF
 			BaseBlockRoot:      snapshotGeneration.BaseBlockRoot, CurrentBlockHead: snapshotGeneration.CurrentBlockHead,
 			WriterEpoch: newWriterEpoch, FormatGeneration: snapshotGeneration.FormatGeneration,
 			DurabilityState: snapshotGeneration.DurabilityState, LocatorVersion: snapshotGeneration.LocatorVersion,
-			Descriptor: append([]byte(nil), snapshotGeneration.Descriptor...),
+			Descriptor: append([]byte(nil), snapshotGeneration.Descriptor...), ResetCopiedSessionState: true,
 		}
 	}
 


### PR DESCRIPTION
## Summary
- persist copied procd session ownership on immutable RootFS generations created by cross-sandbox restore
- project the exact head marker through request/retry resume so restored sandboxes reset copied session state even after prior runtime generations
- consume the marker naturally when the target runtime later publishes its own generation
- add fresh/upgrade schema coverage and restore/fork/resume transaction coverage

## Production symptom
A forked sandbox resumed successfully once, then after pause and restore from the source snapshot, procd never became command-ready. The failed allocation was reclaimed and the next retry reported an absent runtime-slot network namespace. Runtime generation alone only recognized never-run forks and missed restore into an already-used sandbox.

## Validation
- full sandboxstore + nomadclaim PostgreSQL race tests
- full repository unit/architecture race tests
- targeted fresh-schema and upgrade migration tests
- targeted cross-sandbox restore request/retry resume test
- go vet for touched packages
- go mod tidy clean