### PR TITLE
fix(runtime): retire writers from failed terminating resumes

### DIFF
--- a/manager/pkg/runtimeslotwriter/controller.go
+++ b/manager/pkg/runtimeslotwriter/controller.go
@@ -35,6 +35,10 @@ type sandboxRuntimeSlotReader interface {
 	GetRuntimeSlot(context.Context, string) (*sandboxstore.RuntimeSlot, error)
 }
 
+type sandboxLifecycleReader interface {
+	GetLifecycleTxn(context.Context, string) (*sandboxstore.SandboxLifecycleTxn, error)
+}
+
 type sandboxCrashLifecycleStarter interface {
 	BeginOrRestartRootFSWriterCrashLifecycleTxn(context.Context, *sandboxstore.SandboxLifecycleTxn) error
 }
@@ -288,16 +292,54 @@ func (c *Controller) ensureCrashLifecycle(
 			}
 			failedInitialClaim = claim != nil && claim.Phase == sandboxstore.SandboxRuntimeClaimPhaseCleanupPending
 		}
+		terminatingFailedResume := false
+		terminatingFailedResumeCandidate := record != nil && record.DeletedAt.IsZero() &&
+			record.DesiredState == sandboxstore.SandboxDesiredStateTerminating &&
+			record.RuntimeNamespace == "" && record.RuntimeID == "" &&
+			record.RuntimeGeneration >= 0 && record.RuntimeGeneration+1 == runtimeGeneration &&
+			!failedInitialClaim
+		if terminatingFailedResumeCandidate {
+			claimReader, ok := tx.(sandboxRuntimeClaimReader)
+			if !ok {
+				return errors.New("sandbox transaction cannot inspect terminated Nomad resume cleanup")
+			}
+			claim, err := claimReader.GetSandboxRuntimeClaim(lockCtx, grant.SandboxID)
+			if err != nil {
+				return err
+			}
+			slotReader, ok := tx.(sandboxRuntimeSlotReader)
+			if !ok {
+				return errors.New("sandbox transaction cannot inspect the terminated Nomad resume slot")
+			}
+			slot, err := slotReader.GetRuntimeSlot(lockCtx, request.SlotID)
+			if err != nil {
+				return err
+			}
+			lifecycleReader, ok := tx.(sandboxLifecycleReader)
+			if !ok {
+				return errors.New("sandbox transaction cannot inspect the terminated Nomad resume lifecycle")
+			}
+			resume, err := lifecycleReader.GetLifecycleTxn(lockCtx, slot.ClaimOperationID)
+			if err != nil {
+				return err
+			}
+			terminatingFailedResume = claim != nil &&
+				claim.Phase == sandboxstore.SandboxRuntimeClaimPhaseCleanupPending &&
+				terminatingFailedResumeLifecycleMatches(resume, record, grant, slot, runtimeGeneration)
+		}
+		deletedFailedClaim := record != nil && record.DesiredState == sandboxstore.SandboxDesiredStateDeleted &&
+			!record.DeletedAt.IsZero() && record.RuntimeNamespace == "" && record.RuntimeID == "" &&
+			record.RuntimeGeneration == runtimeGeneration
 		fromRuntimeNamespace, fromRuntimeID := grant.RuntimeNamespace, grant.RuntimeIncarnationID
 		switch {
 		case regularRuntime && record.RuntimeNamespace == grant.RuntimeNamespace &&
 			record.RuntimeID == grant.RuntimeIncarnationID:
 			fromRuntimeNamespace = record.RuntimeNamespace
 			fromRuntimeID = record.RuntimeID
-		case failedInitialClaim, precommitResume:
+		case failedInitialClaim, precommitResume, terminatingFailedResume, deletedFailedClaim:
 			// A first claim publishes generation 1 only after command readiness.
-			// Cleanup must therefore accept the durable generation-0 identity
-			// while fencing the exact generation-1 writer bound to its slot.
+			// Cleanup must also survive termination or deletion clearing the
+			// runtime identity after the exact failed attempt was fenced.
 		default:
 			return errors.New("sandbox runtime does not match the runtime slot writer")
 		}
