### PR TITLE
ops(nomad): propagate node claim timings

### DIFF
--- a/manager/pkg/nomadclaim/service.go
+++ b/manager/pkg/nomadclaim/service.go
@@ -1002,10 +1002,25 @@ func (s *Service) ClaimSandbox(ctx context.Context, request *service.ClaimReques
 	if err != nil {
 		return nil, fmt.Errorf("complete Nomad sandbox claim: %w", err)
 	}
-	s.logger.Info("Claimed Nomad sandbox",
+	claimLogFields := []zap.Field{
 		zap.String("sandboxID", sandboxID), zap.String("operationID", req.OperationID),
 		zap.String("slotID", result.Slot.ID), zap.Duration("endToEndDuration", result.Duration),
-	)
+	}
+	if timing := result.NodeClaimTiming; timing != nil {
+		claimLogFields = append(claimLogFields,
+			zap.Int64("nodeClaimDurationMicros", timing.ClaimDurationMicros),
+			zap.Int64("bundleWriteMicros", timing.BundleWriteMicros),
+			zap.Int64("claimStatePersistMicros", timing.ClaimStatePersistMicros),
+			zap.Int64("rootFSEnsureMicros", timing.RootFSEnsureMicros),
+			zap.Int64("consumerRegisterMicros", timing.ConsumerRegisterMicros),
+			zap.Int64("rootFSBindMicros", timing.RootFSBindMicros),
+			zap.Int64("startingReportMicros", timing.StartingReportMicros),
+			zap.Int64("runscCreateMicros", timing.RunscCreateMicros),
+			zap.Int64("runscStartMicros", timing.RunscStartMicros),
+			zap.Int64("activeStatePersistMicros", timing.ActiveStatePersistMicros),
+		)
+	}
+	s.logger.Info("Claimed Nomad sandbox", claimLogFields...)
 	clusterID := runtimeClass.ClusterID
 	return &service.ClaimResponse{
 		SandboxID: sandboxID, Status: "running", ProcdAddress: result.ProcdAddress,

--- a/manager/pkg/runtimeslotclaim/planner.go
+++ b/manager/pkg/runtimeslotclaim/planner.go
@@ -193,6 +193,7 @@ type Result struct {
 	ProcdAddress    string
 	ProcdInstanceID string
 	CommandProof    protocol.CommandReadyProof
+	NodeClaimTiming *protocol.NodeClaimTiming
 	Duration        time.Duration
 	WithinSLO       bool
 	Phases          []PhaseObservation
@@ -617,6 +618,7 @@ func (p *Planner) Claim(ctx context.Context, request Request) (result *Result, r
 	return &Result{
 		Slot: bound, Grant: issued.Grant, Stage: stage, ProcdAddress: procdAddress,
 		ProcdInstanceID: probe.InstanceID, CommandProof: proof,
+		NodeClaimTiming: nodeClaimResponse.ClaimTiming,
 	}, nil
 }
 

--- a/manager/pkg/runtimeslotclaim/planner_test.go
+++ b/manager/pkg/runtimeslotclaim/planner_test.go
@@ -186,6 +186,7 @@ type fakeNode struct {
 	commands      []protocol.CommandReadyControlRequest
 	claimErrors   []error
 	commandErrors []error
+	claimTiming   *protocol.NodeClaimTiming
 }
 
 func (f *fakeNode) Claim(_ context.Context, _ NodeTarget, request protocol.NodeClaimControlRequest) (protocol.NodeControlResponse, error) {
@@ -193,7 +194,9 @@ func (f *fakeNode) Claim(_ context.Context, _ NodeTarget, request protocol.NodeC
 	defer f.mu.Unlock()
 	f.claims = append(f.claims, cloneNodeClaim(request))
 	if len(f.claimErrors) == 0 {
-		return protocol.NodeControlResponse{Phase: string(protocol.StateActive)}, nil
+		return protocol.NodeControlResponse{
+			Phase: string(protocol.StateActive), ClaimTiming: f.claimTiming,
+		}, nil
 	}
 	err := f.claimErrors[0]
 	f.claimErrors = f.claimErrors[1:]
@@ -458,6 +461,9 @@ func newPlannerFixture(t *testing.T) *plannerFixture {
 
 func TestPlannerExecutesCompleteRegionToProcdClaim(t *testing.T) {
 	fixture := newPlannerFixture(t)
+	fixture.node.claimTiming = &protocol.NodeClaimTiming{
+		ClaimDurationMicros: 250_000, RunscCreateMicros: 100_000,
+	}
 	result, err := fixture.planner.Claim(context.Background(), fixture.request)
 	if err != nil {
 		t.Fatalf("Claim() error = %v", err)
@@ -470,6 +476,9 @@ func TestPlannerExecutesCompleteRegionToProcdClaim(t *testing.T) {
 	}
 	if err := result.Stage.Validate(); err != nil {
 		t.Fatalf("result stage is invalid: %v", err)
+	}
+	if result.NodeClaimTiming == nil || result.NodeClaimTiming.RunscCreateMicros != 100_000 {
+		t.Fatalf("node claim timing = %+v, want driver response timing", result.NodeClaimTiming)
 	}
 	fixture.store.mu.Lock()
 	if len(fixture.store.acquires) != 1 || len(fixture.store.issues) != 1 || len(fixture.store.binds) != 1 {

--- a/nomad-driver-sandbox0/internal/driver/control.go
+++ b/nomad-driver-sandbox0/internal/driver/control.go
@@ -42,7 +42,8 @@ type statusResponse struct {
 }
 
 type claimResponse struct {
-	Phase string `json:"phase"`
+	Phase       string                    `json:"phase"`
+	ClaimTiming *protocol.NodeClaimTiming `json:"claim_timing,omitempty"`
 }
 
 func (h *taskHandle) ServeControl(ctx context.Context) {
@@ -84,11 +85,14 @@ func (h *taskHandle) ServeControl(ctx context.Context) {
 				writeControlError(w, http.StatusBadRequest, fmt.Sprintf("decode claim: %v", err))
 				return
 			}
-			if err := h.Claim(claim); err != nil {
+			claimTiming, err := h.claimWithTiming(claim)
+			if err != nil {
 				writeControlOperationError(w, err)
 				return
 			}
-			writeControlJSON(w, http.StatusOK, claimResponse{Phase: string(phaseActive)})
+			writeControlJSON(w, http.StatusOK, claimResponse{
+				Phase: string(phaseActive), ClaimTiming: claimTiming,
+			})
 		})
 		mux.HandleFunc(protocol.NodeCommandReadyControlPath, func(w http.ResponseWriter, request *http.Request) {
 			if request.Method != http.MethodPut {

--- a/nomad-driver-sandbox0/internal/driver/handle.go
+++ b/nomad-driver-sandbox0/internal/driver/handle.go
@@ -168,6 +168,21 @@ type claimTimings struct {
 	activeStatePersist time.Duration
 }
 
+func (t claimTimings) observation(elapsed time.Duration) protocol.NodeClaimTiming {
+	return protocol.NodeClaimTiming{
+		ClaimDurationMicros:      elapsed.Microseconds(),
+		BundleWriteMicros:        t.bundleWrite.Microseconds(),
+		ClaimStatePersistMicros:  t.claimStatePersist.Microseconds(),
+		RootFSEnsureMicros:       t.rootFSEnsure.Microseconds(),
+		ConsumerRegisterMicros:   t.consumerRegister.Microseconds(),
+		RootFSBindMicros:         t.rootFSBind.Microseconds(),
+		StartingReportMicros:     t.startingReport.Microseconds(),
+		RunscCreateMicros:        t.runscCreate.Microseconds(),
+		RunscStartMicros:         t.runscStart.Microseconds(),
+		ActiveStatePersistMicros: t.activeStatePersist.Microseconds(),
+	}
+}
+
 func (h *taskHandle) logClaimTimings(success bool, elapsed time.Duration, timings claimTimings) {
 	args := []any{
 		"success", success,
@@ -445,7 +460,22 @@ func runtimeLeaseCgroupsPath(root, cgroupName string) (string, error) {
 }
 
 // Claim writes the OCI bundle, attaches D as its initial root, then creates and starts runsc.
-func (h *taskHandle) Claim(request ClaimRequest) (resultErr error) {
+func (h *taskHandle) Claim(request ClaimRequest) error {
+	return h.executeClaim(request, nil)
+}
+
+func (h *taskHandle) claimWithTiming(request ClaimRequest) (*protocol.NodeClaimTiming, error) {
+	var observed *protocol.NodeClaimTiming
+	err := h.executeClaim(request, func(timing protocol.NodeClaimTiming) {
+		observed = &timing
+	})
+	return observed, err
+}
+
+func (h *taskHandle) executeClaim(
+	request ClaimRequest,
+	observe func(protocol.NodeClaimTiming),
+) (resultErr error) {
 	requestPayload, err := json.Marshal(request)
 	if err != nil {
 		return fmt.Errorf("encode claim retry identity: %w", err)
@@ -491,7 +521,11 @@ func (h *taskHandle) Claim(request ClaimRequest) (resultErr error) {
 	claimStarted := time.Now()
 	timings := claimTimings{}
 	defer func() {
-		h.logClaimTimings(resultErr == nil, time.Since(claimStarted), timings)
+		elapsed := time.Since(claimStarted)
+		h.logClaimTimings(resultErr == nil, elapsed, timings)
+		if observe != nil {
+			observe(timings.observation(elapsed))
+		}
 	}()
 
 	if request.PolicyToken == "" || request.WriterEpoch == "" {

--- a/nomad-driver-sandbox0/internal/driver/runtime_slot_test.go
+++ b/nomad-driver-sandbox0/internal/driver/runtime_slot_test.go
@@ -658,13 +658,16 @@ func TestRuntimeSlotClaimRetriesStartingBeforeRunscCreate(t *testing.T) {
 	}
 	fixture.authority.mu.Unlock()
 
-	err := handle.Claim(ClaimRequest{
+	claimTiming, err := handle.claimWithTiming(ClaimRequest{
 		OperationID: "operation-1", ClaimID: "claim-1",
 		PolicyToken: token, WriterEpoch: "1", Stage: &stage, NetworkPolicy: networkPolicy,
 		Runtime: runtimeSlotAssignment(), Resources: runtimeSlotResourceLease(t, fixture, stage),
 	})
 	if err != nil {
 		t.Fatalf("Claim() error = %v", err)
+	}
+	if claimTiming == nil || claimTiming.ClaimDurationMicros <= 0 || claimTiming.RunscCreateMicros < 0 {
+		t.Fatalf("claim timing = %+v, want populated non-negative timing", claimTiming)
 	}
 	if startedTooEarly {
 		t.Fatal("runsc create happened before the regional starting transition")

--- a/pkg/runtimeslot/node_client_test.go
+++ b/pkg/runtimeslot/node_client_test.go
@@ -29,13 +29,19 @@ func TestNodeClientCallsRootOwnedUnixControlSocket(t *testing.T) {
 			t.Errorf("Content-Type = %q, want application/json", got)
 		}
 		writer.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(writer).Encode(NodeControlResponse{Phase: string(StateActive)})
+		response := NodeControlResponse{Phase: string(StateActive)}
+		if request.URL.Path == NodeClaimControlPath {
+			response.ClaimTiming = &NodeClaimTiming{ClaimDurationMicros: 250_000}
+		}
+		_ = json.NewEncoder(writer).Encode(response)
 	})
 
 	claim := testNodeClaimControlRequest()
 	response, err := client.Claim(t.Context(), endpoint, claim)
 	require.NoError(t, err)
 	require.Equal(t, string(StateActive), response.Phase)
+	require.NotNil(t, response.ClaimTiming)
+	require.Equal(t, int64(250_000), response.ClaimTiming.ClaimDurationMicros)
 	proof := CommandReadyProof{
 		Version: CommandReadyProofVersion, SlotID: "slot-1", OperationID: claim.OperationID,
 		ClaimID: claim.ClaimID, LaunchAttempt: claim.Stage.Identity.LaunchAttempt,

--- a/pkg/runtimeslot/types.go
+++ b/pkg/runtimeslot/types.go
@@ -390,15 +390,60 @@ func NetworkPolicyDigest(raw string) string {
 	return "sha256:" + hex.EncodeToString(digest[:])
 }
 
+// NodeClaimTiming contains bounded, low-cardinality driver stages from one
+// synchronous claim. Values are elapsed microseconds from the node monotonic
+// clock and are diagnostic only; they are not lifecycle proof.
+type NodeClaimTiming struct {
+	ClaimDurationMicros      int64 `json:"claim_duration_us"`
+	BundleWriteMicros        int64 `json:"bundle_write_us"`
+	ClaimStatePersistMicros  int64 `json:"claim_state_persist_us"`
+	RootFSEnsureMicros       int64 `json:"rootfs_ensure_us"`
+	ConsumerRegisterMicros   int64 `json:"consumer_register_us"`
+	RootFSBindMicros         int64 `json:"rootfs_bind_us"`
+	StartingReportMicros     int64 `json:"starting_report_us"`
+	RunscCreateMicros        int64 `json:"runsc_create_us"`
+	RunscStartMicros         int64 `json:"runsc_start_us"`
+	ActiveStatePersistMicros int64 `json:"active_state_persist_us"`
+}
+
+func (t NodeClaimTiming) Validate() error {
+	for _, field := range []struct {
+		name  string
+		value int64
+	}{
+		{name: "claim_duration_us", value: t.ClaimDurationMicros},
+		{name: "bundle_write_us", value: t.BundleWriteMicros},
+		{name: "claim_state_persist_us", value: t.ClaimStatePersistMicros},
+		{name: "rootfs_ensure_us", value: t.RootFSEnsureMicros},
+		{name: "consumer_register_us", value: t.ConsumerRegisterMicros},
+		{name: "rootfs_bind_us", value: t.RootFSBindMicros},
+		{name: "starting_report_us", value: t.StartingReportMicros},
+		{name: "runsc_create_us", value: t.RunscCreateMicros},
+		{name: "runsc_start_us", value: t.RunscStartMicros},
+		{name: "active_state_persist_us", value: t.ActiveStatePersistMicros},
+	} {
+		if field.value < 0 {
+			return fmt.Errorf("node claim timing %s cannot be negative", field.name)
+		}
+	}
+	return nil
+}
+
 // NodeControlResponse is returned only after the driver has durably reached
 // the requested local phase.
 type NodeControlResponse struct {
-	Phase string `json:"phase"`
+	Phase       string           `json:"phase"`
+	ClaimTiming *NodeClaimTiming `json:"claim_timing,omitempty"`
 }
 
 func (r NodeControlResponse) Validate() error {
 	if r.Phase != string(StateActive) {
 		return fmt.Errorf("node control phase must be active")
+	}
+	if r.ClaimTiming != nil {
+		if err := r.ClaimTiming.Validate(); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/runtimeslot/types_test.go
+++ b/pkg/runtimeslot/types_test.go
@@ -186,6 +186,18 @@ func TestNodeClaimControlRequestValidatesRegionalBinding(t *testing.T) {
 	require.ErrorContains(t, changed.ValidateRegional(), "exceeds 64 KiB")
 }
 
+func TestNodeControlResponseRejectsNegativeClaimTiming(t *testing.T) {
+	response := NodeControlResponse{
+		Phase: string(StateActive),
+		ClaimTiming: &NodeClaimTiming{
+			RunscCreateMicros: -1,
+		},
+	}
+	if err := response.Validate(); err == nil || !strings.Contains(err.Error(), "runsc_create_us") {
+		t.Fatalf("Validate() error = %v, want negative timing rejection", err)
+	}
+}
+
 func TestNodeCleanupProofBindsExactRequestAndAbsenceFacts(t *testing.T) {
 	resources := testNodeClaimControlRequest().Resources
 	resourceDigest, err := resources.Digest()


### PR DESCRIPTION
## Summary
- return bounded node-claim stage timings over the internal driver control response
- validate and preserve the optional diagnostic payload through the manager planner
- include the stage timings in the existing durable manager claim log

The timing payload is diagnostic only. It does not change claim ordering, lifecycle proof, retries, or timeouts.

## Validation
- `go test ./pkg/runtimeslot ./manager/pkg/runtimeslotclaim ./manager/pkg/nomadclaim`
- `go vet ./pkg/runtimeslot ./manager/pkg/runtimeslotclaim ./manager/pkg/nomadclaim`
- `go test ./...` in `nomad-driver-sandbox0`
- `go vet ./...` in `nomad-driver-sandbox0`
- `git diff --check`