### PR TITLE
ops(nomad): warn on slow runtime slot claims

### DIFF
--- a/nomad-driver-sandbox0/internal/driver/handle.go
+++ b/nomad-driver-sandbox0/internal/driver/handle.go
@@ -168,6 +168,27 @@ type claimTimings struct {
 	activeStatePersist time.Duration
 }
 
+func (h *taskHandle) logClaimTimings(success bool, elapsed time.Duration, timings claimTimings) {
+	args := []any{
+		"success", success,
+		"claim_duration_us", elapsed.Microseconds(),
+		"bundle_write_us", timings.bundleWrite.Microseconds(),
+		"claim_state_persist_us", timings.claimStatePersist.Microseconds(),
+		"rootfs_ensure_us", timings.rootFSEnsure.Microseconds(),
+		"consumer_register_us", timings.consumerRegister.Microseconds(),
+		"rootfs_bind_us", timings.rootFSBind.Microseconds(),
+		"starting_report_us", timings.startingReport.Microseconds(),
+		"runsc_create_us", timings.runscCreate.Microseconds(),
+		"runsc_start_us", timings.runscStart.Microseconds(),
+		"active_state_persist_us", timings.activeStatePersist.Microseconds(),
+	}
+	if !success || elapsed >= time.Second {
+		h.logger.Warn("Runtime slot claim timing", args...)
+		return
+	}
+	h.logger.Info("Runtime slot claim timing", args...)
+}
+
 func (h *taskHandle) statePath() string {
 	return filepath.Join(h.bundleDir, ".sandbox0-driver-state.json")
 }
@@ -470,19 +491,7 @@ func (h *taskHandle) Claim(request ClaimRequest) (resultErr error) {
 	claimStarted := time.Now()
 	timings := claimTimings{}
 	defer func() {
-		h.logger.Info("Runtime slot claim timing",
-			"success", resultErr == nil,
-			"claim_duration_us", time.Since(claimStarted).Microseconds(),
-			"bundle_write_us", timings.bundleWrite.Microseconds(),
-			"claim_state_persist_us", timings.claimStatePersist.Microseconds(),
-			"rootfs_ensure_us", timings.rootFSEnsure.Microseconds(),
-			"consumer_register_us", timings.consumerRegister.Microseconds(),
-			"rootfs_bind_us", timings.rootFSBind.Microseconds(),
-			"starting_report_us", timings.startingReport.Microseconds(),
-			"runsc_create_us", timings.runscCreate.Microseconds(),
-			"runsc_start_us", timings.runscStart.Microseconds(),
-			"active_state_persist_us", timings.activeStatePersist.Microseconds(),
-		)
+		h.logClaimTimings(resultErr == nil, time.Since(claimStarted), timings)
 	}()
 
 	if request.PolicyToken == "" || request.WriterEpoch == "" {

--- a/nomad-driver-sandbox0/internal/driver/runtime_slot_test.go
+++ b/nomad-driver-sandbox0/internal/driver/runtime_slot_test.go
@@ -630,6 +630,17 @@ func runtimeSlotAssignment() *runtimecontrol.Assignment {
 	}
 }
 
+func TestSlowRuntimeSlotClaimTimingIsWarning(t *testing.T) {
+	var claimLogs bytes.Buffer
+	handle := newTaskHandle(taskHandleOptions{logger: hclog.New(&hclog.LoggerOptions{
+		Output: &claimLogs, JSONFormat: true, Level: hclog.Info,
+	})})
+	handle.logClaimTimings(true, time.Second, claimTimings{})
+	if log := claimLogs.String(); !strings.Contains(log, `"@level":"warn"`) {
+		t.Fatalf("slow claim timing log = %q, want warning level", log)
+	}
+}
+
 func TestRuntimeSlotClaimRetriesStartingBeforeRunscCreate(t *testing.T) {
 	fixture := newRuntimeSlotPluginFixture(t)
 	var claimLogs bytes.Buffer


### PR DESCRIPTION
## Summary
- retain Info logs for successful claims below the existing one-second readiness budget
- emit the same structured timing at Warn for failed or >=1s claims so Nomad persists actionable misses
- verify the one-second boundary selects warning level

This does not change claim behavior or timeouts.

## Validation
- `go test ./...` in `nomad-driver-sandbox0`
- `go vet ./...` in `nomad-driver-sandbox0`
- focused driver tests and vet after the warning-boundary adjustment
- `git diff --check`