@@ -317,6 +359,36 @@ func (c *Controller) ensureCrashLifecycle(
 		return fmt.Errorf("prepare runtime slot writer crash lifecycle: %w", err)
 	}
 	return nil
+}
+
+func terminatingFailedResumeLifecycleMatches(
+	resume *sandboxstore.SandboxLifecycleTxn,
+	record *sandboxstore.SandboxRecord,
+	grant *sandboxstore.RootFSWriterGrant,
+	slot *sandboxstore.RuntimeSlot,
+	runtimeGeneration int64,
+) bool {
+	return resume != nil && record != nil && grant != nil && slot != nil &&
+		resume.ID == slot.ClaimOperationID && resume.SandboxID == record.ID &&
+		resume.Kind == sandboxstore.SandboxLifecycleKindResume &&
+		resume.Source == sandboxstore.SandboxLifecycleSourceManual && !resume.Cancelable &&
+		resume.Phase == sandboxstore.SandboxLifecyclePhaseAborted &&
+		resume.CancelRequestedAt.IsZero() && !resume.AbortedAt.IsZero() && resume.Error != "" &&
+		resume.Epoch > 0 &&
+		resume.FromGeneration == record.RuntimeGeneration && resume.ToGeneration == runtimeGeneration &&
+		resume.ToGeneration == resume.FromGeneration+1 &&
+		resume.FromRuntimeNamespace == "" && resume.FromRuntimeID == "" &&
+		resume.ToRuntimeNamespace == "" && resume.ToRuntimeID == "" &&
+		resume.ExpectedGenerationID == grant.InitialGenerationID && resume.PreparedGenerationID == "" &&
+		resume.ID == sandboxstore.NomadSandboxResumeOperationID(
+			record.ID, resume.FromGeneration, resume.ExpectedGenerationID, resume.Epoch,
+		) &&
+		slot.ID == grant.SlotID && slot.SandboxID == record.ID && slot.WriterGrantID == grant.ID &&
+		slot.ClaimID == grant.ClaimID && slot.SourceGenerationID == grant.InitialGenerationID &&
+		slot.AllocationID == grant.RuntimeIncarnationID &&
+		slot.AllocationNamespace == grant.RuntimeNamespace &&
+		(slot.State == sandboxstore.RuntimeSlotStateQuiescing ||
+			slot.State == sandboxstore.RuntimeSlotStateOrphaned)
 }
 
 func precommitResumeLifecycleMatches(

--- a/manager/pkg/runtimeslotwriter/controller_test.go
+++ b/manager/pkg/runtimeslotwriter/controller_test.go
@@ -121,6 +121,13 @@ func (f fakeTx) GetActiveLifecycleTxn(context.Context, string) (*sandboxstore.Sa
 	return cloneLifecycle(f.store.lifecycle), nil
 }
 
+func (f fakeTx) GetLifecycleTxn(_ context.Context, txnID string) (*sandboxstore.SandboxLifecycleTxn, error) {
+	if f.store.lifecycle == nil || f.store.lifecycle.ID != txnID {
+		return nil, errors.New("sandbox lifecycle not found")
+	}
+	return cloneLifecycle(f.store.lifecycle), nil
+}
+
 func (f fakeTx) BeginLifecycleTxn(_ context.Context, txn *sandboxstore.SandboxLifecycleTxn) error {
 	if f.store.lifecycle != nil && f.store.lifecycle.Phase != sandboxstore.SandboxLifecyclePhaseAborted &&
 		f.store.lifecycle.Phase != sandboxstore.SandboxLifecyclePhaseCommitted {
@@ -441,6 +448,120 @@ func TestControllerRejectsGenerationGapForFailedInitialClaim(t *testing.T) {
 		SandboxID: store.record.ID, OperationID: "claim-operation-1",
 		Phase: sandboxstore.SandboxRuntimeClaimPhaseCleanupPending,
 	}
+	_, err := controller.Fence(context.Background(), request)
+	if err == nil || store.lifecycle != nil || store.beginCalls != 0 {
+		t.Fatalf("Fence() = %v, lifecycle = %+v, begin calls = %d", err, store.lifecycle, store.beginCalls)
+	}
+}
+
+func TestControllerFencesConsumedWriterAfterFailedClaimDeletion(t *testing.T) {
+	store, controller, request := newFixture(t, sandboxstore.RootFSWriterGrantStateConsumed)
+	store.record.DesiredState = sandboxstore.SandboxDesiredStateDeleted
+	store.record.DeletedAt = time.Now().UTC()
+	store.record.RuntimeNamespace = ""
+	store.record.RuntimeID = ""
+
+	fence, err := controller.Fence(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Fence() error = %v", err)
+	}
+	if len(fence.ProofDigest) != 32 || store.lifecycle == nil ||
+		store.lifecycle.FromGeneration != store.record.RuntimeGeneration ||
+		store.lifecycle.FromRuntimeNamespace != store.grant.RuntimeNamespace ||
+		store.lifecycle.FromRuntimeID != store.grant.RuntimeIncarnationID {
+		t.Fatalf("fence = %+v lifecycle = %+v", fence, store.lifecycle)
+	}
+}
+
+func TestControllerFencesConsumedWriterAfterFailedResumeTermination(t *testing.T) {
+	store, controller, request := newFixture(t, sandboxstore.RootFSWriterGrantStateConsumed)
+	store.record.DesiredState = sandboxstore.SandboxDesiredStateTerminating
+	store.record.RuntimeGeneration = 6
+	store.record.RuntimeNamespace = ""
+	store.record.RuntimeID = ""
+	store.record.LifecycleEpoch = 4
+	resumeOperationID := sandboxstore.NomadSandboxResumeOperationID(
+		store.record.ID, store.record.RuntimeGeneration, store.grant.InitialGenerationID, store.record.LifecycleEpoch,
+	)
+	store.claim = &sandboxstore.SandboxRuntimeClaim{
+		SandboxID: store.record.ID, OperationID: "initial-claim-operation",
+		Phase: sandboxstore.SandboxRuntimeClaimPhaseCleanupPending,
+	}
+	store.lifecycle = &sandboxstore.SandboxLifecycleTxn{
+		ID: resumeOperationID, SandboxID: store.record.ID,
+		Kind: sandboxstore.SandboxLifecycleKindResume, Phase: sandboxstore.SandboxLifecyclePhaseAborted,
+		Source: sandboxstore.SandboxLifecycleSourceManual, Epoch: store.record.LifecycleEpoch,
+		FromGeneration: store.record.RuntimeGeneration, ToGeneration: store.record.RuntimeGeneration + 1,
+		ExpectedGenerationID: store.grant.InitialGenerationID,
+		Error:                "resume runtime did not reach command-ready", AbortedAt: time.Now().UTC(),
+	}
+	store.slot = &sandboxstore.RuntimeSlot{
+		ID: store.grant.SlotID, SandboxID: store.record.ID, ClaimOperationID: resumeOperationID,
+		ClaimID: store.grant.ClaimID, WriterGrantID: store.grant.ID,
+		SourceGenerationID: store.grant.InitialGenerationID,
+		AllocationID:       store.grant.RuntimeIncarnationID, AllocationNamespace: store.grant.RuntimeNamespace,
+		State: sandboxstore.RuntimeSlotStateQuiescing,
+	}
+
+	fence, err := controller.Fence(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Fence() error = %v", err)
+	}
+	if len(fence.ProofDigest) != 32 || store.lifecycle == nil ||
+		store.lifecycle.ID != request.OperationID ||
+		store.lifecycle.Kind != sandboxstore.SandboxLifecycleKindPause ||
+		store.lifecycle.Source != sandboxstore.SandboxLifecycleSourceCrash ||
+		store.lifecycle.FromGeneration != 7 ||
+		store.lifecycle.FromRuntimeNamespace != store.grant.RuntimeNamespace ||
+		store.lifecycle.FromRuntimeID != store.grant.RuntimeIncarnationID {
+		t.Fatalf("fence = %+v lifecycle = %+v", fence, store.lifecycle)
+	}
+}
+
+func TestControllerRejectsTerminatingResumeOwnedByAnotherSlot(t *testing.T) {
+	store, controller, request := newFixture(t, sandboxstore.RootFSWriterGrantStateConsumed)
+	store.record.DesiredState = sandboxstore.SandboxDesiredStateTerminating
+	store.record.RuntimeGeneration = 6
+	store.record.RuntimeNamespace = ""
+	store.record.RuntimeID = ""
+	store.record.LifecycleEpoch = 4
+	resumeOperationID := sandboxstore.NomadSandboxResumeOperationID(
+		store.record.ID, store.record.RuntimeGeneration, store.grant.InitialGenerationID, store.record.LifecycleEpoch,
+	)
+	store.claim = &sandboxstore.SandboxRuntimeClaim{
+		SandboxID: store.record.ID, OperationID: "initial-claim-operation",
+		Phase: sandboxstore.SandboxRuntimeClaimPhaseCleanupPending,
+	}
+	store.lifecycle = &sandboxstore.SandboxLifecycleTxn{
+		ID: resumeOperationID, SandboxID: store.record.ID,
+		Kind: sandboxstore.SandboxLifecycleKindResume, Phase: sandboxstore.SandboxLifecyclePhaseAborted,
+		Source: sandboxstore.SandboxLifecycleSourceManual, Epoch: store.record.LifecycleEpoch,
+		FromGeneration: store.record.RuntimeGeneration, ToGeneration: store.record.RuntimeGeneration + 1,
+		ExpectedGenerationID: store.grant.InitialGenerationID,
+		Error:                "resume runtime did not reach command-ready", AbortedAt: time.Now().UTC(),
+	}
+	store.slot = &sandboxstore.RuntimeSlot{
+		ID: store.grant.SlotID, SandboxID: store.record.ID, ClaimOperationID: "another-resume-operation",
+		ClaimID: store.grant.ClaimID, WriterGrantID: store.grant.ID,
+		SourceGenerationID: store.grant.InitialGenerationID,
+		AllocationID:       store.grant.RuntimeIncarnationID, AllocationNamespace: store.grant.RuntimeNamespace,
+		State: sandboxstore.RuntimeSlotStateQuiescing,
+	}
+
+	_, err := controller.Fence(context.Background(), request)
+	if err == nil || store.lifecycle.ID != resumeOperationID || store.beginCalls != 0 {
+		t.Fatalf("Fence() = %v, lifecycle = %+v, begin calls = %d", err, store.lifecycle, store.beginCalls)
+	}
+}
+
+func TestControllerRejectsDeletedSandboxAtAnotherRuntimeGeneration(t *testing.T) {
+	store, controller, request := newFixture(t, sandboxstore.RootFSWriterGrantStateConsumed)
+	store.record.DesiredState = sandboxstore.SandboxDesiredStateDeleted
+	store.record.DeletedAt = time.Now().UTC()
+	store.record.RuntimeNamespace = ""
+	store.record.RuntimeID = ""
+	store.record.RuntimeGeneration++
+
 	_, err := controller.Fence(context.Background(), request)
 	if err == nil || store.lifecycle != nil || store.beginCalls != 0 {
 		t.Fatalf("Fence() = %v, lifecycle = %+v, begin calls = %d", err, store.lifecycle, store.beginCalls)

--- a/manager/pkg/sandboxstore/store.go
+++ b/manager/pkg/sandboxstore/store.go
@@ -1029,6 +1029,20 @@ func (t sandboxStoreTx) GetActiveLifecycleTxn(ctx context.Context, sandboxID str
 	return getActiveLifecycleTxn(ctx, t.tx, sandboxID)
 }
 
+// GetLifecycleTxn returns an exact lifecycle while the sandbox row is already
+// locked. Recovery controllers use this narrower concrete capability to prove
+// ownership of an aborted runtime attempt without widening SandboxStoreTx.
+func (t sandboxStoreTx) GetLifecycleTxn(ctx context.Context, txnID string) (*SandboxLifecycleTxn, error) {
+	txnID = strings.TrimSpace(txnID)
+	if txnID == "" {
+		return nil, fmt.Errorf("txn_id is required")
+	}
+	return scanLifecycleTxn(t.tx.QueryRow(ctx, lifecycleTxnSelectSQL()+`
+		WHERE txn_id = $1
+		FOR SHARE
+	`, txnID))
+}
+
 func (t sandboxStoreTx) BeginLifecycleTxn(ctx context.Context, txn *SandboxLifecycleTxn) error {
 	if txn == nil {
 		return nil

--- a/manager/pkg/sandboxstore/writer_grant.go
+++ b/manager/pkg/sandboxstore/writer_grant.go
@@ -1628,11 +1628,13 @@ func completeRootFSWriterCrashAbandon(
 }
 
 type rootFSWriterCrashRuntimeMatch struct {
-	active              bool
-	terminating         bool
-	failedClaimCleanup  bool
-	failedClaimDeletion bool
-	renewalRevoked      bool
+	active                  bool
+	terminating             bool
+	precommitResume         bool
+	terminatingFailedResume bool
+	failedClaimCleanup      bool
+	failedClaimDeletion     bool
+	renewalRevoked          bool
 }
 
 func lockRootFSWriterCrashRuntime(
@@ -1663,7 +1665,7 @@ func lockRootFSWriterCrashRuntime(
 	match.terminating = !deletedAt.Valid && desiredState == SandboxDesiredStateTerminating &&
 		runtimeGeneration == lifecycle.FromGeneration &&
 		currentRuntimeNamespace == lifecycle.FromRuntimeNamespace && currentRuntimeID == lifecycle.FromRuntimeID
-	precommitResume := !deletedAt.Valid && desiredState == SandboxDesiredStatePaused &&
+	match.precommitResume = !deletedAt.Valid && desiredState == SandboxDesiredStatePaused &&
 		currentRuntimeNamespace == "" && currentRuntimeID == "" && runtimeGeneration >= 0 &&
 		runtimeGeneration+1 == lifecycle.FromGeneration
 	if err := db.QueryRow(ctx, `
@@ -1679,6 +1681,46 @@ func lockRootFSWriterCrashRuntime(
 		record.NodeUID, record.NodeBootID, RuntimeSlotStateQuiescing, RuntimeSlotStateOrphaned,
 	).Scan(&match.renewalRevoked); err != nil {
 		return match, fmt.Errorf("verify runtime slot writer renewal fence: %w", err)
+	}
+	terminatingFailedResumeCandidate := !deletedAt.Valid && desiredState == SandboxDesiredStateTerminating &&
+		currentRuntimeNamespace == "" && currentRuntimeID == "" && runtimeGeneration >= 0 &&
+		runtimeGeneration+1 == lifecycle.FromGeneration && match.renewalRevoked
+	if terminatingFailedResumeCandidate {
+		if err := db.QueryRow(ctx, `
+			SELECT EXISTS (
+				SELECT 1
+				FROM manager.sandbox_runtime_claims AS claim
+				JOIN manager.runtime_slots AS slot
+					ON slot.sandbox_id = claim.sandbox_id
+				JOIN manager.sandbox_lifecycle_txns AS resume
+					ON resume.txn_id = slot.claim_operation_id
+					AND resume.sandbox_id = slot.sandbox_id
+				WHERE claim.sandbox_id = $1 AND claim.phase = $2
+					AND slot.slot_id = $3 AND slot.writer_grant_id = $4
+					AND slot.claim_id = $5 AND slot.filesystem_id = $6
+					AND slot.node_uid = $7 AND slot.node_boot_id = $8
+					AND slot.source_generation_id = $9
+					AND slot.allocation_namespace = $10 AND slot.allocation_id = $11
+					AND slot.state IN ($12, $13)
+					AND resume.kind = $14 AND resume.source = $15 AND resume.phase = $16
+					AND resume.cancelable = FALSE AND resume.cancel_requested_at IS NULL
+					AND resume.epoch > 0 AND resume.from_generation = $17
+					AND resume.to_generation = $18
+					AND resume.from_runtime_namespace = '' AND resume.from_runtime_id = ''
+					AND resume.to_runtime_namespace = '' AND resume.to_runtime_id = ''
+					AND resume.expected_generation_id = $9 AND resume.prepared_generation_id = ''
+					AND resume.error <> '' AND resume.aborted_at IS NOT NULL
+			)
+		`, record.SandboxID, SandboxRuntimeClaimPhaseCleanupPending,
+			record.SlotID, record.ID, record.ClaimID, record.FilesystemID,
+			record.NodeUID, record.NodeBootID, record.InitialGenerationID,
+			record.RuntimeNamespace, record.RuntimeIncarnationID,
+			RuntimeSlotStateQuiescing, RuntimeSlotStateOrphaned,
+			SandboxLifecycleKindResume, SandboxLifecycleSourceManual, SandboxLifecyclePhaseAborted,
+			runtimeGeneration, lifecycle.FromGeneration,
+		).Scan(&match.terminatingFailedResume); err != nil {
+			return match, fmt.Errorf("verify terminated failed Nomad resume: %w", err)
+		}
 	}
 	match.failedClaimDeletion = desiredState == SandboxDesiredStateDeleted && deletedAt.Valid &&
 		currentRuntimeNamespace == "" && currentRuntimeID == "" && runtimeGeneration == lifecycle.FromGeneration
@@ -1712,8 +1754,8 @@ func lockRootFSWriterCrashRuntime(
 		// logical claim worker no longer exposes cleanup_pending.
 		match.failedClaimCleanup = true
 	}
-	if !match.active && !match.terminating && !precommitResume &&
-		!match.failedClaimCleanup && !match.failedClaimDeletion {
+	if !match.active && !match.terminating && !match.precommitResume &&
+		!match.terminatingFailedResume && !match.failedClaimCleanup && !match.failedClaimDeletion {
 		return match, fmt.Errorf("%w: sandbox runtime no longer matches crash lifecycle txn %s",
 			ErrRootFSWriterGrantConflict, lifecycleTxnID)
 	}

--- a/manager/pkg/sandboxstore/writer_grant_integration_test.go
+++ b/manager/pkg/sandboxstore/writer_grant_integration_test.go
@@ -733,6 +733,158 @@ func TestRootFSWriterCrashAbandonCompletesAbandonedInitialNomadClaimIntegration(
 	require.Equal(t, SandboxRuntimeClaimPhaseCleaned, claimPhase)
 }
 
+func TestRootFSWriterCrashAbandonCompletesTerminatedFailedResumeIntegration(t *testing.T) {
+	ctx := context.Background()
+	pool := newSandboxStoreIntegrationPool(t)
+	store := NewPGSandboxStore(pool)
+	record, filesystem, generation, registration := sandboxRuntimeClaimReadySlotFixture(
+		t, store, "terminated-failed-resume-writer",
+	)
+	_, err := pool.Exec(ctx, `
+		UPDATE manager.sandbox_runtime_claims
+		SET phase = $2, lease_expires_at = NULL, completed_at = NOW()
+		WHERE sandbox_id = $1
+	`, record.ID, SandboxRuntimeClaimPhaseReady)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		UPDATE manager.sandboxes
+		SET desired_state = $2, runtime_generation = 1,
+			runtime_namespace = '', runtime_id = ''
+		WHERE sandbox_id = $1
+	`, record.ID, SandboxDesiredStatePaused)
+	require.NoError(t, err)
+	record, err = store.GetSandbox(ctx, record.ID)
+	require.NoError(t, err)
+	resumeOperationID := NomadSandboxResumeOperationID(
+		record.ID, record.RuntimeGeneration, generation.ID, record.LifecycleEpoch+1,
+	)
+	require.NoError(t, store.WithSandboxLock(ctx, record.ID, func(
+		lockCtx context.Context,
+		tx SandboxStoreTx,
+		locked *SandboxRecord,
+	) error {
+		return tx.BeginLifecycleTxn(lockCtx, &SandboxLifecycleTxn{
+			ID: resumeOperationID, SandboxID: locked.ID,
+			Kind: SandboxLifecycleKindResume, Phase: SandboxLifecyclePhasePreparing,
+			Source: SandboxLifecycleSourceManual, Cancelable: false,
+			FromGeneration: locked.RuntimeGeneration, ToGeneration: locked.RuntimeGeneration + 1,
+			ExpectedGenerationID: generation.ID,
+		})
+	}))
+
+	acquire := sandboxRuntimeSlotAcquireRequest(record, filesystem, generation, registration,
+		"terminated-failed-resume-writer")
+	acquire.OperationID = resumeOperationID
+	acquire.ClaimID = "claim-terminated-failed-resume-writer"
+	claimed, err := store.AcquireRuntimeSlot(ctx, acquire)
+	require.NoError(t, err)
+	binding := sha256.Sum256([]byte("terminated-failed-resume-writer"))
+	issue := rootFSWriterGrantTestIssueRequest(
+		record.ID, "grant-terminated-failed-resume", acquire.ClaimID, claimed.ID, binding[:],
+	)
+	issue.ExpectedFilesystemID = filesystem.ID
+	issue.InitialGenerationID = generation.ID
+	issue.NodeUID = claimed.NodeUID
+	issue.NodeBootID = claimed.NodeBootID
+	issue.RuntimeNamespace = claimed.AllocationNamespace
+	issue.RuntimeID = "slot"
+	issue.RuntimeIncarnationID = claimed.AllocationID
+	issue.NodeName = claimed.NodeID
+	issue.RuntimeGeneration = "2"
+	issued, err := store.IssueRootFSWriterGrant(ctx, issue)
+	require.NoError(t, err)
+	_, err = store.BindRuntimeSlotWriterGrant(ctx, &BindRuntimeSlotWriterGrantRequest{
+		SlotID: claimed.ID, OperationID: acquire.OperationID,
+		ClaimID: acquire.ClaimID, GrantID: issued.Grant.ID,
+	})
+	require.NoError(t, err)
+	_, err = store.ConsumeRootFSWriterGrant(ctx, &ConsumeRootFSWriterGrantRequest{
+		GrantID: issued.Grant.ID, WriterEpoch: issued.Grant.WriterEpoch, RawToken: issue.RawToken,
+		BindingVersion: RootFSWriterBindingVersion, BindingDigest: binding[:],
+		ConsumerNodeUID: claimed.NodeUID, ConsumerAgentUID: "ctld-terminated-resume", LeaseTTL: time.Minute,
+	})
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		UPDATE manager.rootfs_writer_grants
+		SET lease_expires_at = NOW() - ($2::bigint * INTERVAL '1 millisecond')
+		WHERE grant_id = $1
+	`, issued.Grant.ID, RootFSWriterCrashAbandonGrace.Milliseconds()+1000)
+	require.NoError(t, err)
+
+	_, err = store.AbortNomadSandboxResume(
+		ctx, record.ID, resumeOperationID, "resume runtime did not reach command-ready",
+	)
+	require.NoError(t, err)
+	candidate, err := store.RequestSandboxRuntimeClaimCleanup(
+		ctx, record.ID, "sandbox deletion requested",
+	)
+	require.NoError(t, err)
+	require.Equal(t, claimed.ID, candidate.SlotID)
+	require.Equal(t, RuntimeSlotStateQuiescing, candidate.SlotState)
+
+	crashLifecycleID := "reconcile-terminated-failed-resume-writer"
+	require.NoError(t, store.WithSandboxLock(ctx, record.ID, func(
+		lockCtx context.Context,
+		tx SandboxStoreTx,
+		_ *SandboxRecord,
+	) error {
+		return tx.BeginLifecycleTxn(lockCtx, &SandboxLifecycleTxn{
+			ID: crashLifecycleID, SandboxID: record.ID,
+			Kind: SandboxLifecycleKindPause, Phase: SandboxLifecyclePhasePublishing,
+			Source: SandboxLifecycleSourceCrash, Cancelable: false,
+			FromGeneration: 2, FromRuntimeNamespace: claimed.AllocationNamespace,
+			FromRuntimeID: claimed.AllocationID, ExpectedGenerationID: generation.ID,
+		})
+	}))
+	_, err = store.BeginRootFSWriterCrashAbandon(ctx, &BeginRootFSWriterCrashAbandonRequest{
+		GrantID: issued.Grant.ID, WriterEpoch: issued.Grant.WriterEpoch,
+		OperationID: crashLifecycleID, BindingVersion: RootFSWriterBindingVersion,
+		BindingDigest: binding[:], NodeUID: claimed.NodeUID, NodeBootID: claimed.NodeBootID,
+		ExpectedOldGenerationID: generation.ID,
+	})
+	require.NoError(t, err)
+	proof := sha256.Sum256([]byte("terminated-failed-resume-node-cleanup-proof"))
+	complete := func() error {
+		return store.WithSandboxLock(ctx, record.ID, func(
+			lockCtx context.Context,
+			tx SandboxStoreTx,
+			_ *SandboxRecord,
+		) error {
+			_, completeErr := tx.(RootFSWriterCrashAbandonTx).CompleteRootFSWriterCrashAbandon(
+				lockCtx, &CompleteRootFSWriterCrashAbandonRequest{
+					LifecycleTxnID: crashLifecycleID, GrantID: issued.Grant.ID,
+					WriterEpoch: issued.Grant.WriterEpoch, OperationID: crashLifecycleID,
+					BindingVersion: RootFSWriterBindingVersion, BindingDigest: binding[:],
+					ProofVersion: RootFSWriterCrashAbandonProofVersion, ProofDigest: proof[:],
+					NodeUID: claimed.NodeUID, NodeBootID: claimed.NodeBootID,
+					ExpectedOldGenerationID: generation.ID,
+				},
+			)
+			return completeErr
+		})
+	}
+	_, err = pool.Exec(ctx, `
+		UPDATE manager.sandbox_lifecycle_txns SET source = $2 WHERE txn_id = $1
+	`, resumeOperationID, SandboxLifecycleSourceAuto)
+	require.NoError(t, err)
+	require.ErrorIs(t, complete(), ErrRootFSWriterGrantConflict)
+	_, err = pool.Exec(ctx, `
+		UPDATE manager.sandbox_lifecycle_txns SET source = $2 WHERE txn_id = $1
+	`, resumeOperationID, SandboxLifecycleSourceManual)
+	require.NoError(t, err)
+	err = complete()
+	require.NoError(t, err)
+	grant, err := store.GetRootFSWriterGrant(ctx, issued.Grant.ID)
+	require.NoError(t, err)
+	require.Equal(t, RootFSWriterGrantStateRetired, grant.State)
+	stored, err := store.GetSandbox(ctx, record.ID)
+	require.NoError(t, err)
+	require.Equal(t, SandboxDesiredStateTerminating, stored.DesiredState)
+	require.EqualValues(t, 1, stored.RuntimeGeneration)
+	require.Empty(t, stored.RuntimeNamespace)
+	require.Empty(t, stored.RuntimeID)
+}
+
 func newRootFSWriterCrashAbandonFixture(
 	t *testing.T,
 	lifecycleSource string,


### PR DESCRIPTION
## Summary

- allow the terminal writer controller to recover an exact resume slot after sandbox deletion has moved the logical record to terminating
- prove the cleanup against the cleanup-pending claim, immutable slot/writer identity, and the exact aborted resume lifecycle
- preserve existing fail-closed generation and allocation checks, including deleted failed-claim recovery

## Production evidence

A production acceptance child reached generation 1, then its restored generation-2 resume failed before command readiness. The subsequent DELETE left the record terminating with an empty runtime identity while slot 3dd554b6-1bd4-3d67-b342-017da8662108/slot/cf20bb9c retained a consumed writer. The terminal reconciler rejected that valid cleanup because it only recognized paused pre-commit resumes.

Read-only diagnostic runs:
- https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/33657580046
- https://github.com/sandbox0-ai/sandbox0-infra/actions/runs/33658745736

## Validation

- go test -race ./...
- go test -race ./... in nomad-driver-sandbox0
- go vet on affected packages
- make apispec and generated diff check
- go mod tidy checks for both Go modules
- full manager/pkg/sandboxstore race suite against PostgreSQL
- targeted PostgreSQL regression covers paused gen1 -> failed gen2 resume -> DELETE -> writer crash-abandon, plus rejection when the resume lifecycle identity is changed